### PR TITLE
Fix bugs (lint/dead-code, ROT13 false IOCs), add evidence-only mode, update deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -136,6 +136,16 @@ titan-decoder --file suspicious.bin --out report.json --enable-detections \
   --report-out case_report.md --report-format markdown
 ```
 
+`--evidence` can also be used **without** a payload (`--file`/`--batch`) to ingest
+logs on their own. The report is produced with `node_count: 0` and the normalized
+evidence attached:
+
+```bash
+titan-decoder --out report.json \
+  --evidence dns:./logs/dns.csv \
+  --evidence proxy:./logs/proxy.csv
+```
+
 Export a normalized evidence timeline (from the ingested `--evidence` sources):
 
 ```bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Development / test dependencies (used by extras: dev)
-pytest>=9.0.3
-ruff>=0.5.0
-build>=1.4.4
+pytest>=9.1.1
+ruff>=0.15.18
+build>=1.5.0
 twine>=6.2.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,7 +1,7 @@
 # Optional dependencies for enrichment and advanced features
-psutil>=5.9.0
+psutil>=7.2.2
 geoip2>=5.2.0
-python-whois>=0.8.0
-yara-python>=4.3.0
-requests>=2.31.0
-PyYAML>=6.0.1
+python-whois>=0.9.6
+yara-python>=4.5.4
+requests>=2.34.2
+PyYAML>=6.0.3

--- a/tests/test_cli_doctor_jsonl_vault.py
+++ b/tests/test_cli_doctor_jsonl_vault.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 
 def test_cli_doctor_outputs_json_and_exits_zero(monkeypatch, capsys):

--- a/tests/test_cli_exit_codes.py
+++ b/tests/test_cli_exit_codes.py
@@ -2,16 +2,21 @@ import json
 
 
 def test_cli_fail_on_risk_level_high_exits_nonzero(tmp_path, monkeypatch):
-    # Use a payload that triggers at least one HIGH detection.
-    # TITAN-003 (LOLBin Script Execution Pattern) is severity=medium, so instead
-    # we include a URL + public IP + OLE marker? That's too heavy.
-    # The simplest reliable path is XOR+C2 (high) may vary, so we trigger
-    # Multi-Stage Infrastructure (high) by including urls + ipv4 + domains + emails.
+    # Trigger Multi-Stage Infrastructure (high severity) by including urls +
+    # ipv4 + domains + emails, and include enough *distinct* real IOCs that the
+    # risk score reaches HIGH on genuine indicators alone (no reliance on
+    # decoder artifacts).
     data = (
-        b"http://example.com\n"
+        b"http://example.com/a\n"
+        b"https://malicious.example.net/b\n"
+        b"http://cdn.bad.example.org/c\n"
         b"8.8.8.8\n"
-        b"example.org\n"
-        b"test@example.org\n"
+        b"1.1.1.1\n"
+        b"9.9.9.9\n"
+        b"evil.example.com\n"
+        b"c2.example.net\n"
+        b"attacker@example.org\n"
+        b"admin@bad.example.net\n"
     )
 
     sample = tmp_path / "sample.txt"

--- a/tests/test_evidence_links.py
+++ b/tests/test_evidence_links.py
@@ -16,13 +16,13 @@ def test_evidence_links_dns_client_to_domain_and_domain_to_answer_ip():
     links = build_links_from_evidence_events(events)
     keys = {
         (
-            l["src"]["type"],
-            l["src"]["value"],
-            l["dst"]["type"],
-            l["dst"]["value"],
-            l["reason_code"],
+            link["src"]["type"],
+            link["src"]["value"],
+            link["dst"]["type"],
+            link["dst"]["value"],
+            link["reason_code"],
         )
-        for l in links
+        for link in links
     }
 
     assert ("ipv4", "10.0.0.10", "domains", "example.com", "dns_client_queried_domain") in keys
@@ -46,6 +46,6 @@ def test_evidence_links_dns_ignores_non_ip_answers():
 
     links = build_links_from_evidence_events(events)
     # Only one answer-based IP link should exist
