### PR TITLE
Degrade gracefully on corrupt vault / enrichment-cache SQLite files

### DIFF
--- a/tests/test_vault_cache_resilience.py
+++ b/tests/test_vault_cache_resilience.py
@@ -1,0 +1,59 @@
+"""Regression tests: vault and enrichment cache must degrade on a corrupt DB.
+
+Both open SQLite files via executescript/PRAGMA on connect. A corrupt or
+non-SQLite file (truncated write, wrong path, disk corruption) previously
+raised an unhandled sqlite3.DatabaseError — crashing the CLI with a traceback
+for the vault, and able to abort a best-effort enrichment run for the cache.
+"""
+
+import sqlite3
+
+import pytest
+
+from titan_decoder.core.vault import VaultStore, VaultError
+from titan_decoder.core.enrichment_cache import EnrichmentCache
+
+
+def _corrupt(path):
+    path.write_bytes(b"this is not a sqlite database " * 40)
+    return path
+
+
+def test_vault_raises_clean_error_on_corrupt_db(tmp_path):
+    db = _corrupt(tmp_path / "vault.db")
+    with pytest.raises(VaultError):
+        with VaultStore(db):
+            pass
+    # It must be VaultError, not a raw sqlite3.DatabaseError.
+    try:
+        with VaultStore(db):
+            pass
+    except VaultError as e:
+        assert not isinstance(e, sqlite3.DatabaseError)
+
+
+def test_vault_still_works_on_valid_db(tmp_path):
+    db = tmp_path / "vault.db"
+    with VaultStore(db) as store:
+        store.record_run("aid1", tmp_path / "r.json", node_count=2, ioc_count=1)
+        store.record_iocs("aid1", {"urls": ["http://evil.test/x"]})
+        assert len(store.search_value("http://evil.test/x")) == 1
+        assert store.list_recent(10)[0]["analysis_id"] == "aid1"
+
+
+def test_enrichment_cache_degrades_on_corrupt_db(tmp_path):
+    db = _corrupt(tmp_path / "cache.db")
+    cache = EnrichmentCache(db)
+    # get -> miss, set -> no-op (returns a timestamp), stats -> error dict; no raise
+    assert cache.get("virustotal", "ipv4_public", "1.2.3.4") is None
+    assert isinstance(cache.set("virustotal", "ipv4_public", "1.2.3.4", {"x": 1}), str)
+    stats = cache.stats()
+    assert stats["entries"] == 0 and "error" in stats
+
+
+def test_enrichment_cache_still_works_on_valid_db(tmp_path):
+    cache = EnrichmentCache(tmp_path / "cache.db")
+    cache.set("vt", "ipv4_public", "8.8.8.8", {"asn": 15169})
+    hit = cache.get("vt", "ipv4_public", "8.8.8.8")
+    assert hit is not None and hit.payload == {"asn": 15169}
+    assert cache.stats()["entries"] == 1

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -1074,7 +1074,7 @@ def _vault_paths(config: Config) -> tuple[Path, Path]:
 
 
 def _vault_store(config: Config, report: dict) -> None:
-    from titan_decoder.core.vault import VaultStore
+    from titan_decoder.core.vault import VaultStore, VaultError
 
     vault_dir, db_path = _vault_paths(config)
     vault_dir.mkdir(parents=True, exist_ok=True)
@@ -1090,46 +1090,62 @@ def _vault_store(config: Config, report: dict) -> None:
     iocs = report.get("iocs", {}) or {}
     ioc_count = sum(len(v) for v in iocs.values() if isinstance(v, list))
 
