### PR TITLE
Fix ELF metadata parsing for 64-bit and big-endian binaries

### DIFF
--- a/tests/test_elf_analyzer.py
+++ b/tests/test_elf_analyzer.py
@@ -1,0 +1,66 @@
+import struct
+
+from titan_decoder.core.analyzers.base import ELFAnalyzer
+
+
+def _make_elf(entry, machine, etype, phnum, shnum, cls64=True, little_endian=True):
+    endian = "<" if little_endian else ">"
+    e_ident = (
+        bytes([0x7F])
+        + b"ELF"
+        + bytes([2 if cls64 else 1, 1 if little_endian else 2, 1, 0])
+        + b"\x00" * 8
+    )
+    if cls64:
+        rest = struct.pack(
+            endian + "HHIQQQIHHHHHH",
+            etype, machine, 1, entry, 0x40, 0x2000, 0, 64, 56, phnum, 64, shnum, 29,
+        )
+    else:
+        rest = struct.pack(
+            endian + "HHIIIIIHHHHHH",
+            etype, machine, 1, entry, 0x40, 0x2000, 0, 52, 32, phnum, 40, shnum, 28,
+        )
+    return e_ident + rest + b"\x00" * 200
+
+
+def test_elf64_little_endian():
+    md = ELFAnalyzer()._extract_elf_metadata(
+        _make_elf(0x401000, 0x3E, 2, 9, 30, cls64=True, little_endian=True)
+    )
+    assert md["class"] == "64-bit"
+    assert md["machine_type"] == "x86-64"
+    assert md["object_type"] == "Executable"
+    assert md["num_program_headers"] == 9
+    assert md["num_section_headers"] == 30
+    assert md["entry_point"] == "0x0000000000401000"
+
+
+def test_elf64_big_endian():
+    md = ELFAnalyzer()._extract_elf_metadata(
+        _make_elf(0x400ABC, 0xB7, 3, 5, 12, cls64=True, little_endian=False)
+    )
+    assert md["data_encoding"] == "Big endian"
+    assert md["machine_type"] == "AArch64"
+    assert md["num_program_headers"] == 5
+    assert md["num_section_headers"] == 12
+
+
+def test_elf64_high_entry_point():
+    md = ELFAnalyzer()._extract_elf_metadata(
+        _make_elf(0x7FFF12345678, 0x3E, 2, 11, 40, cls64=True, little_endian=True)
+    )
+    # A >32-bit entry point must survive (was truncated before the fix).
+    assert md["entry_point"] == "0x00007fff12345678"
+    assert md["num_program_headers"] == 11
+
+
+def test_elf32_little_endian():
+    md = ELFAnalyzer()._extract_elf_metadata(
+        _make_elf(0x8048000, 0x03, 2, 7, 25, cls64=False, little_endian=True)
+    )
+    assert md["class"] == "32-bit"
+    assert md["machine_type"] == "x86"
+    assert md["num_program_headers"] == 7
+    assert md["num_section_headers"] == 25
+    assert md["entry_point"] == "0x08048000"

--- a/titan_decoder/core/analyzers/base.py
+++ b/titan_decoder/core/analyzers/base.py
@@ -550,6 +550,18 @@ class ELFAnalyzer(Analyzer):
                 12: "OpenBSD",
             }
 
+            # Endianness and word size depend on e_ident: ELF64 uses 8-byte
+            # e_entry/e_phoff/e_shoff, ELF32 uses 4-byte; ei_data selects
+            # little- (1) vs big-endian (2).
+            endian = ">" if ei_data == 2 else "<"
+            if ei_class == 2:  # 64-bit
+                header_fmt = endian + "HHIQQQIHHHHHH"
+            else:  # 32-bit (and fallback)
+                header_fmt = endian + "HHIIIIIHHHHHH"
+            header_size = struct.calcsize(header_fmt)
+            if len(data) < 16 + header_size:
+                return None
+
             # Rest of header
             (
                 e_type,
@@ -565,7 +577,7 @@ class ELFAnalyzer(Analyzer):
                 e_shentsize,
                 e_shnum,
                 e_shstrndx,
-            ) = struct.unpack("<HHIIIIIHHHHHH", data[16:52])
+            ) = struct.unpack(header_fmt, data[16 : 16 + header_size])
 
             # Object file types
             object_types = {


### PR DESCRIPTION
## Problem

`ELFAnalyzer._extract_elf_metadata` parsed the ELF header with a hardcoded little-endian, 32-bit format string `<HHIIIIIHHHHHH`. But:
- **ELF64** has 8-byte `e_entry`/`e_phoff`/`e_shoff` (not 4), so for 64-bit binaries — the common case (x86-64, AArch64) — every field after `e_entry` was misaligned.
- ELF can be **big-endian**, which was always parsed as little-endian.

Observed on a crafted x86-64 executable (before fix):

| Field | Reported | Correct |
|-------|----------|---------|
| `num_program_headers` | **0** | 9 |
| `num_section_headers` | **0** | 30 |
| entry point > 4 GB | truncated | full 64-bit |

## Fix

Select the `struct` format from `e_ident`: endianness from `ei_data` (1=LE, 2=BE) and 32- vs 64-bit field widths from `ei_class`. Bounds-checked against the (larger) ELF64 header size.

## Verification
- New `tests/test_elf_analyzer.py`: ELF64 little-endian (x86-64), ELF64 big-endian (AArch64), a >32-bit entry point, and ELF32 — all now report correct machine type, header counts, and entry point.
- `pytest -q` → **88 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_