-    ip_links = [l for l in links if l.get("reason_code") == "dns_answer"]
+    ip_links = [link for link in links if link.get("reason_code") == "dns_answer"]
     assert len(ip_links) == 1
     assert ip_links[0]["dst"]["value"] == "93.184.216.34"

--- a/tests/test_evidence_parsers_and_cli.py
+++ b/tests/test_evidence_parsers_and_cli.py
@@ -72,6 +72,59 @@ def test_cli_evidence_attached_to_report(tmp_path: Path, monkeypatch):
     assert isinstance(report["evidence"]["links"], list)
 
 
+def test_cli_evidence_only_without_file(tmp_path: Path, monkeypatch):
+    # Evidence-only mode: no --file/--batch, just IR logs to ingest.
+    from titan_decoder import cli
+
+    dns = tmp_path / "dns.csv"
+    dns.write_text(
+        "timestamp,client_ip,query,answers\n"
+        "2025-01-01 00:00:01,10.0.0.10,example.com,93.184.216.34\n"
+    )
+
+    out = tmp_path / "report.json"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "titan-decoder",
+            "--out",
+            str(out),
+            "--quiet",
+            "--evidence",
+            f"dns:{dns}",
+        ],
+    )
+
+    try:
+        cli.main()
+        assert False, "Expected SystemExit"
+    except SystemExit as e:
+        assert e.code == 0
+
+    report = json.loads(out.read_text())
+    # No payload was analyzed, but the report is well-formed and carries evidence.
+    assert report["node_count"] == 0
+    assert "run_manifest" in report
+    assert "evidence" in report
+    assert len(report["evidence"]["events"]) == 1
+    vals = {(i["type"], i["value"]) for i in report["evidence"]["indicators"]}
+    assert ("domains", "example.com") in vals
+
+
+def test_cli_no_input_source_errors(tmp_path: Path, monkeypatch):
+    # Neither --file, --batch, nor --evidence: should error out cleanly.
+    from titan_decoder import cli
+
+    monkeypatch.setattr("sys.argv", ["titan-decoder", "--quiet"])
+
+    try:
+        cli.main()
+        assert False, "Expected SystemExit"
+    except SystemExit as e:
+        assert e.code == 1
+
+
 def test_cli_case_report_includes_evidence(tmp_path: Path, monkeypatch):
     from titan_decoder import cli
 

--- a/tests/test_evidence_parsers_and_cli.py
+++ b/tests/test_evidence_parsers_and_cli.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-import pytest
 
 
 def test_evidence_parser_dns_csv_produces_indicators(tmp_path: Path):

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -14,7 +14,6 @@ from .config import Config
 from .core.offline_guard import block_network, is_network_blocked
 from .core.evidence_parsers import parse_evidence_file, combine_parse_results
 from .core.evidence_correlation import top_pivots, build_last_seen, build_entity_hints
-from .core.evidence_models import Indicator
 from .core.evidence_links import build_links_from_evidence_events, top_links
 
 
@@ -300,13 +299,6 @@ def main():
             results.append(parse_evidence_file(path, kind))
         return combine_parse_results(results)
 
-    # If user requested trace, persist into config so the engine can act on it.
-    if args.trace:
-        try:
-            config_for_trace = True
-        except Exception:
-            config_for_trace = True
-
     # Setup signal handlers for clean shutdown
     interrupted = False
 
@@ -508,8 +500,6 @@ def main():
     except Exception as e:
         print(f"Error: Failed to initialize engine: {e}")
         sys.exit(1)
-
-    offline_ctx = block_network() if args.offline else None
 
     if args.perf_profile:
         from .core.profiling import PerformanceProfiler

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -458,41 +458,43 @@ def main():
 
     # Normal analysis mode
     if not args.file:
-        print(
-            "Error: --file or --batch is required"
-        )
-        sys.exit(1)
+        # Evidence-only mode: ingest IR logs/artifacts without a payload to
+        # decode. With no input source at all, this is an error.
+        if not args.evidence:
+            print("Error: --file, --batch, or --evidence is required")
+            sys.exit(1)
+        data = b""
+    else:
+        if not args.file.exists():
+            print(f"Error: Input file {args.file} does not exist")
+            sys.exit(1)
 