-    with VaultStore(db_path) as store:
-        store.record_run(
-            analysis_id,
-            report_path,
-            node_count=node_count,
-            risk_level=str(risk_level) if risk_level is not None else None,
-            risk_score=int(risk_score) if isinstance(risk_score, (int, float)) else None,
-            ioc_count=int(ioc_count),
-        )
-        store.record_iocs(analysis_id, iocs)
+    # The report JSON is already persisted above; if the index DB is corrupt,
+    # warn but don't crash (and don't lose the completed analysis).
+    try:
+        with VaultStore(db_path) as store:
+            store.record_run(
+                analysis_id,
+                report_path,
+                node_count=node_count,
+                risk_level=str(risk_level) if risk_level is not None else None,
+                risk_score=int(risk_score) if isinstance(risk_score, (int, float)) else None,
+                ioc_count=int(ioc_count),
+            )
+            store.record_iocs(analysis_id, iocs)
+    except VaultError as e:
+        print(f"Warning: vault indexing skipped: {e}", file=sys.stderr)
 
 
 def _vault_search(config: Config, value: str, ioc_type: str | None = None) -> list:
-    from titan_decoder.core.vault import VaultStore
+    from titan_decoder.core.vault import VaultStore, VaultError
 
     _, db_path = _vault_paths(config)
     if not db_path.exists():
         return []
-    with VaultStore(db_path) as store:
-        return store.search_value(value, ioc_type=ioc_type)
+    try:
+        with VaultStore(db_path) as store:
+            return store.search_value(value, ioc_type=ioc_type)
+    except VaultError as e:
+        print(f"Warning: {e}", file=sys.stderr)
+        return []
 
 
 def _vault_list_recent(config: Config, limit: int) -> list:
-    from titan_decoder.core.vault import VaultStore
+    from titan_decoder.core.vault import VaultStore, VaultError
 
     _, db_path = _vault_paths(config)
     if not db_path.exists():
         return []
-    with VaultStore(db_path) as store:
-        return store.list_recent(limit=limit)
+    try:
+        with VaultStore(db_path) as store:
+            return store.list_recent(limit=limit)
+    except VaultError as e:
+        print(f"Warning: {e}", file=sys.stderr)
+        return []
 
 
 def _vault_prune(config: Config, days: int) -> dict:
-    from titan_decoder.core.vault import VaultStore
+    from titan_decoder.core.vault import VaultStore, VaultError
 
     _, db_path = _vault_paths(config)
     if not db_path.exists():
         return {"ok": True, "result": {"before_runs": 0, "after_runs": 0, "deleted_runs": 0}}
-    with VaultStore(db_path) as store:
-        result = store.prune_days(days)
+    try:
+        with VaultStore(db_path) as store:
+            result = store.prune_days(days)
+    except VaultError as e:
+        return {"ok": False, "error": str(e)}
     return {"ok": True, "result": result}
 
 

--- a/titan_decoder/core/enrichment_cache.py
+++ b/titan_decoder/core/enrichment_cache.py
@@ -61,7 +61,12 @@ class EnrichmentCache:
         if not provider or not indicator_type or not indicator_value:
             return None
 
-        conn = self._connect()
+        try:
+            conn = self._connect()
+        except sqlite3.DatabaseError:
+            # Corrupt/non-SQLite cache file: treat as a cache miss rather than
+            # aborting the whole (best-effort) enrichment/analysis run.
+            return None
         try:
             cur = conn.cursor()
             cur.execute(
@@ -83,6 +88,8 @@ class EnrichmentCache:
                 cached_at=str(cached_at),
                 payload=payload,
             )
+        except sqlite3.DatabaseError:
+            return None
         finally:
             conn.close()
 
@@ -94,23 +101,34 @@ class EnrichmentCache:
             return _utc_now_iso()
 
         cached_at = _utc_now_iso()
-        conn = self._connect()
+        try:
+            conn = self._connect()
+        except sqlite3.DatabaseError:
+            # Corrupt cache file: skip persisting rather than crash the run.
+            return cached_at
         try:
             conn.execute(
                 "INSERT OR REPLACE INTO enrichment_cache(provider, indicator_type, indicator_value, cached_at, payload_json) VALUES (?, ?, ?, ?, ?)",
                 (provider, indicator_type, indicator_value, cached_at, json.dumps(payload, sort_keys=True)),
             )
             conn.commit()
+        except sqlite3.DatabaseError:
+            pass
         finally:
             conn.close()
         return cached_at
 
     def stats(self) -> Dict[str, Any]:
