### PR TITLE
Bound PDF FlateDecode output to prevent decompression bombs

### DIFF
--- a/tests/test_decompression_bomb.py
+++ b/tests/test_decompression_bomb.py
@@ -54,3 +54,35 @@ def test_output_exactly_at_cap_is_allowed():
     out, ok = GzipDecoder(100).decode(payload)
     assert ok is True
     assert out == b"A" * 100
+
+
+def test_pdf_flatedecode_bomb_is_bounded():
+    import zlib
+
+    from titan_decoder.decoders.base import PDFDecoder
+
+    cap = 1 * 1024 * 1024  # 1 MB
+    flate_bomb = zlib.compress(b"\x00" * (50 * 1024 * 1024))  # 50 MB -> tiny
+    pdf = (
+        b"%PDF-1.5\n1 0 obj<</Filter/FlateDecode/Length "
+        + str(len(flate_bomb)).encode()
+        + b">>stream\n" + flate_bomb + b"\nendstream endobj\n%%EOF"
+    )
+    out, ok = PDFDecoder(cap).decode(pdf)
+    # Bomb exceeds the cap: the inflated 50 MB must NOT be produced.
+    assert len(out) <= len(pdf) + 16
+
+
+def test_pdf_legit_flate_stream_still_extracted():
+    import zlib
+
+    from titan_decoder.decoders.base import PDFDecoder
+
+    payload = b"http://pdf-c2.example.net 8.8.8.8 secret"
+    pdf = (
+        b"%PDF-1.5\n1 0 obj<</Filter/FlateDecode/Length 0>>stream\n"
+        + zlib.compress(payload) + b"\nendstream endobj\n%%EOF"
+    )
+    out, ok = PDFDecoder(50 * 1024 * 1024).decode(pdf)
+    assert ok is True
+    assert payload in out

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -176,7 +176,7 @@ class TitanEngine:
         if self.config.get("decoders", {}).get("xor", True):
             self.decoders.append(XorDecoder())
         if self.config.get("decoders", {}).get("pdf", True):
-            self.decoders.append(PDFDecoder())
+            self.decoders.append(PDFDecoder(max_decompressed))
         if self.config.get("decoders", {}).get("ole", True):
             self.decoders.append(OLEDecoder())
         if self.config.get("decoders", {}).get("url", True):

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -365,8 +365,8 @@ class XorDecoder(Decoder):
 class PDFDecoder(Decoder):
     """PDF file stream decoder - extracts compressed streams and objects."""
 
-    def __init__(self):
-        pass
+    def __init__(self, max_output_size: int = DEFAULT_MAX_DECOMPRESSED_SIZE):
+        self.max_output_size = max_output_size
 
     def can_decode(self, data: bytes) -> bool:
         """Check if data looks like a PDF file."""
@@ -377,27 +377,37 @@ class PDFDecoder(Decoder):
         """Extract and decompress PDF streams and objects."""
         try:
             extracted_content = []
+            total = 0  # Cap total extracted bytes (FlateDecode streams can be bombs).
 
             # Find all stream objects with their preceding dictionaries
             # Pattern matches: <<...>> stream ... endstream
             stream_pattern = b"<<([^>]*)>>\\s*stream\\r?\\n(.*?)\\r?\\nendstream"
-            import re
 
             matches = re.findall(stream_pattern, data, re.DOTALL)
 
             for dict_part, stream_data in matches:
+                if total >= self.max_output_size:
+                    break
                 # Check if this stream uses FlateDecode compression
                 if b"/FlateDecode" in dict_part:
                     try:
-                        import zlib
-
-                        decompressed = zlib.decompress(stream_data)
+                        # Bound the inflate output so a crafted stream cannot
+                        # expand without limit (decompression bomb).
+                        decompressed = _bounded_decompress(
+                            zlib.decompressobj,
+                            stream_data,
+                            self.max_output_size - total,
+                        )
                         extracted_content.append(decompressed)
+                        total += len(decompressed)
                     except Exception:
-                        # If decompression fails, keep original
+                        # Decompression failed or exceeded the cap: keep the raw
+                        # (compressed, hence small) stream instead.
                         extracted_content.append(stream_data)
+                        total += len(stream_data)
                 else:
                     extracted_content.append(stream_data)
+                    total += len(stream_data)
 
             # Also extract JavaScript if present
             js_pattern = b"/JavaScript\\s*(.*?)\\s*endobj"


### PR DESCRIPTION
## Problem (found by adversarial stress test)

While fuzzing the engine with malformed/adversarial inputs, a **PDF FlateDecode bomb** hung it (>25 s) and exhausted memory. `PDFDecoder.decode` inflated streams with:

```python
decompressed = zlib.decompress(stream_data)   # no size limit
```

A crafted PDF whose Flate stream expands to hundreds of MB is fully inflated, then the engine hashes/analyzes/recurses over that giant node. This is the **same decompression-bomb class fixed in #43** for the standalone Gzip/Bz2/LZMA/Zlib decoders — but the PDF path was never covered.

## Fix

Inflate each FlateDecode stream with the shared `_bounded_decompress` helper against a **per-extraction budget** (default 100 MB, overridden by the engine from config `max_data_size` = 50 MB). Streams exceeding the budget fall back to keeping the raw (small, still-compressed) bytes, and the total extracted size is capped across streams. `PDFDecoder(max_output_size=…)` is wired from the engine like the other decompressors.

## Verification
- **300 MB PDF Flate bomb**: was a **>25 s hang** → now **~1 s, ~100 MB peak** (bounded).
- Legitimate FlateDecode streams still decode and yield IOCs.
- The full adversarial corpus (truncated/corrupt streams, archive bombs, path traversal, malformed PE/ELF, deep nesting, ReDoS-style inputs) otherwise passed with **0 crashes / hangs / memory blowups** — this was the one gap.
- New regression tests; `pytest -q` → **108 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_