### PR TITLE
Fix Base64Decoder: it never decoded, and corrupted wrapped payloads

### DIFF
--- a/tests/test_base64_decoder.py
+++ b/tests/test_base64_decoder.py
@@ -1,0 +1,52 @@
+"""Regression tests for Base64Decoder.
+
+Two bugs previously lived in Base64Decoder.decode:
+
+1. ``data.splitlines()`` yields ``bytes``, but the code called ``line.encode()``
+   (a ``str`` method), raising AttributeError on every input. The decoder caught
+   it and returned ``(data, False)``, so it never actually decoded anything — it
+   only appeared to work in the engine because RecursiveBase64Decoder (registered
+   first) handled base64 instead.
+2. It decoded each line separately and joined with ``b"\\n"``, injecting spurious
+   newlines that corrupted line-wrapped (PEM/MIME/``-enc``) binary payloads.
+"""
+
+import base64
+
+from titan_decoder.decoders.base import Base64Decoder
+
+
+def test_single_line_roundtrip():
+    dec = Base64Decoder()
+    for original in (b"hello world, triage payload 123", bytes(range(256)), b"a" * 500):
+        out, ok = dec.decode(base64.b64encode(original))
+        assert ok is True
+        assert out == original
+
+
+def test_line_wrapped_binary_reconstructs_exactly():
+    """PEM/MIME-style wrapping must not inject bytes into the decoded payload."""
+    dec = Base64Decoder()
+    payload = bytes(range(256)) * 3
+    enc = base64.b64encode(payload)
+    for width, sep in ((64, b"\n"), (76, b"\r\n")):
+        wrapped = sep.join(enc[i : i + width] for i in range(0, len(enc), width))
+        out, ok = dec.decode(wrapped)
+        assert ok is True
+        assert out == payload, f"width={width} sep={sep!r} corrupted payload"
+
+
+def test_non_base64_returns_failure_not_hallucination():
+    dec = Base64Decoder()
+    for bad in (b"\x00\x01\x02 not base64 !!!", b"short", b"%" * 32, b"", b"\xff\xfe\xfd"):
+        out, ok = dec.decode(bad)
+        assert ok is False
+        assert out == bad
+
+
+def test_can_decode_consistent_with_decode():
+    dec = Base64Decoder()
+    enc = base64.b64encode(b"the quick brown fox jumps over the lazy dog")
+    assert dec.can_decode(enc) is True
+    out, ok = dec.decode(enc)
+    assert ok is True and out == b"the quick brown fox jumps over the lazy dog"

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -73,18 +73,17 @@ class Base64Decoder(Decoder):
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            # Handle multiline
-            lines = data.splitlines()
-            decoded_parts = []
-            for line in lines:
-                line = line.strip()
-                if not line:
-                    continue
-                if looks_like_base64(line.encode()):
-                    decoded_parts.append(base64.b64decode(line))
-                else:
-                    decoded_parts.append(line.encode())
-            return b"\n".join(decoded_parts), True
+            # Treat the input as a single base64 stream. ``b64decode`` ignores
+            # embedded whitespace/newlines, so line-wrapped payloads (PEM/MIME/
+            # PowerShell ``-enc``) are reconstructed byte-for-byte. Two earlier
+            # bugs lived here: ``line.encode()`` on the ``bytes`` lines raised
+            # AttributeError and made the decoder always fail, and joining the
+            # per-line decodes with ``b"\n"`` injected spurious newlines that
+            # corrupted wrapped binary payloads.
+            stripped = b"".join(data.split())
+            if not looks_like_base64(stripped):
+                return data, False
+            return base64.b64decode(stripped), True
         except Exception:
             return data, False
 


### PR DESCRIPTION
## What

Decoder-fuzzing the full engine surfaced two defects in `Base64Decoder.decode`:

1. **It never decoded anything.** `data.splitlines()` yields `bytes`, but the code called `line.encode()` (a `str` method) → `AttributeError` on every input → caught → returned `(data, False)`. The standalone Base64 decoder always failed; it only *looked* fine because `RecursiveBase64Decoder` (registered first) handles base64 in the engine.
2. **It corrupted line-wrapped payloads.** It decoded each line separately and joined the decoded bytes with `b"\n"`, injecting spurious newlines every ~48 bytes — corrupting PEM/MIME/`-enc`-style wrapped binary payloads.

## Fix

Decode the input as a single base64 stream. `base64.b64decode` ignores embedded whitespace, so line-wrapped payloads reconstruct byte-for-byte, and non-base64 input returns `(data, False)` instead of a hallucinated success.

## Tests

`tests/test_base64_decoder.py` covers single-line round-trip, LF/CRLF line-wrapped **binary** reconstruction, `can_decode`/`decode` consistency, and rejection of non-base64/short/empty input.

## Verification

Part of a full decoder fuzz sweep of all 19 engine decoders:
- **Crash/hang:** 0 crashes, 0 hangs, 0 contract violations across the corpus.
- **Round-trip:** all invertible decoders (Base64, Hex, Base32, Gzip, Bz2, LZMA, ZLIB, URL, QuotedPrintable, UU, HTMLEntity, UnicodeEscape) reconstruct exactly.
- **Hallucination rate:** engine-gated false-positive `success=True` on 2000 random blobs is 0 for nearly all decoders; the small residue (URL/HTML/QP) is faithful decoding of input that genuinely contains those sequences. ROT13 output is a faithful rotation and real text is correctly gated out.
- **Engine-level:** 234 adversarial blobs analyzed, 0 crashes.
- Full suite: **131 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_