### PR TITLE
Reject invalid IPv4 addresses and fix public/private IOC classification

### DIFF
--- a/tests/test_ioc_extraction.py
+++ b/tests/test_ioc_extraction.py
@@ -19,3 +19,25 @@ def test_hash_ioc_ignores_non_standard_hex_runs():
     for length in (31, 33, 34, 39, 41, 50, 63, 65, 95, 127):
         run = "a" * length
         assert extract_iocs(f"id={run}")["hashes"] == [], length
+
+
+def test_ipv4_ioc_rejects_invalid_octets():
+    # Octets > 255 are not valid IPv4 addresses and must not be extracted.
+    for bad in ("999.999.999.999", "256.1.1.1", "300.400.500.600"):
+        iocs = extract_iocs(f"addr {bad} seen")
+        assert iocs["ipv4"] == [], bad
+        assert iocs["ipv4_public"] == [], bad
+
+
+def test_ipv4_ioc_public_private_classification():
+    iocs = extract_iocs(
+        "external 8.8.8.8 internal 192.168.1.1 10.0.0.1 loopback 127.0.0.1 "
+        "linklocal 169.254.1.1 cgnat 100.64.0.1 edge 172.32.0.1"
+    )
+    # Globally routable addresses are public.
+    assert "8.8.8.8" in iocs["ipv4_public"]
+    assert "172.32.0.1" in iocs["ipv4_public"]  # outside RFC1918 172.16/12
+    # RFC1918 + loopback + link-local + CGNAT are not public.
+    for ip in ("192.168.1.1", "10.0.0.1", "127.0.0.1", "169.254.1.1", "100.64.0.1"):
+        assert ip in iocs["ipv4_private"], ip
+        assert ip not in iocs["ipv4_public"], ip

--- a/titan_decoder/utils/helpers.py
+++ b/titan_decoder/utils/helpers.py
@@ -1,4 +1,5 @@
 import hashlib
+import ipaddress
 import math
 from typing import Dict, List
 import re
@@ -93,16 +94,17 @@ def looks_like_hex(data: bytes) -> bool:
 # IOC Extraction
 # =========================
 
-PRIVATE_IP_RANGES = [
-    re.compile(r"^10\."),
-    re.compile(r"^192\.168\."),
-    re.compile(r"^172\.(1[6-9]|2[0-9]|3[0-1])\."),
-]
-
-
 def is_private_ip(ip: str) -> bool:
-    """Check if IP is private."""
-    return any(r.match(ip) for r in PRIVATE_IP_RANGES)
+    """Return True if ip is a valid IPv4 address that is not globally routable.
+
+    Covers the RFC1918 private ranges plus loopback, link-local, CGNAT, and
+    other reserved/special-use space — anything that should not be treated as a
+    public indicator. Returns False for invalid addresses.
+    """
+    try:
+        return not ipaddress.IPv4Address(ip).is_global
+    except ValueError:
+        return False
 
 
 def _clean_indicator(val: str) -> str:
@@ -161,6 +163,11 @@ def extract_iocs(text: str) -> Dict[str, List[str]]:
     for raw_ip in ipv4:
         ip = _clean_indicator(raw_ip)
         if not ip:
+            continue
+        try:
+            # Reject malformed addresses (e.g. octets > 255 like 999.999.999.999).
+            ipaddress.IPv4Address(ip)
+        except ValueError:
             continue
         iocs["ipv4"].add(ip)
         if is_private_ip(ip):


### PR DESCRIPTION
## Problem

Found while continuing to test-run the engine for false-positive IOCs.

`extract_iocs` matched IPv4 candidates with `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b`, which accepts **octets > 255**. So malformed strings were reported as IP IOCs — and because they didn't match the RFC1918 ranges, they were bucketed as **public** IPs, inflating risk scoring with garbage:

| Input | Before |
|-------|--------|
| `999.999.999.999` | reported as public IP ❌ |
| `256.1.1.1` | reported as public IP ❌ |
| `300.400.500.600` | reported as public IP ❌ |

Classification was also incomplete — `is_private_ip` only checked RFC1918, so these were mislabelled **public**:

| Address | Before | Correct |
|---------|--------|---------|
| `127.0.0.1` (loopback) | public ❌ | private/non-routable |
| `169.254.1.1` (link-local) | public ❌ | private/non-routable |
| `100.64.0.1` (CGNAT) | public ❌ | private/non-routable |
| `172.32.0.1` (outside 172.16/12) | public ✓ | public ✓ |

## Fix

Use `ipaddress.IPv4Address` to:
1. **Validate** each candidate and drop malformed ones (octets > 255).
2. **Classify** via `is_global` — only globally routable addresses count as public; RFC1918 + loopback + link-local + CGNAT + reserved space go to the private bucket.

Real public/private IPs are unaffected (`8.8.8.8` → public, `192.168.1.1` → private).

## Verification
- New regression tests: invalid-octet rejection + public/private bucketing across RFC1918/loopback/link-local/CGNAT/edge cases.
- `pytest -q` → **80 passed**; `ruff check .` → clean.

## Also noted (not changed here)
`PruningEngine.should_prune_path` and `should_prune_similar_content` in `scoring.py` are defined but never called anywhere in the engine — dead code (they also contain a questionable quality-decay threshold). Happy to remove them in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_