-    if not args.file.exists():
-        print(f"Error: Input file {args.file} does not exist")
-        sys.exit(1)
+        # Read input data with error handling
+        try:
+            data = args.file.read_bytes()
+        except PermissionError:
+            print(f"Error: Permission denied reading {args.file}")
+            sys.exit(1)
+        except OSError as e:
+            print(f"Error: Could not read file {args.file}: {e}")
+            sys.exit(1)
 
-    # Read input data with error handling
-    try:
-        data = args.file.read_bytes()
-    except PermissionError:
-        print(f"Error: Permission denied reading {args.file}")
-        sys.exit(1)
-    except OSError as e:
-        print(f"Error: Could not read file {args.file}: {e}")
-        sys.exit(1)
+        if len(data) == 0:
+            print(f"Error: Input file {args.file} is empty")
+            sys.exit(1)
 
-    if len(data) == 0:
-        print(f"Error: Input file {args.file} is empty")
-        sys.exit(1)
-
-    # Check file size
-    max_size = config.get("max_data_size", 50 * 1024 * 1024)
-    if len(data) > max_size:
-        if not args.quiet:
-            print(
-                f"Warning: File size ({len(data)} bytes) exceeds max_data_size ({max_size} bytes)",
-                file=sys.stderr,
-            )
-            print(
-                "Analysis may be slow or incomplete. Increase max_data_size in config if needed.",
-                file=sys.stderr,
-            )
+        # Check file size
+        max_size = config.get("max_data_size", 50 * 1024 * 1024)
+        if len(data) > max_size:
+            if not args.quiet:
+                print(
+                    f"Warning: File size ({len(data)} bytes) exceeds max_data_size ({max_size} bytes)",
+                    file=sys.stderr,
+                )
+                print(
+                    "Analysis may be slow or incomplete. Increase max_data_size in config if needed.",
+                    file=sys.stderr,
+                )
 
     # Run analysis with optional profiling and error handling
     try:

--- a/titan_decoder/core/advanced_heuristics.py
+++ b/titan_decoder/core/advanced_heuristics.py
@@ -91,7 +91,6 @@ class XORKeyFinder:
 
             # Calculate metrics
             entropy = EntropyAnalyzer.calculate_entropy(xored)
-            Counter(xored)
 
             # Count printable characters (heuristic for plaintext)
             printable = sum(1 for b in xored if 32 <= b <= 126 or b in (9, 10, 13))

--- a/titan_decoder/core/case_report.py
+++ b/titan_decoder/core/case_report.py
@@ -76,11 +76,11 @@ def to_markdown(case: Dict[str, Any]) -> str:
         if links:
             lines.append("")
             lines.append("### Top Links")
-            for l in links[:10]:
-                src = (l.get("src") or {})
-                dst = (l.get("dst") or {})
+            for link in links[:10]:
+                src = (link.get("src") or {})
+                dst = (link.get("dst") or {})
                 lines.append(
-                    f"- {src.get('type')}={src.get('value')} -> {dst.get('type')}={dst.get('value')} ({l.get('reason_code')}, confidence={l.get('confidence')})"
+                    f"- {src.get('type')}={src.get('value')} -> {dst.get('type')}={dst.get('value')} ({link.get('reason_code')}, confidence={link.get('confidence')})"
                 )
         lines.append("")
 

--- a/titan_decoder/core/endpoint_parsers.py
+++ b/titan_decoder/core/endpoint_parsers.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from ..utils.helpers import extract_iocs
 from .evidence_models import EvidenceEvent, Indicator, EvidenceRef
