### PR TITLE
Harden evidence parsing: fix O(n²) merge and CSV field-limit crash

### DIFF
--- a/tests/test_evidence_hardening.py
+++ b/tests/test_evidence_hardening.py
@@ -1,0 +1,73 @@
+import time
+
+from titan_decoder.core.evidence_models import (
+    EvidenceRef,
+    Indicator,
+    merge_indicators,
+)
+from titan_decoder.core.evidence_parsers import parse_evidence_file
+
+
+def _ind(value, line, conf="low", tags=("t",)):
+    return Indicator(
+        indicator_type="domains",
+        value=value,
+        first_seen=f"2025-01-01T00:00:{line % 60:02d}Z",
+        last_seen=None,
+        confidence=conf,
+        tags=list(tags),
+        sources=[EvidenceRef("p", "e", f"line:{line}", "domain")],
+    )
+
+
+def test_merge_indicators_dedupes_and_unions():
+    inds = [
+        _ind("a.com", 1, conf="low", tags=("t1",)),
+        _ind("a.com", 1, conf="high", tags=("t2",)),  # duplicate source
+        _ind("a.com", 2, conf="low", tags=("t1",)),    # new source
+    ]
+    merged = merge_indicators(inds)
+    assert len(merged) == 1
+    m = merged[0]
+    assert len(m.sources) == 2            # duplicate source not re-added
+    assert m.confidence == "high"
+    assert m.tags == ["t1", "t2"]
+
+
+def test_merge_indicators_is_linear_for_repeated_value():
+    # The same value across many records (a recurring C2 domain) must not be
+    # O(n^2). O(n^2) here would take tens of seconds; O(n) is well under a second.
+    inds = [_ind("evil.com", i) for i in range(40000)]
+    start = time.monotonic()
+    merged = merge_indicators(inds)
+    elapsed = time.monotonic() - start
+    assert len(merged) == 1
+    assert len(merged[0].sources) == 40000
+    assert elapsed < 5.0, f"merge_indicators too slow ({elapsed:.1f}s) - O(n^2) regression"
+
+
+def test_csv_oversized_field_does_not_abort_file(tmp_path):
+    # A field larger than the old 128 KB csv limit used to raise and discard the
+    # entire file. The bad row should be tolerated and other rows still parsed.
+    csv_path = tmp_path / "dns.csv"
+    csv_path.write_text(
+        "timestamp,client_ip,query,answers\n"
+        "2025-01-01T00:00:01Z,10.0.0.1," + ("a" * 200000) + ",1.2.3.4\n"
+        "2025-01-01T00:00:02Z,10.0.0.2,evil.com,9.9.9.9\n"
+    )
+    res = parse_evidence_file(csv_path, "dns")
+    vals = {(i.indicator_type, i.value) for i in res.indicators}
+    assert ("domains", "evil.com") in vals
+    assert ("ipv4", "9.9.9.9") in vals
+
+
+def test_csv_nul_byte_row_is_tolerated(tmp_path):
+    csv_path = tmp_path / "dns.csv"
+    csv_path.write_bytes(
+        b"timestamp,client_ip,query,answers\n"
+        b"2025-01-01T00:00:01Z,10.0.0.1,evil\x00.com,1.2.3.4\n"
+        b"2025-01-01T00:00:02Z,10.0.0.2,good.com,8.8.8.8\n"
+    )
+    res = parse_evidence_file(csv_path, "dns")
+    vals = {(i.indicator_type, i.value) for i in res.indicators}
+    assert ("domains", "good.com") in vals

--- a/titan_decoder/core/evidence_models.py
+++ b/titan_decoder/core/evidence_models.py
@@ -230,6 +230,14 @@ def merge_indicators(indicators: List[Indicator]) -> List[Indicator]:
             return a
         return a if a >= b else b
 
+    # Maintain each merged indicator's set of source keys incrementally. The
+    # previous code rebuilt this set from cur.sources on every merge, which is
+    # O(n^2) when one value (e.g. a C2 domain) recurs across many log lines.
+    seen_sources: Dict[tuple[str, str], set] = {}
+
+    def _source_key(s) -> tuple:
+        return (s.evidence_path, s.extracted_by, s.record_id, s.field)
+
     for ind in indicators:
         k = ind.key()
         if k not in merged:
@@ -242,17 +250,19 @@ def merge_indicators(indicators: List[Indicator]) -> List[Indicator]:
                 tags=list(ind.tags),
                 sources=list(ind.sources),
             )
