### PR TITLE
Document hardening/correctness work in README, SECURITY, and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## Unreleased — Hardening & correctness
+
+Security / DoS resistance (untrusted-input hardening):
+
+- Bound decompressor output for Gzip/Bz2/LZMA/Zlib to defeat decompression
+  bombs (incremental, multi-stream-aware, capped by `max_data_size`).
+- Bound PDF FlateDecode output the same way, so a malicious object stream
+  can't exhaust memory.
+- Bound OLE decoder output and fix an O(n^2) VBA-string scan that could hang
+  on crafted documents (per-signature match cap + output budget).
+- Fix O(n^2) blow-ups in the URL and HTML-entity decoders (single-pass
+  rewrites) that let small inputs burn large amounts of CPU.
+- Harden evidence ingestion: O(n) indicator merge (was O(n^2)), a bounded CSV
+  field-size limit, and per-row skipping so a malformed row/field can't abort
+  the whole run.
+- Degrade gracefully on corrupt browser-history SQLite files instead of
+  crashing the evidence run.
+- Make `psutil` truly optional: `--perf-profile` now runs (timing + cProfile)
+  and reports memory/CPU as `0.0` when psutil isn't installed, instead of
+  crashing with `ModuleNotFoundError`.
+- Document the rule-pack `content_regex` ReDoS trust boundary: patterns run
+  with Python's `re` (no timeout); only load packs you trust.
+
+Correctness:
+
+- Fix ELF metadata parsing for 64-bit and big-endian binaries.
+- Fix PE metadata parsing (broken optional-header struct format) and bound the
+  image-base read.
+- Detect GNU-format tar archives (`ustar` magic at offset 257).
+- Reject invalid IPv4 addresses and correct public/private classification via
+  `ipaddress`.
+- Stop hex blobs being mis-reported as hash IOCs (exact-length matching).
+- Stop ROT13 from mangling plaintext and polluting IOCs (English-likeness gate).
+- Reduce IOC/forensics false positives from filenames and encoded layers.
+- Reimplement the UU decoder without the deprecated stdlib `uu` module, and fix
+  the UU/QuotedPrintable decoder return contract on the failure path.
+- Fix IOC export: STIX value quote-escaping and MISP duplicate-IP dedup;
+  timezone-aware timestamps.
+
+Maintenance:
+
+- Remove dead path-pruning code and unused `titan_decoder.core` modules.
+- Add regression tests across decoders, analyzers, evidence/endpoint parsers,
+  IOC export, decompression-bomb defenses, and the profiler (124+ tests).
+
 ## 2.0.0
 
 - Evidence ingestion layer (canonical events/indicators) with pivots/last-seen.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - Don’t upload real incident data (logs, browser history DBs, reports) to public issues.
 - This tool can process untrusted inputs; run in a sandboxed environment when possible.
 - Outputs may contain sensitive artifacts extracted from samples (IOCs, emails, hostnames). Handle accordingly.
+- Built-in hardening (decompression-bomb caps, DoS-resistant decoders, resource limits) and known trust boundaries are documented in [SECURITY.md](SECURITY.md).
 - No warranty: see [LICENSE](LICENSE).
 
 ## 🚀 Quick Start (5 Minutes)
@@ -104,9 +105,14 @@ python -c 'import json; r=json.load(open("report.json")); print((r.get("risk_ass
 ### Production Features
 - **Batch Processing**: Analyze entire directories
 - **PII Redaction**: Safe log sharing
-- **Resource Limits**: Memory caps, timeouts
+- **Resource Limits**: Memory caps, timeouts, recursion/node/size bounds
+- **DoS Resistance**: Bounded decompression (anti-bomb) and O(n)-by-design
+  decoders that don't blow up on crafted input (see [SECURITY.md](SECURITY.md))
 - **Signal Handling**: Clean shutdown (Ctrl+C)
-- **Error Recovery**: Graceful handling of corrupted files
+- **Error Recovery**: Malformed archives, corrupt SQLite, and bad CSV/JSONL rows
+  are skipped rather than crashing the run
+- **No Required Dependencies**: Core runs on the stdlib; optional extras
+  (`psutil`, enrichment) degrade gracefully when absent
 
 ## 📖 Usage Examples
 
