### PR TITLE
Enforce max_node_count on decoded/extracted content (nested-archive DoS)

### DIFF
--- a/tests/test_engine_node_cap.py
+++ b/tests/test_engine_node_cap.py
@@ -1,0 +1,80 @@
+"""Regression tests for the global node-count cap on extracted/decoded content.
+
+Recursion into decoded content and analyzer-extracted files is marked
+``is_decoded_content=True``, which makes ``should_prune_node`` return False and
+skips the pre-analysis prune check. That is intentional for *score* pruning
+(we always want to follow a successful decode), but it also bypassed the
+count-based caps, so a small crafted nested archive could fan out to millions
+of nodes (max_node_count unenforced) and exhaust memory. A hard global
+node-count guard now applies to all content.
+"""
+
+import io
+import zipfile
+
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.config import Config
+
+
+def _make_zip(entries):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for name, content in entries:
+            z.writestr(name, content)
+    return buf.getvalue()
+
+
+def _nested_archive(fan=8):
+    """Outer zip -> middle zips -> inner zips -> distinct leaf files."""
+    inner = [
+        (f"in_{a}_{b}.zip", _make_zip([(f"{a}_{b}_l{i}.txt", f"u-{a}-{b}-{i}".encode())
+                                       for i in range(fan)]))
+        for a in range(fan) for b in range(fan)
+    ]
+    middle = [(f"mid_{a}.zip", _make_zip(inner[a * fan:(a + 1) * fan])) for a in range(fan)]
+    return _make_zip(middle)
+
+
+def test_nested_archive_respects_node_cap():
+    cfg = Config()
+    cap = cfg.get("max_node_count")
+    eng = TitanEngine(cfg)
+    rep = eng.run_analysis(_nested_archive(fan=8))
+    # Without the guard this produced ~585 nodes for an 8-fan tree (and could
+    # reach millions with fan=25); it must now stay within the configured cap.
+    assert rep["node_count"] <= cap
+
+
+def test_node_cap_scales_with_config():
+    data = _nested_archive(fan=8)
+    small = TitanEngine(_cfg(max_node_count=30)).run_analysis(data)
+    big = TitanEngine(_cfg(max_node_count=200)).run_analysis(data)
+    assert small["node_count"] <= 30
+    assert big["node_count"] <= 200
+    # A larger cap should let strictly more of the tree through here.
+    assert big["node_count"] > small["node_count"]
+
+
+def test_simple_payload_still_fully_analyzed():
+    import base64
+
+    eng = TitanEngine(Config())
+    payload = base64.b64encode(base64.b64encode(b"powershell -enc http://evil.test/x"))
+    rep = eng.run_analysis(payload)
+    assert rep["node_count"] >= 2  # peeled both base64 layers
+    assert "http://evil.test/x" in rep["iocs"].get("urls", [])
+
+
+def test_dedup_still_prunes_identical_content():
+    eng = TitanEngine(Config())
+    data = _make_zip([(f"f{i}.txt", b"IDENTICAL-CONTENT-BLOB") for i in range(10)])
+    rep = eng.run_analysis(data)
+    pruned = sum(1 for n in rep["nodes"] if n.get("pruned"))
+    assert pruned >= 1  # duplicate extracted files collapse via hash dedup
+
+
+def _cfg(**overrides):
+    c = Config()
+    for k, v in overrides.items():
+        c.set(k, v)
+    return c

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -272,6 +272,10 @@ class TitanEngine:
             pass
 
         self.nodes: List[AnalysisNode] = []
+        # Running set of node content hashes for O(1) dedup (rebuilding a set
+        # from all prior nodes on every call was O(n^2)).
+        self._seen_hashes: set = set()
+        self._node_cap_reached: bool = False
 
     def analyze_blob(
         self,
@@ -302,6 +306,20 @@ class TitanEngine:
             logger.warning(f"Max recursion depth reached at depth {depth}")
             return
 
+        # Global node-count cap. This MUST apply to decoded/extracted content
+        # too: is_decoded_content bypasses every score/count pruning rule below,
+        # so without this hard stop a small crafted nested archive fans out to
+        # millions of nodes (max_node_count is otherwise unenforced once you are
+        # inside decoded content), exhausting memory well before the timeout.
+        if len(self.nodes) >= self.pruning_engine.max_nodes:
+            if not self._node_cap_reached:
+                self._node_cap_reached = True
+                logger.warning(
+                    f"Max node count ({self.pruning_engine.max_nodes}) reached; "
+                    "stopping further analysis"
+                )
+            return
+
         # For root node and decoded content, always analyze. For speculative branches, check pruning.
         if (
             not is_decoded_content
@@ -322,12 +340,12 @@ class TitanEngine:
         node.id = len(self.nodes)
         self.nodes.append(node)
 
-        # Check for duplicate content (hash deduplication)
-        existing_hashes = {n.sha256 for n in self.nodes[:-1]}  # Exclude current node
-        if node.sha256 in existing_hashes:
+        # Check for duplicate content (hash deduplication), O(1) via running set.
+        if node.sha256 in self._seen_hashes:
             logger.info("Duplicate content detected, skipping analysis")
             node.pruned = True
             return
+        self._seen_hashes.add(node.sha256)
 
         # Smart detection: Check if we should enable any off-by-default decoders
         detected_decoders = self.smart_detector.detect_format(data)
@@ -527,6 +545,8 @@ class TitanEngine:
         )
 
         self.nodes = []
+        self._seen_hashes = set()
+        self._node_cap_reached = False
         self.decision_trace = []
         self.analyze_blob(input_data, None, 0)
 


### PR DESCRIPTION
## What

Fuzzing the recursive engine traversal found that the global `max_node_count` cap is **not enforced for decoded/extracted content**.

Recursion into decoded content and analyzer-extracted files passes `is_decoded_content=True`, which makes `should_prune_node` return `False` immediately and skips the pre-analysis prune check. That's intended for *score* pruning (always follow a successful decode), but it also bypassed the **count-based** caps. Since analyzers fan out to up to `max_zip_files` (25) children per level and depth goes to `MAX_RECURSION_DEPTH` (5), a small crafted nested archive fans out unbounded:

- 27 KB nested zip → **585 nodes** (~6× the `max_node_count` of 100)
- 636 KB fan=25 tree → heads toward **~25⁵ ≈ 9.7M nodes**, exhausting memory well before the 300s timeout

The `max_memory_mb` guard doesn't save this: it uses psutil, an optional dependency, so it's **inert when psutil isn't installed**.

## Fix

Add a hard global node-count guard at the top of `analyze_blob` that applies to **all** content (decoded or not), logged once per run to avoid log amplification. Also replace the O(n²) dedup (rebuilding a hash set from all prior nodes on every call) with an O(1) running set.

Result: fan=25 nested archive now stops at **100 nodes in 0.30s**.

## Tests

`tests/test_engine_node_cap.py`:
- nested archive respects the node cap,
- the cap scales with `max_node_count` config (30 vs 200),
- a simple nested-base64 payload is still fully analyzed and its IOC extracted,
- hash dedup still collapses identical extracted files.

## Also verified during this fuzz pass (no bug)
- Meaningful decodes still recurse and IOCs are still extracted; dedup of identical content still works.
- Full suite: **147 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_