### PR TITLE
Fix UU/QuotedPrintable decoder return contract on failure path

### DIFF
--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -587,7 +587,9 @@ class UUDecoder(Decoder):
             uu.decode(input_buffer, output_buffer)
             decoded = output_buffer.getvalue()
 
-            return decoded if decoded else (data, False), bool(decoded)
+            if decoded:
+                return decoded, True
+            return data, False
         except Exception:
             return data, False
 
@@ -710,7 +712,9 @@ class QuotedPrintableDecoder(Decoder):
             import quopri
 
             decoded = quopri.decodestring(data)
-            return decoded if decoded != data else (data, False), decoded != data
+            if decoded != data:
+                return decoded, True
+            return data, False
         except Exception:
             return data, False
 


### PR DESCRIPTION
## Problem

`Decoder.decode` must return `Tuple[bytes, bool]`. An operator-precedence mistake in two decoders made the **failure branch** return `((data, False), False)` — a `(tuple, bool)` instead of `(bytes, bool)`:

```python
# UUDecoder
return decoded if decoded else (data, False), bool(decoded)
# QuotedPrintableDecoder
return decoded if decoded != data else (data, False), decoded != data
```

`decoded if decoded else (data, False), bool(decoded)` parses as `(decoded if decoded else (data, False)), bool(decoded)`, so when `decoded` is falsy the first tuple element becomes `(data, False)` instead of `data`.

The engine masked this (it only uses the decoded bytes when `success` is `True`), but the contract was still violated and would break any direct caller of `decode()`.

## Fix

Replace the clever one-liners with explicit `if/return` so both decoders always return `(bytes, bool)`.

## Verification
- Both decoders now return well-formed `(bytes, bool)` on success, no-op, garbage, and exception paths (checked UU + QP across valid/invalid inputs).
- `pytest -q` → **84 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_