### PR TITLE
Fix mis-keyed DECODER_COSTS so LZMA/ROT13/ZLIB are scored correctly

### DIFF
--- a/tests/test_scoring_costs.py
+++ b/tests/test_scoring_costs.py
@@ -1,0 +1,66 @@
+"""Regression test for ScoringEngine.DECODER_COSTS key alignment.
+
+The cost table is keyed by decoder/analyzer ``.name``. If a key doesn't match a
+real name, the lookup silently falls back to the default cost and that decoder
+is mis-scored. Historically "Lzma"/"Rot13" never matched the real "LZMA"/"ROT13"
+and "ZLIB" was missing, so three decoders were mis-costed.
+"""
+
+from titan_decoder.core.scoring import ScoringEngine
+from titan_decoder.core.analyzers.base import (
+    ZipAnalyzer,
+    TarAnalyzer,
+    PEAnalyzer,
+    ELFAnalyzer,
+)
+from titan_decoder.decoders.base import (
+    Base64Decoder,
+    RecursiveBase64Decoder,
+    GzipDecoder,
+    Bz2Decoder,
+    LzmaDecoder,
+    ZlibDecoder,
+    HexDecoder,
+    Rot13Decoder,
+    XorDecoder,
+    PDFDecoder,
+    OLEDecoder,
+    UUDecoder,
+    ASN1Decoder,
+    QuotedPrintableDecoder,
+    Base32Decoder,
+    URLDecoder,
+    HTMLEntityDecoder,
+    UnicodeEscapeDecoder,
+)
+
+ALL_NAMES = {
+    d().name
+    for d in (
+        Base64Decoder, RecursiveBase64Decoder, GzipDecoder, Bz2Decoder, LzmaDecoder,
+        ZlibDecoder, HexDecoder, Rot13Decoder, XorDecoder, PDFDecoder, OLEDecoder,
+    )
+} | {
+    UUDecoder().name, ASN1Decoder().name, QuotedPrintableDecoder().name,
+    Base32Decoder().name, URLDecoder().name, HTMLEntityDecoder().name,
+    UnicodeEscapeDecoder().name,
+} | {ZipAnalyzer().name, TarAnalyzer().name, PEAnalyzer().name, ELFAnalyzer().name}
+
+
+def test_no_orphan_cost_keys():
+    """Every DECODER_COSTS key must correspond to a real decoder/analyzer name."""
+    orphans = [k for k in ScoringEngine.DECODER_COSTS if k not in ALL_NAMES]
+    assert orphans == [], f"DECODER_COSTS keys with no matching .name: {orphans}"
+
+
+def test_previously_mismatched_names_are_present():
+    for name in ("LZMA", "ROT13", "ZLIB"):
+        assert name in ScoringEngine.DECODER_COSTS
+
+
+def test_rot13_cheaper_than_lzma_in_cost_component():
+    # ROT13 (cost 1) must score higher on the cost component than LZMA (cost 4);
+    # before the fix both silently resolved to the same default cost.
+    rot13_cost = ScoringEngine._decoder_cost_score("ROT13", 0)
+    lzma_cost = ScoringEngine._decoder_cost_score("LZMA", 0)
+    assert rot13_cost > lzma_cost

--- a/titan_decoder/core/scoring.py
+++ b/titan_decoder/core/scoring.py
@@ -19,15 +19,19 @@ class ScoringEngine:
     STRUCTURE_WEIGHT = 0.2
     COST_WEIGHT = 0.1
 
-    # Decoder cost rankings (lower = cheaper)
+    # Decoder cost rankings (lower = cheaper). Keys MUST match each decoder's
+    # ``.name`` exactly, otherwise the lookup silently falls back to the default
+    # cost: "Lzma"/"Rot13" never matched the real names "LZMA"/"ROT13", and
+    # "ZLIB" was missing entirely, so those three were mis-costed.
     DECODER_COSTS = {
         "Base64": 1,
         "RecursiveBase64": 2,
         "Gzip": 3,
         "Bz2": 3,
-        "Lzma": 4,
+        "LZMA": 4,
+        "ZLIB": 3,
         "Hex": 2,
-        "Rot13": 1,
+        "ROT13": 1,
         "XOR": 5,  # Expensive due to brute force
         "ZIP": 3,
         "TAR": 3,


### PR DESCRIPTION
## What

Fuzzing the scoring path found that `ScoringEngine.DECODER_COSTS` — keyed by each decoder's `.name` — used the wrong keys:

| cost-table key | real decoder `.name` | result |
|---|---|---|
| `"Lzma"` | `"LZMA"` | never matched → default cost 3 (intended 4) |
| `"Rot13"` | `"ROT13"` | never matched → default cost 3 (intended 1) |
| *(absent)* | `"ZLIB"` | missing → default cost 3 |

So the cost component of `decode_score` was wrong for these three. ROT13's `cost_score` was 0.4 instead of 0.8; with the 0.1 cost weight that shifts the final score by up to ~0.04 — enough, near `min_score_threshold = 0.1`, to flip a borderline prune decision.

## Fix

Align the keys to the actual `.name` values and add `ZLIB`. No behavior depends on the old (unreachable) keys.

## Tests

`tests/test_scoring_costs.py`:
- **no orphan keys** — every `DECODER_COSTS` key must correspond to a real decoder/analyzer `.name` (guards against future typos),
- the three formerly-mismatched names are present,
- ROT13 outscores LZMA on the cost component (would fail if both fell back to the same default).

## Also verified during this fuzz pass (no bug)

- Smart-detection regexes are bounded/ReDoS-safe; the engine enables off-by-default decoders on any detection and the detection names match what it checks (confidence is cosmetic — the 0.7-threshold helper methods are simply unused).
- `calculate_decode_score` and `should_prune_node`: 20000 random inputs each, 0 crashes, scores always within [0.0, 1.0].

Full suite: **143 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_