-        conn = self._connect()
+        try:
+            conn = self._connect()
+        except sqlite3.DatabaseError as e:
+            return {"entries": 0, "error": f"cache unavailable: {e}"}
         try:
             cur = conn.cursor()
             cur.execute("SELECT COUNT(*) FROM enrichment_cache")
             (count,) = cur.fetchone() or (0,)
             return {"entries": int(count)}
+        except sqlite3.DatabaseError as e:
+            return {"entries": 0, "error": f"cache unavailable: {e}"}
         finally:
             conn.close()

--- a/titan_decoder/core/vault.py
+++ b/titan_decoder/core/vault.py
@@ -45,6 +45,10 @@ CREATE INDEX IF NOT EXISTS idx_runs_created ON runs(created_ts);
 """
 
 
+class VaultError(RuntimeError):
+    """Raised when the vault database can't be opened (e.g. corrupt/non-SQLite file)."""
+
+
 class VaultStore:
     def __init__(self, db_path: Path):
         self.db_path = db_path
@@ -52,9 +56,22 @@ class VaultStore:
 
     def __enter__(self):
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path)
-        self.conn.executescript(SCHEMA)
-        self._migrate_schema()
+        try:
+            self.conn = sqlite3.connect(self.db_path)
+            self.conn.executescript(SCHEMA)
+            self._migrate_schema()
+        except sqlite3.DatabaseError as e:
+            # Corrupt or non-SQLite file at db_path: fail with a clear, catchable
+            # error instead of leaking a raw sqlite3.DatabaseError traceback.
+            if self.conn is not None:
+                try:
+                    self.conn.close()
+                except Exception:
+                    pass
+                self.conn = None
+            raise VaultError(
+                f"Vault database at {self.db_path} could not be opened: {e}"
+            ) from e
         return self
 
     def __exit__(self, exc_type, exc, tb):


### PR DESCRIPTION
## What

Sweeping the vault, enrichment, and report-export modules found an unhandled-crash bug in the SQLite-backed ones.

`VaultStore.__enter__` and `EnrichmentCache._connect` open the DB via `executescript`/`PRAGMA` on connect. A corrupt or non-SQLite file at `--vault-db-path` or `--enrichment-cache-path` (truncated write, wrong path, disk corruption) raised an unhandled `sqlite3.DatabaseError`:

- `titan-decoder --vault-list-recent 5` (and `--vault-search`/`--vault-prune-days`/`--vault-store`) crashed with a raw traceback (exit 1).
- A corrupt enrichment cache could abort an otherwise best-effort analysis run.

Same class as the browser-history SQLite fix (#56).

## Fix

- `VaultStore` catches `sqlite3.DatabaseError` on open and raises a clear, catchable `VaultError`. The CLI vault helpers catch it and degrade: search/list → empty result + stderr warning, prune → `{"ok": false, "error": ...}`, store → warn but keep the already-written report JSON and the completed analysis.
- `EnrichmentCache.get/set/stats` catch `DatabaseError` and degrade to miss / no-op / `{"entries": 0, "error": ...}`, so a corrupt cache never breaks analysis.

`--vault-list-recent` against a corrupt DB now prints a clean warning and returns `{"recent": []}` with exit 0.

## Tests

`tests/test_vault_cache_resilience.py`: corrupt DB degrades (raises `VaultError`, not raw `DatabaseError`, for the vault; miss/no-op for the cache) and valid DBs still store/search/get correctly.

## Also swept, no bug (report-export modules)

- `ioc_export` (JSON/CSV/STIX/MISP) fuzzed with adversarial IOC dicts — XSS strings, unicode control chars, NUL bytes, huge values, embedded quotes: **0 crashes**, STIX/MISP output stays valid JSON.
- `case_report` markdown/HTML: **0 crashes**, `<script>` and friends stay HTML-escaped (user data only goes into element content, never attributes).
- `vault` SQL is fully parameterized (no injection); `list_recent`/`prune_days` cast to int; negative `prune_days` is a safe no-op.

Full suite: **151 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_