### PR TITLE
Document ReDoS risk in rule-pack content_regex

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -222,6 +222,7 @@ Notes:
 
 - YAML packs are also supported (`.yml`/`.yaml`) when PyYAML is installed (see `requirements-optional.txt`).
 - Pack provenance is recorded in `report.meta.rule_packs` and each detection includes a `source` field.
+- **Security:** only load rule packs you trust. A `content_regex` pattern is run with Python's `re` (no timeout) against content from the untrusted payload, so a catastrophic-backtracking pattern (e.g. `(a+)+$`) can hang the run on a crafted input. Author patterns that avoid nested/ambiguous quantifiers.
 
 ## First 10 minutes (beginner checklist)
 

--- a/titan_decoder/core/rule_packs.py
+++ b/titan_decoder/core/rule_packs.py
@@ -20,6 +20,18 @@ rules:
 Supported rule types:
 - content_regex: regex over concatenated node content_preview
 - ioc_present: requires one or more IOC types to meet minimum counts
+
+Security note
+-------------
+A ``content_regex`` pattern is supplied by whoever authors the rule pack and is
+run with Python's ``re`` against content derived from the analyzed (untrusted)
+payload. ``re`` has no execution timeout and a tight C match loop cannot be
+interrupted by signals, so a pattern prone to catastrophic backtracking (e.g.
+``(a+)+$``, ``(.*a){20}``) can hang the run when the payload contains a
+triggering string. Only load rule packs from sources you trust, and author
+patterns that avoid nested/ambiguous quantifiers (prefer possessive-style,
+anchored, or character-class patterns). The engine bounds the scanned text via
+``max_node_count``/preview limits, but that does not prevent backtracking.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Fuzzing the rule-pack surface found a **ReDoS** in `content_regex` rules: all four classic catastrophic-backtracking patterns (`(a+)+$`, `(a|a)*$`, `(.*a){25}$`, `(a*)*b`) hang >8 s against payload-derived content, with no timeout.

This is **not robustly fixable in code**: a `content_regex` pattern is authored by whoever wrote the rule pack and run with Python's `re` against content from the untrusted payload. `re` has no execution timeout, and its tight C match loop cannot be interrupted by `signal.alarm` — interrupting a hung `re` would require the third-party `regex` module or process isolation. The engine already bounds the scanned text via `max_node_count`/preview limits, but that doesn't prevent backtracking.

So the proportionate, honest action is to document the trust boundary:
- Added a **Security note** to the `rule_packs` module docstring.
- Added a security bullet to the rule-packs section of `docs/USAGE.md`.

Guidance: only load rule packs you trust, and author patterns that avoid nested/ambiguous quantifiers.

## Context — surfaces fuzzed in this pass (no further code bugs)
- **Config / rule-pack loading**: graceful (Config falls back to defaults on malformed JSON; bad packs raise and are caught by `CorrelationRulesEngine`).
- **Vault / enrichment_cache (SQLite)**: robust for realistic inputs; the only failures were internal-contract violations (a `list` where an `int` is expected; a non-JSON-serializable payload) that real callers never produce, and the corrupt-DB path is already wrapped by the enrichment layer.

`pytest -q` → **124 passed**; `ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_