### PR TITLE
Reimplement UU decoder without the deprecated stdlib uu module

### DIFF
--- a/tests/test_uu_decoder.py
+++ b/tests/test_uu_decoder.py
@@ -1,0 +1,55 @@
+import binascii
+import warnings
+
+from titan_decoder.decoders.base import UUDecoder
+
+
+def _uuencode(payload: bytes, name: str = "sample.txt") -> bytes:
+    lines = [f"begin 644 {name}\n".encode()]
+    for i in range(0, len(payload), 45):
+        lines.append(binascii.b2a_uu(payload[i : i + 45]))
+    lines.append(b"`\nend\n")
+    return b"".join(lines)
+
+
+def test_uudecode_roundtrip():
+    dec = UUDecoder(enabled=True)
+    for payload in (
+        b"Hello, UUencoded world! http://evil.com 8.8.8.8\n",
+        b"X" * 200 + b"\nsecond line\n",
+        bytes(range(256)) * 3,  # full binary range
+        b"a",
+        b"B" * 45,  # exactly one full line
+    ):
+        data = _uuencode(payload)
+        out, ok = dec.decode(data)
+        assert ok is True
+        assert out == payload
+
+
+def test_uudecode_handles_crlf():
+    dec = UUDecoder(enabled=True)
+    payload = b"crlf test 1.2.3.4\n"
+    data = _uuencode(payload).replace(b"\n", b"\r\n")
+    out, ok = dec.decode(data)
+    assert ok is True
+    assert out == payload
+
+
+def test_uudecode_emits_no_deprecation_warning():
+    # Must not import the deprecated stdlib `uu` module.
+    dec = UUDecoder(enabled=True)
+    data = _uuencode(b"no deprecation please\n")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        out, ok = dec.decode(data)
+    assert ok is True
+
+
+def test_uudecode_graceful_on_garbage():
+    dec = UUDecoder(enabled=True)
+    assert dec.decode(b"random bytes, no header") == (b"random bytes, no header", False)
+
+
+def test_uudecode_disabled_by_default():
+    assert UUDecoder().can_decode(_uuencode(b"x" * 20)) is False

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -576,17 +576,31 @@ class UUDecoder(Decoder):
             return False
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
+        # Implemented with binascii.a2b_uu rather than the stdlib `uu` module,
+        # which is deprecated (3.11) and removed in Python 3.13.
         try:
-            import uu
-            import io
+            out = bytearray()
+            started = False
+            for raw in data.split(b"\n"):
+                line = raw.rstrip(b"\r")
+                if not started:
+                    if line.startswith(b"begin "):
+                        started = True
+                    continue
+                if line.startswith(b"end"):
+                    break
+                if not line or line == b"`":
+                    # ` is the zero-length data line that precedes `end`.
+                    continue
+                try:
+                    out += binascii.a2b_uu(line)
+                except binascii.Error:
+                    # Some encoders strip trailing whitespace; recompute the
+                    # expected byte count from the length char and retry.
+                    nbytes = (((line[0] - 32) & 0x3F) * 4 + 5) // 3
+                    out += binascii.a2b_uu(line[: nbytes + 1])
 
-            # Create a buffer and attempt UU decode
-            input_buffer = io.BytesIO(data)
-            output_buffer = io.BytesIO()
-
-            uu.decode(input_buffer, output_buffer)
-            decoded = output_buffer.getvalue()
-
+            decoded = bytes(out)
             if decoded:
                 return decoded, True
             return data, False


### PR DESCRIPTION
## Problem

`UUDecoder.decode` used the stdlib `uu` module (`uu.decode`). `uu` is **deprecated since Python 3.11** and **removed in Python 3.13** (PEP 594):
- On 3.11/3.12 it emits a `DeprecationWarning` whenever the decoder runs.
- On 3.13 `import uu` fails, so UU payloads silently stop decoding (the `except` returns `(data, False)`).

## Fix

Reimplement uudecode directly with `binascii.a2b_uu` (not deprecated):
- Parse the `begin … / end` framing and the `` ` `` zero-length terminator.
- Decode each line; on a length mismatch, recompute the expected byte count from the leading length character and retry (matching how the stdlib handled encoders that strip trailing whitespace).
- Tolerate CRLF line endings.

Behavior is unchanged on currently-supported versions and now also works on 3.13.

## Verification
- New `tests/test_uu_decoder.py`: round-trip (including the full 256-byte range, multi-line, and CRLF), **no `DeprecationWarning`** (asserted via `simplefilter("error")`), graceful failure on garbage, and off-by-default gating.
- `pytest -q` → **103 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_