### PR TITLE
Reduce IOC/forensics false positives from filenames and encoded layers

### DIFF
--- a/tests/test_forensics.py
+++ b/tests/test_forensics.py
@@ -39,3 +39,19 @@ def test_handles_empty_nodes_gracefully():
     assert summary["vm"]["detected"] is False
     assert summary["mobile_ids"] == {"imei": [], "imsi": [], "iccid": []}
     assert summary["burner"]["score"] == 0
+
+
+def test_ignores_intermediate_encoded_layers():
+    # The root (base64-ish) layer carries noise; only the decoded leaf should be
+    # scanned. Parent/child ids mark the root as a non-leaf intermediate node.
+    report = {
+        "nodes": [
+            {"id": 0, "parent": None, "content_preview": "AMDxQUNvcmU=", "content_type": "Text"},
+            {"id": 1, "parent": 0, "content_preview": "clean VMware host DESKTOP-AB12CD", "content_type": "Text"},
+        ]
+    }
+    summary = ForensicsEngine().analyze(report)
+    # VM signal from the decoded leaf is detected...
+    assert summary["vm"]["detected"]
+    # ...but the "AMD" substring in the encoded parent must not surface.
+    assert summary["hardware_hints"] == []

--- a/tests/test_ioc_extraction.py
+++ b/tests/test_ioc_extraction.py
@@ -41,3 +41,26 @@ def test_ipv4_ioc_public_private_classification():
     for ip in ("192.168.1.1", "10.0.0.1", "127.0.0.1", "169.254.1.1", "100.64.0.1"):
         assert ip in iocs["ipv4_private"], ip
         assert ip not in iocs["ipv4_public"], ip
+
+
+def test_domain_extraction_drops_filenames():
+    from titan_decoder.utils.helpers import extract_iocs
+
+    text = (
+        "open config.json and gate.php, see report.pdf data.csv style.css app.exe; "
+        "c2 is evil-corp.net via cdn.bad.example.org"
+    )
+    domains = extract_iocs(text)["domains"]
+    for filename in ("config.json", "gate.php", "report.pdf", "data.csv", "style.css", "app.exe"):
+        assert filename not in domains
+    assert "evil-corp.net" in domains
+    assert "cdn.bad.example.org" in domains
+
+
+def test_domain_extraction_keeps_cctld_lookalikes():
+    # .sh / .py are real ccTLDs and must NOT be treated as file extensions.
+    from titan_decoder.utils.helpers import extract_iocs
+
+    domains = extract_iocs("hosts evil.sh and paraguay.py")["domains"]
+    assert "evil.sh" in domains
+    assert "paraguay.py" in domains

--- a/titan_decoder/core/device_forensics.py
+++ b/titan_decoder/core/device_forensics.py
@@ -65,7 +65,7 @@ class ForensicsEngine:
 
     def analyze(self, analysis_report: Dict[str, Any]) -> Dict[str, Any]:
         nodes = analysis_report.get("nodes", [])
-        text_corpus = self._gather_text(nodes)
+        text_corpus = self._gather_text(self._meaningful_nodes(nodes))
 
         vm_hits = self._detect_vm(text_corpus)
         mobile_ids = self._detect_mobile_ids(text_corpus)
@@ -88,6 +88,21 @@ class ForensicsEngine:
             "network_indicators": {"ips": ips},
             "recommendations": recommendations,
         }
