### PR TITLE
Bound decompressor output to prevent decompression bombs

### DIFF
--- a/tests/test_decompression_bomb.py
+++ b/tests/test_decompression_bomb.py
@@ -1,0 +1,56 @@
+import bz2
+import gzip
+import lzma
+import zlib
+
+from titan_decoder.decoders.base import (
+    Bz2Decoder,
+    GzipDecoder,
+    LzmaDecoder,
+    ZlibDecoder,
+)
+
+CAP = 1 * 1024 * 1024  # 1 MB cap for tests
+BOMB = b"\x00" * (50 * 1024 * 1024)  # 50 MB of zeros -> tiny compressed payload
+
+
+def test_decompression_bomb_is_rejected():
+    cases = [
+        (GzipDecoder(CAP), gzip.compress(BOMB)),
+        (Bz2Decoder(CAP), bz2.compress(BOMB)),
+        (LzmaDecoder(CAP), lzma.compress(BOMB)),
+        (ZlibDecoder(CAP), zlib.compress(BOMB)),
+    ]
+    for decoder, payload in cases:
+        out, ok = decoder.decode(payload)
+        # Bomb must not expand past the cap: decode fails and returns input as-is.
+        assert ok is False, decoder.name
+        assert out == payload, decoder.name
+
+
+def test_legit_compressed_data_still_decodes():
+    text = b"hello world http://example.com 8.8.8.8"
+    cases = [
+        (GzipDecoder(CAP), gzip.compress(text)),
+        (Bz2Decoder(CAP), bz2.compress(text)),
+        (LzmaDecoder(CAP), lzma.compress(text)),
+        (ZlibDecoder(CAP), zlib.compress(text)),
+    ]
+    for decoder, payload in cases:
+        out, ok = decoder.decode(payload)
+        assert ok is True, decoder.name
+        assert out == text, decoder.name
+
+
+def test_multi_member_gzip_is_preserved():
+    payload = gzip.compress(b"part1 ") + gzip.compress(b"part2")
+    out, ok = GzipDecoder(CAP).decode(payload)
+    assert ok is True
+    assert out == b"part1 part2"
+
+
+def test_output_exactly_at_cap_is_allowed():
+    payload = gzip.compress(b"A" * 100)
+    out, ok = GzipDecoder(100).decode(payload)
+    assert ok is True
+    assert out == b"A" * 100

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -152,19 +152,23 @@ class TitanEngine:
         self.smart_detector = SmartDetectionEngine()
 
         # Initialize decoders based on config
+        # Cap decompressed output to defend against decompression bombs.
+        max_decompressed = int(
+            self.config.get("max_data_size", 50 * 1024 * 1024)
+        )
         self.decoders: List[Decoder] = []
         if self.config.get("decoders", {}).get("recursive_base64", True):
             self.decoders.append(RecursiveBase64Decoder())
         if self.config.get("decoders", {}).get("base64", True):
             self.decoders.append(Base64Decoder())
         if self.config.get("decoders", {}).get("gzip", True):
-            self.decoders.append(GzipDecoder())
+            self.decoders.append(GzipDecoder(max_decompressed))
         if self.config.get("decoders", {}).get("bz2", True):
-            self.decoders.append(Bz2Decoder())
+            self.decoders.append(Bz2Decoder(max_decompressed))
         if self.config.get("decoders", {}).get("lzma", True):
-            self.decoders.append(LzmaDecoder())
+            self.decoders.append(LzmaDecoder(max_decompressed))
         if self.config.get("decoders", {}).get("zlib", True):
-            self.decoders.append(ZlibDecoder())
+            self.decoders.append(ZlibDecoder(max_decompressed))
         if self.config.get("decoders", {}).get("hex", True):
             self.decoders.append(HexDecoder())
         if self.config.get("decoders", {}).get("rot13", True):

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Tuple
 import base64
-import gzip
 import bz2
 import lzma
+import zlib
 import binascii
 import re
 
@@ -13,6 +13,36 @@ from ..utils.helpers import (
     looks_like_bz2,
     looks_like_hex,
 )
+
+
+# Cap on decompressed output to defend against decompression bombs: a few KB of
+# bz2/gzip/lzma can expand to many GB. This mirrors the size limits the archive
+# (ZIP/TAR) analyzers already enforce. The engine overrides this per-decoder
+# from config (max_data_size).
+DEFAULT_MAX_DECOMPRESSED_SIZE = 100 * 1024 * 1024  # 100 MB
+
+
+def _bounded_decompress(make_decompressor, data: bytes, max_output: int) -> bytes:
+    """Decompress with an output cap to defend against decompression bombs.
+
+    ``make_decompressor`` is a zero-arg factory returning a fresh incremental
+    decompressor (zlib/bz2/lzma style) exposing ``decompress(data, max_length)``,
+    ``.eof`` and ``.unused_data``. Concatenated streams (e.g. multi-member gzip)
+    are handled by creating a new decompressor per stream. ``decompress`` returns
+    at most ``max_length`` bytes and buffers the rest, so peak memory stays
+    bounded. Raises ValueError if the total output would exceed ``max_output``.
+    """
+    result = bytearray()
+    remaining = data
+    while remaining:
+        decompressor = make_decompressor()
+        # Allow one byte past the remaining budget so overflow is detectable.
+        budget = max_output - len(result) + 1
+        result += decompressor.decompress(remaining, budget)
+        if len(result) > max_output or not decompressor.eof:
+            raise ValueError("decompressed output exceeds maximum allowed size")
+        remaining = decompressor.unused_data
+    return bytes(result)
 
 
 class Decoder(ABC):