@@ -201,23 +207,6 @@ Create `~/.titan_decoder/config.json`:
     },
   
     "analyzers": {
-    ---
-
-    ## 💬 Feedback & Contributing
-
-    - Bugs / questions: open a GitHub Issue (please avoid sensitive incident data)
-    - Feature ideas: open a Feature Request Issue
-    - Security issues: use GitHub Security Advisories (private report)
-
-    See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup and PR guidelines.
-
-## 🆘 Support
-
-- Issues (bugs/questions): https://github.com/pragmaconflux/titan1/issues
-- Discussions (Q&A/ideas, enable in repo settings): https://github.com/pragmaconflux/titan1/discussions
-- Security reports (private): https://github.com/pragmaconflux/titan1/security/advisories/new
-
-### Quick Config
         "zip": true,
         "tar": true,
         "pe": true,
@@ -322,7 +311,10 @@ titan_decoder/
 
 ## 🤝 Contributing
 
-Contributions welcome! Please open a PR or issue to discuss changes.
+Contributions welcome! Please open a PR or issue to discuss changes (avoid
+sensitive incident data in public issues). See [CONTRIBUTING.md](CONTRIBUTING.md)
+for dev setup and PR guidelines, and [SECURITY.md](SECURITY.md) to report
+security issues privately.
 
 **Add a custom decoder:**
 ```python

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,42 @@
 
 This project is best-effort and maintained on a rolling basis. If you find a security issue, please report it; fixes are typically released in the next patch/minor release.
 
+## Security model & hardening
+
+Titan Decoder is designed to process **untrusted, potentially malicious input**
+(samples, archives, logs). It runs entirely offline by default and parses
+everything with best-effort, dependency-free code. The engine includes
+defenses against common analysis-time abuse:
+
+- **Decompression bombs**: Gzip/Bz2/LZMA/Zlib and PDF FlateDecode output is
+  produced incrementally and capped at `max_data_size`, so a small input can't
+  inflate into multi-GB memory use.
+- **Algorithmic DoS**: the URL, HTML-entity, and OLE decoders were rewritten to
+  avoid O(n^2) behavior; the OLE scan also caps matches per signature.
+- **Resource limits**: recursion depth, node count, input size, per-operation
+  timeouts, and optional memory caps bound every run.
+- **Malformed-input tolerance**: corrupt SQLite browser histories, malformed
+  CSV/JSONL rows, and non-object records are skipped rather than aborting the
+  run; binary parsers (PE/ELF/TAR) fail closed on truncated/odd headers.
+- **Offline-first**: `--offline` additionally enables a best-effort
+  process-local network kill switch.
+
+### Known trust boundary: rule-pack `content_regex`
+
+Detection rule packs (`--rules-pack`) may contain `content_regex` patterns that
+run with Python's `re` against content derived from the untrusted payload.
+`re` has **no execution timeout** and its C match loop cannot be interrupted by
+signals, so a catastrophic-backtracking pattern (e.g. `(a+)+$`) can hang a run
+when the payload contains a triggering string. **Only load rule packs from
+sources you trust**, and author patterns that avoid nested/ambiguous
+quantifiers. This is a property of the stdlib regex engine, not a bug in Titan.
+
+### Residual risk
+
+These are mitigations, not guarantees. Always analyze unknown samples in a
+disposable VM or otherwise isolated environment, as a non-root user, with
+resource limits configured. See the Safety Recommendations in the README.
+
 ## Reporting a Vulnerability
 
 Please **do not** open a public GitHub issue for security-sensitive reports.


### PR DESCRIPTION
## What

Brings the project docs in line with the post-2.0.0 hardening and bug-fix campaign (PRs #39–#60). Docs only — no code changes.

## Changes

**CHANGELOG.md** — adds an `Unreleased — Hardening & correctness` section enumerating the merged work, grouped into:
- *Security / DoS resistance*: bounded decompression (Gzip/Bz2/LZMA/Zlib + PDF FlateDecode) anti-bomb caps, O(n²) fixes in the URL/HTML-entity/OLE decoders, evidence-parsing hardening, graceful handling of corrupt SQLite, optional `psutil`, and the rule-pack ReDoS trust boundary.
- *Correctness*: ELF/PE/TAR parsing fixes, IPv4 validation, hash-IOC exact-length matching, ROT13 false-IOC gate, UU/QP fixes, IOC export escaping/dedup.
- *Maintenance*: dead-code removal and the regression-test suite (124+ tests).

**SECURITY.md** — adds a `Security model & hardening` section documenting the built-in protections (decompression bombs, algorithmic DoS, resource limits, malformed-input tolerance, offline-first), the known `content_regex` ReDoS trust boundary, and residual-risk guidance.

**README.md**
- Strengthens *Production Features* (DoS resistance, graceful degradation of optional deps, malformed-input tolerance).
- Links `SECURITY.md` from the Safety and Contributing sections.
- Fixes a pre-existing broken *Full Configuration* block whose JSON example was split in half by a stray, duplicated "Feedback & Contributing / Support" section. The JSON now parses as a single valid block; the duplicated Support/Contributing content already exists later in the README.

## Verification

- Extracted and `json.loads()`-validated the README config block (valid, single block).
- Confirmed exactly one Support and one Contributing section remain, stray duplicate removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_