### PR TITLE
Fix PE metadata parsing (broken optional-header struct format)

### DIFF
--- a/tests/test_pe_analyzer.py
+++ b/tests/test_pe_analyzer.py
@@ -1,0 +1,60 @@
+import struct
+
+from titan_decoder.core.analyzers.base import PEAnalyzer
+
+
+def _build_pe(magic, opt_header_size, tail=b""):
+    # DOS header: MZ + padding + e_lfanew=64
+    mz = b"MZ" + b"\x00" * 58 + struct.pack("<I", 64)
+    machine = 0x8664 if magic == 0x20B else 0x14C
+    coff = struct.pack(
+        "<HHIIIHH", machine, 4, 0x600D1234, 0, 0, opt_header_size, 0x0022
+    )
+    # Standard optional-header common fields (24 bytes):
+    # magic, major/minor linker, code/init/uninit sizes, entry point, base of code.
+    opt = struct.pack(
+        "<HBBIIIII", magic, 14, 29, 0x1000, 0x800, 0, 0x1500, 0x1000
+    ) + tail
+    return mz + b"PE\x00\x00" + coff + opt
+
+
+def test_pe32plus_metadata():
+    pe = _build_pe(0x20B, 0xF0, tail=struct.pack("<Q", 0x140000000) + b"\x00" * 200)
+    md = PEAnalyzer()._extract_pe_metadata(pe)
+    assert "error" not in md
+    assert md["machine_type"] == "x64"
+    assert md["magic"] == "PE32+"
+    assert md["num_sections"] == 4
+    assert md["entry_point"] == "0x00001500"
+    assert md["image_base"] == "0x0000000140000000"
+
+
+def test_pe32_metadata():
+    pe = _build_pe(
+        0x10B, 0xE0, tail=struct.pack("<I", 0) + struct.pack("<I", 0x400000) + b"\x00" * 200
+    )
+    md = PEAnalyzer()._extract_pe_metadata(pe)
+    assert "error" not in md
+    assert md["machine_type"] == "x86"
+    assert md["magic"] == "PE32"
+    assert md["image_base"] == "0x00400000"
+
+
+def test_truncated_pe_keeps_core_metadata():
+    # Optional header declared but no image-base bytes present: parsing should
+    # still yield core metadata and simply omit image_base (no error).
+    pe = _build_pe(0x20B, 0xF0)
+    md = PEAnalyzer()._extract_pe_metadata(pe)
+    assert "error" not in md
+    assert md["machine_type"] == "x64"
+    assert md["entry_point"] == "0x00001500"
+    assert "image_base" not in md
+
+
+def test_pe_analyze_returns_metadata_json():
+    pe = _build_pe(0x20B, 0xF0, tail=struct.pack("<Q", 0x140000000) + b"\x00" * 200)
+    result = PEAnalyzer().analyze(pe)
+    assert len(result) == 1
+    name, content = result[0]
+    assert name == "pe_metadata.json"
+    assert b"PE32+" in content

--- a/titan_decoder/core/analyzers/base.py
+++ b/titan_decoder/core/analyzers/base.py
@@ -457,7 +457,7 @@ class PEAnalyzer(Analyzer):
                         size_of_uninit_data,
                         entry_point,
                         base_of_code,
-                    ) = struct.unpack("<HBBIIIIII", data[opt_offset : opt_offset + 24])
+                    ) = struct.unpack("<HBBIIIII", data[opt_offset : opt_offset + 24])
 
                     metadata.update(
                         {
@@ -473,15 +473,15 @@ class PEAnalyzer(Analyzer):
                         }
                     )
 
-                    # For PE32, image base is at offset 28
-                    if magic == 0x10B and opt_offset + 28 <= len(data):
+                    # For PE32, image base is a 4-byte field at offset 28.
+                    if magic == 0x10B and opt_offset + 32 <= len(data):
                         image_base = struct.unpack(
                             "<I", data[opt_offset + 28 : opt_offset + 32]
                         )[0]
                         metadata["image_base"] = f"0x{image_base:08x}"
 
-                    # For PE32+, image base is at offset 24
-                    elif magic == 0x20B and opt_offset + 24 <= len(data):
+                    # For PE32+, image base is an 8-byte field at offset 24.
+                    elif magic == 0x20B and opt_offset + 32 <= len(data):
                         image_base = struct.unpack(
                             "<Q", data[opt_offset + 24 : opt_offset + 32]
                         )[0]


### PR DESCRIPTION
## Problem (PE analysis was completely broken)

`PEAnalyzer._extract_pe_metadata` unpacked the optional header with `struct.unpack("<HBBIIIIII", data[opt_offset:opt_offset+24])`. That format string has **9 fields / 28 bytes**, but the code:
- slices only **24 bytes** → `struct.error: unpack requires a buffer of 28 bytes`
- unpacks into **8 variables** → `ValueError: too many values to unpack`

So `struct.unpack` raised for **every PE that has an optional header** (i.e. every real PE). The exception propagated to the outer handler and the analyzer returned only `{"error": "..."}` — no machine type, sections, entry point, image base, anything.

## Fix

1. **Struct format typo** — remove the extra `I` (`<HBBIIIIII` → `<HBBIIIII`, 8 fields / 24 bytes), matching the 24-byte slice and 8 target variables. The standard optional-header common fields now parse.
2. **`image_base` bounds checks** — they verified the *start* offset (`opt_offset + 24` / `+ 28`) but read 4–8 bytes through `+ 32`. On a truncated optional header the slice underflowed and `struct.unpack` raised, discarding *all* metadata. Now check `+ 32`, so `image_base` is simply omitted while core metadata is preserved.

## Verification (before → after)
- PE32+ x64: was `{"error": ...}` → now `machine_type=x64, magic=PE32+, entry_point, num_sections, image_base=0x140000000`.
- PE32 x86: now `magic=PE32, image_base=0x00400000`.
- Truncated PE32+: now keeps machine/entry, omits `image_base`, no error.
- New `tests/test_pe_analyzer.py` (PE32, PE32+, truncated, `analyze()` output).
- `pytest -q` → **92 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_