### PR TITLE
Detect GNU-format tar archives

### DIFF
--- a/tests/test_tar_analyzer.py
+++ b/tests/test_tar_analyzer.py
@@ -1,0 +1,33 @@
+import io
+import os
+import tarfile
+
+from titan_decoder.core.analyzers.base import TarAnalyzer
+
+
+def _make_tar(fmt, name="evil.txt", content=b"http://bad.com 8.8.8.8"):
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", format=fmt) as t:
+        info = tarfile.TarInfo(name)
+        info.size = len(content)
+        t.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def test_can_analyze_all_tar_formats():
+    # GNU format (common default of `tar`) uses "ustar  " magic; POSIX/PAX use
+    # "ustar\x00". Both must be detected.
+    for fmt in (tarfile.USTAR_FORMAT, tarfile.GNU_FORMAT, tarfile.PAX_FORMAT):
+        assert TarAnalyzer().can_analyze(_make_tar(fmt)) is True
+
+
+def test_can_analyze_rejects_non_tar():
+    assert TarAnalyzer().can_analyze(b"ustar") is False  # too short
+    assert TarAnalyzer().can_analyze(os.urandom(600)) is False
+
+
+def test_gnu_tar_contents_extracted():
+    extracted = TarAnalyzer().analyze(_make_tar(tarfile.GNU_FORMAT))
+    assert len(extracted) == 1
+    name, content = extracted[0]
+    assert b"http://bad.com" in content

--- a/titan_decoder/core/analyzers/base.py
+++ b/titan_decoder/core/analyzers/base.py
@@ -216,11 +216,10 @@ class TarAnalyzer(Analyzer):
         self.max_workers = self.config.get("max_parallel_workers", 4)
 
     def can_analyze(self, data: bytes) -> bool:
-        return (
-            data.startswith(b"\x75\x73\x74\x61\x72")
-            or len(data) >= 512
-            and data[257:263] == b"ustar\x00"
-        )
+        # The ustar magic lives at offset 257 of the 512-byte tar header. Both
+        # the POSIX ("ustar\x00") and GNU ("ustar  ") variants begin with
+        # b"ustar" there, so match that prefix to cover both.
+        return len(data) >= 262 and data[257:262] == b"ustar"
 
     def analyze(self, data: bytes) -> List[Tuple[str, bytes]]:
         """Analyze TAR file with safety checks and optional parallel extraction."""


### PR DESCRIPTION
## Problem

`TarAnalyzer.can_analyze` recognized only POSIX/PAX archives:

```python
return (
    data.startswith(b"\x75\x73\x74\x61\x72")   # dead: ustar is never at offset 0
    or len(data) >= 512
    and data[257:263] == b"ustar\x00"
)
```

The ustar magic field at offset 257 differs by format:
- POSIX/PAX: `b"ustar\x00"`
- **GNU**: `b"ustar  "` (ustar + two spaces) — the default output of `tar` on many systems

So **GNU tarballs failed `can_analyze`**, and the engine never invoked the analyzer on them — their embedded files and IOCs were silently never extracted. The first condition (`startswith(b"ustar")`) is also dead: the magic lives at offset 257, never offset 0.

## Fix

Match the `b"ustar"` prefix at offset 257, which is common to POSIX, PAX, and GNU:

```python
return len(data) >= 262 and data[257:262] == b"ustar"
```

## Verification
- All three formats (USTAR/GNU/PAX) now detected; random/short data rejected.
- End-to-end: a GNU tar now extracts its embedded file and IOCs through the engine.
- New `tests/test_tar_analyzer.py`; `pytest -q` → **95 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_