### PR TITLE
Stop evidence _as_int crashing on Infinity/NaN (silent evidence loss)

### DIFF
--- a/tests/test_evidence_as_int.py
+++ b/tests/test_evidence_as_int.py
@@ -1,0 +1,52 @@
+"""Regression test: numeric coercion must not crash on non-finite floats.
+
+json.loads accepts Infinity/NaN by default, so an evidence JSONL field like
+``"src_port": Infinity`` produced a float('inf'); _as_int then did a bare
+int(inf) -> OverflowError (and int(nan) -> ValueError). That aborted
+parse_evidence_file, and the CLI's catch-all then silently dropped ALL evidence
+(warning only under --verbose), defeating the per-row resilience.
+"""
+
+import json
+
+import pytest
+
+from titan_decoder.core.evidence_parsers import _as_int, parse_evidence_file
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (float("inf"), None),
+        (float("-inf"), None),
+        (float("nan"), None),
+        (3.9, 3),
+        ("inf", None),
+        ("nan", None),
+        ("12.5", 12),
+        ("", None),
+        ("abc", None),
+        (None, None),
+        (42, 42),
+    ],
+)
+def test_as_int_handles_non_finite_and_junk(value, expected):
+    assert _as_int(value) == expected
+
+
+def test_firewall_jsonl_with_infinity_does_not_crash(tmp_path):
+    p = tmp_path / "fw.jsonl"
+    # Infinity / NaN are valid to json.loads by default.
+    p.write_text(
+        '{"timestamp":"2021-01-01T00:00:00Z","src_ip":"1.2.3.4","dst_ip":"5.6.7.8",'
+        '"src_port":Infinity,"dst_port":NaN,"proto":"tcp","action":"allow"}\n'
+    )
+    res = parse_evidence_file(p, "firewall")
+    # The record is kept (ports simply coerce to None) instead of the whole
+    # file being discarded.
+    assert len(res.events) == 1
+    ev = res.events[0]
+    raw = ev.to_dict()
+    assert raw.get("src_ip") == "1.2.3.4"
+    # Output must be JSON-serializable (no lingering inf/nan in numeric fields).
+    json.dumps(raw)

--- a/titan_decoder/core/evidence_parsers.py
+++ b/titan_decoder/core/evidence_parsers.py
@@ -126,7 +126,13 @@ def _as_int(value: Any) -> Optional[int]:
         except Exception:
             return None
     if isinstance(value, float):
-        return int(value)
+        # int(float("inf")) raises OverflowError and int(float("nan")) raises
+        # ValueError; json.loads accepts Infinity/NaN by default, so a crafted
+        # evidence field must degrade to None rather than abort parsing.
+        try:
+            return int(value)
+        except (ValueError, OverflowError):
+            return None
     return None
 
 


### PR DESCRIPTION
## What

Fuzzing the evidence pipeline harder found a crash-to-silent-data-loss bug.

`json.loads` accepts `Infinity`/`NaN` by default, so an evidence JSONL numeric field like `"src_port": Infinity` becomes `float('inf')`. `_as_int` then ran a bare `int(value)` on it:
- `int(float('inf'))` → `OverflowError`
- `int(float('nan'))` → `ValueError`

That aborted `parse_evidence_file` for the whole file, and the CLI's catch-all around evidence parsing (`evidence_result = None`) then **silently discarded ALL evidence across every `--evidence` file** — with a warning only under `--verbose`. This defeats the per-row resilience the CSV/JSONL readers are built for (they skip individual bad rows).

## Fix

Guard the `float` branch of `_as_int` so non-finite values coerce to `None`, matching the already-guarded string branch. The offending record is kept (the port just becomes `None`) instead of the entire evidence set being dropped.

Before: firewall JSONL with one `Infinity` field → `evidence.events == 0`.
After: → record retained, `evidence.events == 1`.

## Tests

`tests/test_evidence_as_int.py`: `_as_int` on inf/-inf/nan/junk/valid, and a firewall JSONL record with `Infinity`/`NaN` parsing without loss and staying JSON-serializable.

## Also fuzzed this pass (no further bug)

- **Parsers:** 400 trials × 11 kinds (dns/proxy/firewall/vpn/auth/dhcp/generic/unknown/powershell/browser) with adversarial records (inf/nan/lists/dicts/unicode/NUL/huge ints/ipv6) → **0 crashes** after the fix.
- **End-to-end:** 500 trials of adversarial multi-file evidence through `parse → combine_parse_results → sort → to_dict → build_links_from_evidence_events → build_last_seen/top_pivots/entity_hints/top_links → json.dumps` → **0 crashes**.
- `merge_indicators`: 2000 adversarial trials → 0 crashes.

Full suite: **159 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_