+
+    def _meaningful_nodes(
+        self, nodes: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Keep only leaf nodes (decoded/final content).
+
+        Intermediate encoding layers (e.g. the raw base64 or compressed bytes of
+        a parent node) carry their still-encoded form in content_preview, which
+        produces spurious matches like an "AMD" hardware hint from base64 noise.
+        The meaningful, decoded content lives in their child/leaf nodes. A node
+        is a leaf when no other node references it as a parent.
+        """
+        parent_ids = {n.get("parent") for n in nodes if n.get("parent") is not None}
+        leaves = [n for n in nodes if n.get("id") not in parent_ids]
+        return leaves or nodes
 
     def _gather_text(self, nodes: Iterable[Dict[str, Any]]) -> str:
         parts: List[str] = []

--- a/titan_decoder/utils/helpers.py
+++ b/titan_decoder/utils/helpers.py
@@ -94,6 +94,27 @@ def looks_like_hex(data: bytes) -> bool:
 # IOC Extraction
 # =========================
 
+# Common file extensions that the domain regex would otherwise mistake for a
+# TLD (e.g. "config.json", "gate.php", "payload.txt" -> bogus domains). Every
+# entry here is NOT a real TLD, so filtering on them never drops a real domain.
+# Ambiguous extensions that *are* ccTLDs/gTLDs (sh, py, io, zip, mov, md, ...)
+# are deliberately omitted to avoid false negatives.
+COMMON_FILE_EXTENSIONS = frozenset(
+    {
+        "txt", "log", "json", "xml", "csv", "yaml", "yml", "toml", "ini",
+        "cfg", "conf", "php", "html", "htm", "css", "js", "jsx", "ts", "tsx",
+        "exe", "dll", "bin", "dat", "dmp", "img", "iso", "msi", "apk", "ipa",
+        "deb", "rpm", "png", "jpg", "jpeg", "gif", "bmp", "svg", "ico", "webp",
+        "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "odt", "rtf",
+        "bak", "tmp", "swp", "lock", "sqlite", "db", "ps1", "psm1", "vbs",
+        "asp", "aspx", "jsp", "jar", "war", "ear", "class", "pyc", "pyo",
+        "woff", "woff2", "ttf", "otf", "eot", "mp3", "mp4", "avi", "mkv",
+        "wav", "flac", "webm", "gz", "bz2", "xz", "tgz", "vhd", "vmdk",
+        "pem", "crt", "der", "pfx", "manifest",
+    }
+)
+
+
 def is_private_ip(ip: str) -> bool:
     """Return True if ip is a valid IPv4 address that is not globally routable.
 
@@ -182,8 +203,13 @@ def extract_iocs(text: str) -> Dict[str, List[str]]:
 
     for raw_domain in domains:
         domain = _clean_indicator(raw_domain).lower()
-        if domain:
-            iocs["domains"].add(domain)
+        if not domain:
+            continue
+        # Drop filename-like matches (e.g. config.json) whose final label is a
+        # known non-TLD file extension.
+        if domain.rsplit(".", 1)[-1] in COMMON_FILE_EXTENSIONS:
+            continue
+        iocs["domains"].add(domain)
 
     for raw_email in emails:
         email = _clean_indicator(raw_email).lower()


### PR DESCRIPTION
## Summary

Fixes two false-positive sources surfaced during a live end-to-end engine test.

### 1. Filenames reported as domain IOCs
The domain regex matched any `word.ext`, so `config.json`, `gate.php`, `payload.txt`, `report.pdf`, `data.csv`, etc. were emitted as domains.

**Fix:** drop candidates whose final label is a known **non-TLD** file extension (`COMMON_FILE_EXTENSIONS`). The set deliberately **omits extensions that are also real TLDs** (`sh`, `py`, `io`, `zip`, `mov`, `md`, …), so a real domain is never dropped — e.g. `evil.sh` and `paraguay.py` are preserved.

### 2. Forensics scanned still-encoded layers
`ForensicsEngine` concatenated `content_preview` from **every** node, including intermediate encoding layers (the raw base64/compressed bytes). That produced spurious signals — e.g. an `AMD` hardware hint pulled from base64 noise in the root node.

**Fix:** scan only **leaf nodes** (the decoded/final content; a node is a leaf when nothing references it as a parent). Real VM/host/burner signals are still detected.

## Verification (on the live-test payload)
- `hardware_hints`: `['AMD']` → `[]`, while `vmware` + `DESKTOP-…` burner pattern + real IP are still detected.
- `gate.php` no longer appears in domains; `c2.evil-corp.net` / `evil-corp.net` remain.
- New regression tests (filename filtering, ccTLD look-alike preservation, forensics layer filtering).
- `pytest -q` → **106 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_