### PR TITLE
Fix IOC export: MISP duplicate IPs and STIX quote escaping

### DIFF
--- a/tests/test_ioc_export.py
+++ b/tests/test_ioc_export.py
@@ -1,0 +1,42 @@
+import json
+import warnings
+
+from titan_decoder.core.ioc_export import export_misp, export_stix_minimal
+
+# IOC dict shaped like extract_iocs output: ipv4 is a superset of ipv4_public.
+IOCS = {
+    "ipv4": ["8.8.8.8", "192.168.1.1"],
+    "ipv4_public": ["8.8.8.8"],
+    "ipv4_private": ["192.168.1.1"],
+    "urls": ["http://evil.com/a'b"],
+    "domains": ["bad.com"],
+    "emails": [],
+    "hashes": [],
+}
+
+
+def test_misp_does_not_duplicate_overlapping_ip_buckets(tmp_path):
+    out = tmp_path / "misp.json"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        export_misp(IOCS, out)
+    event = json.loads(out.read_text())
+    ip_values = [a["value"] for a in event["Event"]["Attribute"] if a["type"] == "ip-dst"]
+    assert ip_values.count("8.8.8.8") == 1
+
+
+def test_stix_escapes_quotes_in_values(tmp_path):
+    out = tmp_path / "stix.json"
+    export_stix_minimal(IOCS, out)
+    bundle = json.loads(out.read_text())
+    url_patterns = [o["pattern"] for o in bundle["objects"] if "url:value" in o["pattern"]]
+    assert url_patterns == ["[url:value = 'http://evil.com/a\\'b']"]
+
+
+def test_stix_no_duplicate_ip_indicators(tmp_path):
+    out = tmp_path / "stix.json"
+    export_stix_minimal(IOCS, out)
+    bundle = json.loads(out.read_text())
+    patterns = [o["pattern"] for o in bundle["objects"]]
+    assert len(patterns) == len(set(patterns))
+    assert patterns.count("[ipv4-addr:value = '8.8.8.8']") == 1

--- a/titan_decoder/core/ioc_export.py
+++ b/titan_decoder/core/ioc_export.py
@@ -65,23 +65,27 @@ def export_stix_minimal(iocs: Dict[str, Any], path: Path):
     }
 
     def mk_indicator(ind_type: str, value: str, idx: int) -> Dict[str, Any]:
+        # STIX string literals escape backslash and single quote; without this
+        # an IOC value containing a quote (e.g. a crafted URL) produces an
+        # invalid STIX pattern.
+        safe = value.replace("\\", "\\\\").replace("'", "\\'")
         pattern = None
         if ind_type == "ipv4":
-            pattern = f"[ipv4-addr:value = '{value}']"
+            pattern = f"[ipv4-addr:value = '{safe}']"
         elif ind_type == "domains":
-            pattern = f"[domain-name:value = '{value}']"
+            pattern = f"[domain-name:value = '{safe}']"
         elif ind_type == "urls":
-            pattern = f"[url:value = '{value}']"
+            pattern = f"[url:value = '{safe}']"
         elif ind_type == "emails":
-            pattern = f"[email-addr:value = '{value}']"
+            pattern = f"[email-addr:value = '{safe}']"
         elif ind_type == "hashes":
-            pattern = f"[file:hashes.'SHA-256' = '{value}']"
+            pattern = f"[file:hashes.'SHA-256' = '{safe}']"
         elif ind_type == "imei":
-            pattern = f"[x-device:imei = '{value}']"
+            pattern = f"[x-device:imei = '{safe}']"
         elif ind_type == "imsi":
-            pattern = f"[x-device:imsi = '{value}']"
+            pattern = f"[x-device:imsi = '{safe}']"
         elif ind_type == "iccid":
-            pattern = f"[x-device:iccid = '{value}']"
+            pattern = f"[x-device:iccid = '{safe}']"
         if not pattern:
             return None
         return {
@@ -93,15 +97,14 @@ def export_stix_minimal(iocs: Dict[str, Any], path: Path):
         }
 
     idx = 1
+    seen_patterns: set[str] = set()
     for key, values in iocs.items():
-        mapped_key = key
-        if key == "domains":
-            mapped_key = "domains"
         for v in values:
-            obj = mk_indicator(mapped_key, v, idx)
-            idx += 1
-            if obj:
+            obj = mk_indicator(key, v, idx)
+            if obj and obj["pattern"] not in seen_patterns:
+                seen_patterns.add(obj["pattern"])
                 bundle["objects"].append(obj)
+                idx += 1
     path.write_text(json.dumps(bundle, indent=2))
 
 
@@ -110,16 +113,17 @@ def export_misp(
 ):
     """Export IOCs as MISP event (JSON format)."""
     import uuid
-    from datetime import datetime
+    from datetime import datetime, timezone
 
+    now = datetime.now(timezone.utc)
     event_uuid = str(uuid.uuid4())
-    timestamp = int(datetime.utcnow().timestamp())
+    timestamp = int(now.timestamp())
 
     event = {
         "Event": {
             "uuid": event_uuid,
             "info": event_info,
-            "date": datetime.utcnow().strftime("%Y-%m-%d"),
+            "date": now.strftime("%Y-%m-%d"),
             "timestamp": str(timestamp),
             "published": False,
             "analysis": "1",  # Ongoing
@@ -141,12 +145,19 @@ def export_misp(
         "iccid": "sim-number",
     }
 
+    # The IOC dict has overlapping IP buckets (ipv4 is a superset of
+    # ipv4_public), so dedupe by (type, value) to avoid emitting the same
+    # attribute twice.
+    seen: set[tuple[str, str]] = set()
     for ioc_type, values in iocs.items():
         misp_type = type_mapping.get(ioc_type)
         if not misp_type:
             continue
 
         for value in values:
+            if (misp_type, value) in seen:
+                continue
+            seen.add((misp_type, value))
             attribute = {
                 "uuid": str(uuid.uuid4()),
                 "type": misp_type,


### PR DESCRIPTION
## Problems

`extract_iocs` returns overlapping IP buckets (`ipv4` is a superset of `ipv4_public`). Two threat-sharing exporters mishandled this and quoting:

1. **MISP duplicates public IPs** — `type_mapping` maps both `ipv4` and `ipv4_public` to `ip-dst`, so every public IP was emitted as two identical attributes. (e.g. `8.8.8.8` appeared twice.)
2. **STIX produces invalid patterns** — IOC values were interpolated straight into pattern string literals, so a value containing a single quote (a crafted URL like `http://evil.com/a'b`) yielded `[url:value = 'http://evil.com/a'b']`, which is syntactically invalid STIX and breaks downstream parsers.
3. `datetime.utcnow()` (deprecated in 3.12) used in the MISP exporter.

## Fix

- **MISP**: dedupe attributes by `(type, value)`.
- **STIX**: escape `\` and `'` in values per STIX string-literal rules, and dedupe indicator objects by pattern.
- Replace `datetime.utcnow()` → `datetime.now(timezone.utc)`.

## Verification (after)
- MISP: `8.8.8.8` appears once; no `DeprecationWarning`.
- STIX: `[url:value = 'http://evil.com/a\'b']` (escaped), no duplicate IP indicators.
- New `tests/test_ioc_export.py`; `pytest -q` → **98 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_