### PR TITLE
Release 2.0.1: bump version and finalize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — Hardening & correctness
+## 2.0.1 — Hardening & correctness (2026-06-30)
 
 Security / DoS resistance (untrusted-input hardening):
 

--- a/titan_decoder/__init__.py
+++ b/titan_decoder/__init__.py
@@ -1,6 +1,6 @@
 # Titan Decoder Engine
 # A comprehensive payload decoding and analysis framework
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __author__ = "PragmaConflux"
 __description__ = "Advanced payload decoding and analysis engine for cybersecurity"


### PR DESCRIPTION
## What

Cuts the **2.0.1** patch release that collects the post-2.0.0 hardening and correctness work (PRs #39–#61).

- `titan_decoder/__init__.py`: `__version__` 2.0.0 → 2.0.1
- `CHANGELOG.md`: rename the `Unreleased — Hardening & correctness` section to `2.0.1 — Hardening & correctness (2026-06-30)`

SemVer patch: bug fixes + security hardening only, no breaking changes and no new user-facing features. The CLI reads `__version__` dynamically, so `--version` and the report `meta` now report `2.0.1`.

## Verification

- `titan-decoder --version` → `titan-decoder 2.0.1`
- `python -c "import titan_decoder; print(titan_decoder.__version__)"` → `2.0.1`
- Full suite: **127 passed**

After merge, an annotated `v2.0.1` tag will be pushed to the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_