+            seen_sources[k] = {_source_key(s) for s in merged[k].sources}
             continue
 
         cur = merged[k]
         cur.first_seen = min_ts(cur.first_seen, ind.first_seen)
         cur.last_seen = max_ts(cur.last_seen, ind.last_seen)
-        cur.tags = sorted(set(cur.tags) | set(ind.tags))
+        if not set(ind.tags) <= set(cur.tags):
+            cur.tags = sorted(set(cur.tags) | set(ind.tags))
 
-        # Merge sources (best-effort de-dupe)
-        seen = {(s.evidence_path, s.extracted_by, s.record_id, s.field) for s in cur.sources}
+        # Merge sources (best-effort de-dupe) using the persistent seen set.
+        seen = seen_sources[k]
         for s in ind.sources:
-            key = (s.evidence_path, s.extracted_by, s.record_id, s.field)
+            key = _source_key(s)
             if key in seen:
                 continue
             cur.sources.append(s)

--- a/titan_decoder/core/evidence_parsers.py
+++ b/titan_decoder/core/evidence_parsers.py
@@ -52,11 +52,33 @@ def _read_jsonl(path: Path) -> Iterator[Dict[str, Any]]:
                 yield obj
 
 
+# Some log exports have long fields (URLs, user-agents); raise the 128 KB
+# default but keep it bounded so a single unterminated quote can't be read as a
+# multi-GB field.
+_CSV_FIELD_LIMIT = 16 * 1024 * 1024
+try:
+    csv.field_size_limit(_CSV_FIELD_LIMIT)
+except (OverflowError, ValueError):  # pragma: no cover - platform dependent
+    pass
+
+
 def _read_csv(path: Path) -> Iterator[Dict[str, Any]]:
     with path.open("r", encoding="utf-8", errors="ignore", newline="") as handle:
         reader = csv.DictReader(handle)
-        for row_no, row in enumerate(reader, start=2):
-            # row_no=2 because header is line 1
+        # Header is line 1, so data rows start at line 2.
+        row_no = 1
+        while True:
+            try:
+                row = next(reader)
+            except StopIteration:
+                break
+            except csv.Error:
+                # Malformed row (oversized field, bad quoting, embedded NUL):
+                # skip it instead of aborting the whole file (as JSONL does).
+                continue
+            row_no += 1
+            if not isinstance(row, dict):
+                continue
             row = dict(row)
             row.setdefault("_line", row_no)
             yield row


### PR DESCRIPTION
## Problems (found while fuzzing the `--evidence` ingestion path)

### 1. `merge_indicators` was O(n²) → effective hang
For each duplicate of a value, it rebuilt the `seen` source-key set from the merged indicator's **growing** source list. When one value recurs across many log lines (e.g. the same C2 domain in thousands of proxy/DNS rows — extremely common), this is quadratic:

| dup rows | time |
|----------|------|
| 1,000 | 0.06 s |
| 4,000 | 1.43 s |
| 8,000 | 7.08 s |
| 200,000 | never finished |

### 2. One malformed CSV field aborted the whole file
`_read_csv` used `csv.DictReader` with the default 128 KB field limit. A field larger than that raised an **uncaught `_csv.Error`** mid-iteration (also triggered by an unterminated quote or an embedded NUL), discarding **all** records from the file — unlike the JSONL reader, which skips bad lines.

## Fixes

1. **Merge** — maintain each indicator's `seen` source-key set **incrementally** → O(n), output unchanged (verified identical dedup/union). 400k repeated-value indicators now merge in ~1.4 s (was effectively unbounded). Also skip the tag re-sort when no new tags are present.
2. **CSV** — raise the field limit to a bounded 16 MB and **skip rows that still error** (oversized field / bad quoting / NUL), so the rest of the file still parses.

## Verification
- `merge_indicators`: 10k→0.03 s, 100k→0.31 s, 400k→1.36 s (linear); dedup/union/confidence output identical.
- CSV: a 200 KB field row no longer aborts the file; NUL-byte and unclosed-quote rows are tolerated and surrounding rows parse.
- New `tests/test_evidence_hardening.py`; `pytest -q` → **112 passed**; `ruff check .` → clean.

## Noted (not in this PR)
`_mk_ref` recomputes a `json.dumps` preview of the record for every indicator (3× per DNS row), which dominates large-file parse time (~14 s for 200k rows). It's linear, not a bug — a candidate follow-up optimization (compute the preview once per record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_