@@ -140,12 +140,6 @@ def parse_browser_history_sqlite(path: Path) -> Tuple[List[EvidenceEvent], List[
         # Chrome/Edge
         if _table_exists(conn, "urls"):
             cur = conn.cursor()
-            cols = [
-                "url",
-                "title",
-                "visit_count",
-                "last_visit_time",
-            ]
             try:
                 cur.execute(
                     "SELECT url, title, visit_count, last_visit_time FROM urls ORDER BY last_visit_time DESC LIMIT 500"

--- a/titan_decoder/core/enrichment_cache.py
+++ b/titan_decoder/core/enrichment_cache.py
@@ -15,7 +15,7 @@ import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional
 
 
 SCHEMA = """

--- a/titan_decoder/core/evidence_correlation.py
+++ b/titan_decoder/core/evidence_correlation.py
@@ -10,7 +10,7 @@ This is intentionally lightweight and deterministic.
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from .evidence_models import Indicator
 

--- a/titan_decoder/core/evidence_links.py
+++ b/titan_decoder/core/evidence_links.py
@@ -11,7 +11,7 @@ Goal: "pivots with proof" without heavy dependencies.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 
 def _looks_like_ipv4(value: str) -> bool:
@@ -274,19 +274,19 @@ def build_links_from_evidence_events(events: List[Dict[str, Any]]) -> List[Dict[
             )
 
     # Return deterministic ordering
-    out = [l.to_dict() for l in sorted(links.values(), key=lambda x: (x.src_type, x.src_value, x.dst_type, x.dst_value, x.reason_code))]
+    out = [link.to_dict() for link in sorted(links.values(), key=lambda x: (x.src_type, x.src_value, x.dst_type, x.dst_value, x.reason_code))]
     return out
 
 
 def top_links(links: List[Dict[str, Any]], limit: int = 10) -> List[Dict[str, Any]]:
     """Rank links by number of sources then lexicographically."""
-    def score(l: Dict[str, Any]) -> tuple[int, str, str, str, str, str]:
-        src = l.get("src") or {}
-        dst = l.get("dst") or {}
+    def score(link: Dict[str, Any]) -> tuple[int, str, str, str, str, str]:
+        src = link.get("src") or {}
+        dst = link.get("dst") or {}
         return (
-            len(l.get("sources") or []),
-            str(l.get("confidence") or ""),
-            str(l.get("reason_code") or ""),
+            len(link.get("sources") or []),
+            str(link.get("confidence") or ""),
+            str(link.get("reason_code") or ""),
             str(src.get("type") or ""),
             str(src.get("value") or ""),
             str(dst.get("value") or ""),

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -184,6 +184,29 @@ class HexDecoder(Decoder):
         return "Hex"
 
 
+# Relative frequencies (percent) of letters in English text. Used to decide
+# whether a ROT13 rotation actually yields more English-like output than its
+# input, so the self-inverse cipher is not applied to already-readable text.
+_ENGLISH_LETTER_FREQ = {
+    "a": 8.2, "b": 1.5, "c": 2.8, "d": 4.3, "e": 12.7, "f": 2.2, "g": 2.0,
+    "h": 6.1, "i": 7.0, "j": 0.15, "k": 0.77, "l": 4.0, "m": 2.4, "n": 6.7,
+    "o": 7.5, "p": 1.9, "q": 0.095, "r": 6.0, "s": 6.3, "t": 9.1, "u": 2.8,
+    "v": 0.98, "w": 2.4, "x": 0.15, "y": 2.0, "z": 0.074,
+}
+
+
+def _english_likeness(text: str) -> float:
+    """Average English letter frequency over the alphabetic characters in text.
+
+    Higher means more English-like. ROT13 ciphertext of English scores low;
+    actual English prose scores high. Returns 0.0 when there are no letters.
+    """
+    letters = [c.lower() for c in text if c.isalpha()]
+    if not letters:
+        return 0.0
+    return sum(_ENGLISH_LETTER_FREQ.get(c, 0.0) for c in letters) / len(letters)
+
+
 class Rot13Decoder(Decoder):
     """ROT13 decoder."""
 
@@ -227,6 +250,14 @@ class Rot13Decoder(Decoder):
                     decoded += chr((ord(char) - ord("A") + 13) % 26 + ord("A"))
                 else:
                     decoded += char
+
+            # ROT13 is self-inverse, so it cannot tell plaintext from ciphertext
+            # by structure alone. Only treat it as a successful decode when the
+            # rotation makes the text more English-like; otherwise we would mangle
+            # already-readable content into garbage and pollute downstream IOCs.
+            if _english_likeness(decoded) <= _english_likeness(text):
+                return data, False
+
             return decoded.encode("ascii"), True
         except Exception:
             return data, False


### PR DESCRIPTION
## Summary

Error-detection pass plus a dependency refresh. Four logical pieces:

1. Lint & dead-code fixes
2. ROT13 false-positive IOC fix (correctness bug found while test-running the engine)
3. Evidence-only CLI mode
4. Dependency updates (all 9 open dependabot PRs)

---

### 1. Error detection & dead-code fixes
Audited with `ruff`, the test suite, and a manual review of core modules.

- **`cli.py`**: removed a no-op `config_for_trace` block (a `try/except` that assigned `True` either way and was never used — trace is configured via `config.set("include_decision_trace", True)`).
- **`cli.py`**: removed `offline_ctx = block_network() if args.offline else None` — it created a context manager but **never entered it**, so it looked like it enabled offline mode but did nothing. Real blocking is handled by the `with block_network():` statements (verified offline mode still reports `network_blocked: true`).
- **`advanced_heuristics.py`**: removed a useless `Counter(xored)` expression whose result was discarded.
- **`endpoint_parsers.py`**: removed an unused `cols` list.
- Removed 8 unused imports; renamed 5 ambiguous `l` variables to `link` (E741).

### 2. ROT13 mangled plaintext → false-positive IOCs
Found by test-running the engine. When an upstream decoder (e.g. Gzip) revealed readable text like `contact c2.evil.com and user@bad.com`, the **ROT13 decoder re-encoded it into garbage** (`pbagnpg p2.rivy.pbz naq hfre@onq.pbz`), and that garbage node fed IOC extraction — surfacing **bogus domains/emails** (`onq.pbz`, `p2.rivy.pbz`, `hfre@onq.pbz`) alongside the real ones, i.e. false leads for an investigator.

Root cause: ROT13 is self-inverse, so `can_decode` (just "is this alphabetic text?") can't tell plaintext from ciphertext. **Fix:** ROT13 now only reports success when the rotation makes text *more* English-like (letter-frequency scoring). Real ROT13 ciphertext still decodes (`uryyb jbeyq` → `hello world`); readable text is left untouched.

This also exposed that `test_cli_fail_on_risk_level_high_exits_nonzero` was silently relying on the bogus rotated IOCs to inflate risk to HIGH; its payload now reaches HIGH on genuine indicators.

### 3. Evidence-only CLI mode
`--evidence KIND:PATH` previously required a payload (`--file`/`--batch`); running it alone errored. IR workflows often want to ingest logs (DNS/proxy/firewall/auth/…) with no payload to decode.

Now `--evidence` works standalone: the report is produced with `node_count: 0` and a valid `run_manifest`, augmented with normalized events, indicators, pivots, and links. With **no** input source at all, the CLI still errors (exit 1) with an updated message naming `--evidence`. Documented in `USAGE.md`.

### 4. Dependency updates (incorporates all 9 open dependabot PRs)

| File | Update | Dependabot |
|------|--------|-----------|
| requirements-dev | pytest `>=9.1.1` | #37 |
| requirements-dev | ruff `>=0.15.18` | #38 |
| requirements-dev | build `>=1.5.0` | #26 |
| requirements-optional | psutil `>=7.2.2` | #18 |
| requirements-optional | python-whois `>=0.9.6` | #21 |
| requirements-optional | yara-python `>=4.5.4` | #27 |
| requirements-optional | requests `>=2.34.2` | #30 |
| requirements-optional | PyYAML `>=6.0.3` | #20 |
| tests.yml | actions/checkout `v7` | #36 |

Merging this satisfies those requirements; dependabot will auto-close PRs #18, #20, #21, #26, #27, #30, #36, #37, #38.

---

## Verification
- `ruff check .` → **clean** (validated against the updated ruff, a jump from 0.5 → 0.15).
- `pytest -q` → **76 passed** under pytest 9.1.1 (2 new tests for evidence-only success + no-input error).
- Test-ran the engine across ~25 input types and all CLI output paths — no crashes/hangs; determinism holds; offline network-blocking confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)