### PR TITLE
Fix O(n^2) archive pre-scan that let many-entry zip/tar hang analysis

### DIFF
--- a/tests/test_analyzer_prescan.py
+++ b/tests/test_analyzer_prescan.py
@@ -1,0 +1,71 @@
+"""Regression tests for archive pre-scan complexity and size caps.
+
+ZipAnalyzer._pre_scan_zip / TarAnalyzer._pre_scan_tar previously recomputed the
+running total size with ``sum(... for f in safe_files)`` on every iteration,
+making the scan O(n^2). A small crafted archive with many tiny entries (which
+never trip the total-size cap, so the safe list keeps growing) turned pre-scan
+into a multi-minute CPU hang — an algorithmic-complexity DoS reachable from
+untrusted input. The fix tracks the total incrementally (O(n)).
+"""
+
+import io
+import os
+import hashlib
+import time
+import zipfile
+import tarfile
+
+from titan_decoder.core.analyzers.base import ZipAnalyzer, TarAnalyzer
+
+
+def _zip_of_empty(n: int) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as z:
+        for i in range(n):
+            z.writestr(f"f{i}", b"")
+    return buf.getvalue()
+
+
+def _tar_of_empty(n: int) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as t:
+        for i in range(n):
+            ti = tarfile.TarInfo(f"f{i}")
+            ti.size = 0
+            t.addfile(ti)
+    return buf.getvalue()
+
+
+def test_zip_prescan_many_tiny_entries_is_not_quadratic():
+    # At O(n^2) this took ~30s+; O(n) finishes in well under the bound.
+    data = _zip_of_empty(20000)
+    t0 = time.time()
+    out = ZipAnalyzer().analyze(data)
+    assert time.time() - t0 < 15.0
+    assert len(out) <= 25  # max_zip_files cap still applies
+
+
+def test_tar_prescan_many_tiny_entries_is_not_quadratic():
+    data = _tar_of_empty(20000)
+    t0 = time.time()
+    out = TarAnalyzer().analyze(data)
+    assert time.time() - t0 < 15.0
+    assert len(out) <= 25
+
+
+def test_zip_total_size_cap_still_honored():
+    files = [(f"file_{i}.bin", os.urandom(8000)) for i in range(40)]
+    expected = {nm: hashlib.sha256(c).hexdigest() for nm, c in files}
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for nm, c in files:
+            z.writestr(nm, c)
+    # ~100KB total cap -> only ~12 of the 8KB files fit.
+    out = ZipAnalyzer({"max_zip_total_size": 100 * 1024, "max_zip_files": 100}).analyze(
+        buf.getvalue()
+    )
+    total = sum(len(c) for _, c in out)
+    assert total <= 100 * 1024 + 8000  # cap, plus at most one boundary-crossing file
+    # whatever was extracted must be byte-correct (no corruption)
+    for nm, c in out:
+        assert expected[nm] == hashlib.sha256(c).hexdigest()

--- a/titan_decoder/core/analyzers/base.py
+++ b/titan_decoder/core/analyzers/base.py
@@ -145,6 +145,11 @@ class ZipAnalyzer(Analyzer):
     def _pre_scan_zip(self, zip_file: zipfile.ZipFile, zip_size: int) -> List[str]:
         """Pre-scan ZIP contents for safety issues. Returns list of safe filenames."""
         safe_files = []
+        # Track the running total incrementally. Recomputing
+        # ``sum(getinfo(f).file_size ...)`` on every iteration made this O(n^2):
+        # a small crafted archive with many tiny entries (which never trip the
+        # total-size cap) turned pre-scan into a multi-minute CPU hang.
+        current_safe_size = 0
 
         for info in zip_file.infolist():
             # Skip directories
@@ -167,12 +172,11 @@ class ZipAnalyzer(Analyzer):
                 continue
 
             # Check for files that would make total size too large
-            # (rough estimate based on current safe files)
-            current_safe_size = sum(zip_file.getinfo(f).file_size for f in safe_files)
             if current_safe_size + info.file_size > self.max_total_size:
                 continue
 
             safe_files.append(info.filename)
+            current_safe_size += info.file_size
 
         return safe_files
 
@@ -316,6 +320,9 @@ class TarAnalyzer(Analyzer):
     ) -> List[tarfile.TarInfo]:
         """Pre-scan TAR contents for safety issues. Returns list of safe TarInfo objects."""
         safe_members = []
+        # Incremental running total; recomputing ``sum(m.size ...)`` per member
+        # was O(n^2) and let a many-entry archive hang pre-scan.
+        current_safe_size = 0
 
         for member in tar_file.getmembers():
             # Skip non-files
@@ -336,11 +343,11 @@ class TarAnalyzer(Analyzer):
                     continue
 
             # Check for files that would make total size too large
-            current_safe_size = sum(m.size for m in safe_members)
             if current_safe_size + member.size > self.max_total_size:
                 continue
 
             safe_members.append(member)
+            current_safe_size += member.size
 
         return safe_members
 


### PR DESCRIPTION
## What

Fuzzing the analyzers found an algorithmic-complexity DoS in the ZIP and TAR pre-scans.

`ZipAnalyzer._pre_scan_zip` and `TarAnalyzer._pre_scan_tar` recomputed the running total uncompressed size with `sum(... for f in safe_files)` **on every iteration**. Because the safe list only stops growing once the total-size cap is hit, an archive full of tiny or zero-byte entries — which never trip that cap — turns the scan into **O(n²)**.

Measured (before): 685 KB zip of 8000 empty files → 4.3s; each 2× in entry count ~4× the time. A 50 MB archive (within `max_data_size`) holds ~660k tiny entries → pre-scan hangs for minutes on untrusted input.

## Fix

Track the total incrementally (O(n)). Behavior is otherwise identical — same total-size cap, same `max_files` cap, same extracted content. The incremental total is also slightly more correct than the old `getinfo(name)` re-lookup, which collapsed duplicate names.

Measured (after): 8000-entry zip 4.3s → 0.68s; scaling is linear.

## Tests

`tests/test_analyzer_prescan.py`:
- non-quadratic timing guard for zip and tar (20000 tiny entries must finish well under a generous bound that the old O(n²) blew past),
- total-size-cap correctness check that also verifies extracted content is byte-for-byte intact.

## Also verified during this fuzz pass (no bug)

- Crash/hang fuzz of all four analyzers on random + magic-prefixed garbage: 0 crashes, 0 hangs.
- ZIP/TAR **parallel** extraction over 150 runs each with incompressible content: 0 content corruption, 0 missing, 0 crashes (CPython `zipfile` serializes reads internally — the suspected thread-safety bug does not exist).
- Zip-bomb compression-ratio filter and `max_files` cap both hold.

Full suite: **140 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_