### PR TITLE
Fix email regex: literal '|' in TLD character class

### DIFF
--- a/tests/test_email_ioc_regex.py
+++ b/tests/test_email_ioc_regex.py
@@ -1,0 +1,30 @@
+"""Regression test for the email IOC / redaction regex TLD character class.
+
+The TLD class was written [A-Z|a-z], which includes a literal '|' inside the
+character class ('|' is not alternation inside [...]). That matched bogus TLDs
+containing a pipe. The intent is letters only: [A-Za-z].
+"""
+
+from titan_decoder.utils.helpers import extract_iocs
+
+
+def test_real_emails_still_extracted():
+    iocs = extract_iocs("reach me at real.user@corp.example.com or ops@sub.domain.io")
+    assert "real.user@corp.example.com" in iocs["emails"]
+    assert "ops@sub.domain.io" in iocs["emails"]
+
+
+def test_pipe_not_accepted_in_tld():
+    iocs = extract_iocs("junk a@b.co|m and x@y.z|z endjunk")
+    # No extracted email may contain a pipe character.
+    assert all("|" not in e for e in iocs["emails"])
+    # The match stops at the valid letter run before the pipe.
+    assert "a@b.co" in iocs["emails"]
+
+
+def test_secure_logging_pattern_has_no_pipe_in_class():
+    from titan_decoder.core.secure_logging import PIIRedactor
+
+    assert "[A-Z|a-z]" not in PIIRedactor.EMAIL_PATTERN.pattern
+    # And redaction still works on a real email.
+    assert "[EMAIL_REDACTED]" in PIIRedactor.redact("hi user@example.com bye")

--- a/titan_decoder/core/secure_logging.py
+++ b/titan_decoder/core/secure_logging.py
@@ -16,7 +16,8 @@ class PIIRedactor:
     """Redact PII from log messages."""
 
     # Regex patterns for common PII
-    EMAIL_PATTERN = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b")
+    # TLD class was [A-Z|a-z] (literal '|' inside the class); intent is letters only.
+    EMAIL_PATTERN = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
     IP_PATTERN = re.compile(r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b")
     HASH_PATTERN = re.compile(r"\b[a-fA-F0-9]{32,128}\b")
 

--- a/titan_decoder/utils/helpers.py
+++ b/titan_decoder/utils/helpers.py
@@ -170,7 +170,10 @@ def extract_iocs(text: str) -> Dict[str, List[str]]:
     urls = re.findall(r"\bhttps?://[^\s\"']+\b", text_for_urls)
     domains = re.findall(r"\b(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}\b", text_for_other)
     emails = re.findall(
-        r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b", text_for_other
+        # TLD class was [A-Z|a-z], which includes a literal '|' inside the
+        # character class (a common regex mistake) and matched bogus TLDs like
+        # ".co|m"; the intent is just letters.
+        r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b", text_for_other
     )
     # Match only real hash digest lengths (hex): MD5=32, SHA1=40, SHA224=56,
     # SHA256=64, SHA384=96, SHA512=128. A loose {32,128} range would flag any


### PR DESCRIPTION
## What

A full-engine stress test flagged fabricated email IOCs like `am@zusk7vmot.dn|` on random input. Root cause: the email pattern's TLD class was `[A-Z|a-z]` — a **literal pipe inside the character class** (`|` is not alternation inside `[...]`), so it accepted `|` as a valid TLD character.

The same defect existed in two places:
- `utils/helpers.py` — IOC extraction
- `core/secure_logging.py` — PII redaction (`PIIRedactor.EMAIL_PATTERN`)

## Fix

Correct both to `[A-Za-z]{2,}`. Real emails are unaffected; pipe-containing TLDs (`a@b.co|m`) are no longer matched — confirmed at the engine level that pipe-containing email IOCs drop to zero.

## Tests

`tests/test_email_ioc_regex.py`: real emails still extracted, no extracted email contains a pipe, the redaction pattern no longer contains `[A-Z|a-z]`, and `PIIRedactor.redact` still redacts a real email.

## Stress-test context (findings I verified but did NOT "fix")

The stress run (3500 engine runs over nested multi-decoder chains + random/high-entropy inputs) showed:
- **0 crashes, 0 hangs.**
- Residual email over-matching on random text (e.g. `n@yo5.zbx`) is genuinely email-shaped and is the **documented** inherent limitation of regex IOC extraction ("treat as leads, not proof") — not a code defect; tightening further would harm recall.
- Some depth-1 base32/hex/qp payloads aren't decoded because a competing generic base64 decode of the (also-base64-alphabet) input wins the score on the cost tiebreak when printable-*gain* is uninformative. This is a scoring-heuristic **false negative** (a miss, not a fabrication); changing core scoring is out of scope for this fix and reported for separate consideration.

Full suite: **166 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_