@@ -91,12 +121,18 @@ class RecursiveBase64Decoder(Decoder):
 class GzipDecoder(Decoder):
     """Gzip decompressor."""
 
+    def __init__(self, max_output_size: int = DEFAULT_MAX_DECOMPRESSED_SIZE):
+        self.max_output_size = max_output_size
+
     def can_decode(self, data: bytes) -> bool:
         return looks_like_gzip(data)
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            return gzip.decompress(data), True
+            # wbits=31 selects the gzip header/format.
+            return _bounded_decompress(
+                lambda: zlib.decompressobj(31), data, self.max_output_size
+            ), True
         except Exception:
             return data, False
 
@@ -108,12 +144,17 @@ class GzipDecoder(Decoder):
 class Bz2Decoder(Decoder):
     """Bz2 decompressor."""
 
+    def __init__(self, max_output_size: int = DEFAULT_MAX_DECOMPRESSED_SIZE):
+        self.max_output_size = max_output_size
+
     def can_decode(self, data: bytes) -> bool:
         return looks_like_bz2(data)
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            return bz2.decompress(data), True
+            return _bounded_decompress(
+                bz2.BZ2Decompressor, data, self.max_output_size
+            ), True
         except Exception:
             return data, False
 
@@ -125,12 +166,17 @@ class Bz2Decoder(Decoder):
 class LzmaDecoder(Decoder):
     """LZMA/XZ decompressor."""
 
+    def __init__(self, max_output_size: int = DEFAULT_MAX_DECOMPRESSED_SIZE):
+        self.max_output_size = max_output_size
+
     def can_decode(self, data: bytes) -> bool:
         return data.startswith(b"\xfd7zXZ") or data.startswith(b"\x5d\x00\x00")
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            return lzma.decompress(data), True
+            return _bounded_decompress(
+                lzma.LZMADecompressor, data, self.max_output_size
+            ), True
         except Exception:
             return data, False
 
@@ -141,6 +187,9 @@ class LzmaDecoder(Decoder):
 
 class ZlibDecoder(Decoder):
     """ZLIB decompressor."""
+
+    def __init__(self, max_output_size: int = DEFAULT_MAX_DECOMPRESSED_SIZE):
+        self.max_output_size = max_output_size
 
     def can_decode(self, data: bytes) -> bool:
         # ZLIB compressed data typically starts with compression method
@@ -155,9 +204,9 @@ class ZlibDecoder(Decoder):
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            import zlib
-
-            return zlib.decompress(data), True
+            return _bounded_decompress(
+                zlib.decompressobj, data, self.max_output_size
+            ), True
         except Exception:
             return data, False
 


### PR DESCRIPTION
## Problem (memory-exhaustion DoS)

Found while continuing to probe the engine. The raw `Gzip`/`Bz2`/`LZMA`/`Zlib` decoders called `decompress()` with **no size limit**, so a tiny crafted payload expands without bound:

| Decoder | Compressed input | Decompresses to |
|---------|------------------|-----------------|
| Bz2 | **81 bytes** | 50 MB |
| Gzip | ~200 KB | 200 MB |
| LZMA | ~30 KB | 200 MB |

For a tool that decodes **untrusted** payloads, this is a classic decompression-bomb DoS. The ZIP/TAR analyzers already guard against bombs (`max_compression_ratio`, `max_total_size`), but these standalone decoders bypassed all of it, and the engine's `max_memory_mb` check only runs *after* the allocation.

## Fix

Decompress incrementally with an output cap via a shared `_bounded_decompress` helper:
- The cap defaults to 100 MB and is overridden by the engine from config `max_data_size` (50 MB).
- `decompress(data, max_length)` yields at most `max_length` bytes at a time, so **peak memory stays bounded** (measured ~20 MB for a 200 MB bomb against a 10 MB cap).
- Exceeding the cap fails the decode cleanly — returns the input unchanged, exactly like other unsupported inputs.
- **Concatenated streams** (multi-member gzip, multi-stream bz2/lzma) are still fully decoded by processing each stream in turn, so legitimate payloads are unaffected (verified `GzipDecoder` output matches `gzip.decompress`).

## Verification
- New `tests/test_decompression_bomb.py`: bomb rejection for all four formats, normal decode still works, multi-member gzip preserved, exactly-at-cap boundary allowed.
- `pytest -q` → **84 passed**; `ruff check .` → clean.
- End-to-end: legit base64+gzip payload still decodes and extracts IOCs through the engine; a 300 MB bomb no longer expands (engine survives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_