### PR TITLE
Stop hex blobs being mis-reported as hash IOCs

### DIFF
--- a/tests/test_ioc_extraction.py
+++ b/tests/test_ioc_extraction.py
@@ -1,0 +1,21 @@
+import hashlib
+
+from titan_decoder.utils.helpers import extract_iocs
+
+
+def test_hash_ioc_only_matches_real_digest_lengths():
+    # Real hash digest lengths should be detected.
+    for algo in ("md5", "sha1", "sha224", "sha256", "sha384", "sha512"):
+        digest = hashlib.new(algo, b"sample").hexdigest()
+        assert digest in extract_iocs(f"file {digest} seen")["hashes"], algo
+
+
+def test_hash_ioc_ignores_non_standard_hex_runs():
+    # Hex-encoded payloads / arbitrary hex runs of non-hash length must not be
+    # reported as hash IOCs.
+    hex_text = "48656c6c6f20576f726c6420746573740a"  # 34 chars: hex of "Hello World test\n"
+    assert extract_iocs(hex_text)["hashes"] == []
+
+    for length in (31, 33, 34, 39, 41, 50, 63, 65, 95, 127):
+        run = "a" * length
+        assert extract_iocs(f"id={run}")["hashes"] == [], length

--- a/titan_decoder/utils/helpers.py
+++ b/titan_decoder/utils/helpers.py
@@ -149,9 +149,14 @@ def extract_iocs(text: str) -> Dict[str, List[str]]:
     emails = re.findall(
         r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", text_for_other
     )
+    # Match only real hash digest lengths (hex): MD5=32, SHA1=40, SHA224=56,
+    # SHA256=64, SHA384=96, SHA512=128. A loose {32,128} range would flag any
+    # hex-encoded blob (e.g. a 34-char hex payload) as a bogus "hash" IOC.
     hashes = re.findall(
-        r"\b[a-fA-F0-9]{32,128}\b", text_for_other
-    )  # MD5, SHA1, SHA256, etc.
+        r"\b(?:[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{56}"
+        r"|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})\b",
+        text_for_other,
+    )
 
     for raw_ip in ipv4:
         ip = _clean_indicator(raw_ip)


### PR DESCRIPTION
## Problem

Found while test-running the engine on hex-encoded input. The IOC extractor's hash regex matched **any** hex run of length 32–128:

```python
r"\b[a-fA-F0-9]{32,128}\b"
```

But real hash digests only have fixed hex lengths. So hex-encoded *content* (not a hash) of a length in that range got reported as a bogus `hash` IOC — a false lead for an analyst, the same class of issue as the ROT13 false-IOC bug.

| Input | Before | Correct |
|-------|--------|---------|
| hex of `"Hello World test"` (34 chars) | reported as hash `48656c…740a` | ❌ it's hex text |
| 33 / 50 / 95-char hex run | reported as hash | ❌ no such hash length |
| real MD5 (32) / SHA256 (64) | detected | ✓ |

## Fix

Pin the regex to the actual hash digest lengths — MD5=32, SHA1=40, SHA224=56, SHA256=64, SHA384=96, SHA512=128:

```python
r"\b(?:[a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{56}"
r"|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})\b"
```

Real hashes still match; arbitrary/odd-length hex blobs no longer produce false-positive IOCs.

## Verification
- New regression test (`tests/test_ioc_extraction.py`): every real digest length (32/40/56/64/96/128) is detected; non-standard lengths (31, 33, 34, 39, 41, 50, 63, 65, 95, 127) and the hex-of-text payload yield no hash IOCs.
- `pytest -q` → **78 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_