### PR TITLE
Extract IOCs from all node previews, not just Text-classified ones

### DIFF
--- a/tests/test_ioc_all_nodes.py
+++ b/tests/test_ioc_all_nodes.py
@@ -1,0 +1,62 @@
+"""Regression test: IOCs must be extracted from all node previews, not just
+Text-classified ones.
+
+run_analysis previously joined only ``content_type == "Text"`` node previews for
+IOC extraction. Malware routinely embeds C2 URLs/IPs in otherwise-binary content
+(config blobs, shellcode, a readable URL followed by binary padding), which
+tips ``looks_like_text`` to "Binary" and silently dropped the indicators.
+"""
+
+import io
+import os
+import binascii
+
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.config import Config
+
+
+def _engine():
+    cfg = Config()
+    cfg.set("max_recursion_depth", 8)
+    return TitanEngine(cfg)
+
+
+def test_url_in_binary_blob_is_extracted():
+    # A URL embedded between random binary padding -> node classifies Binary.
+    blob = os.urandom(64) + b" c2=http://c2.binary.test/gate " + os.urandom(64)
+    rep = _engine().run_analysis(blob)
+    assert "http://c2.binary.test/gate" in rep["iocs"].get("urls", [])
+
+
+def test_public_ip_in_binary_blob_is_extracted():
+    # 8.8.8.8 is a genuinely global/routable address (documentation ranges like
+    # 203.0.113.0/24 are correctly classified non-global by ipaddress.is_global).
+    blob = os.urandom(48) + b" callback 8.8.8.8 now " + os.urandom(48)
+    rep = _engine().run_analysis(blob)
+    assert "8.8.8.8" in rep["iocs"].get("ipv4_public", [])
+
+
+def test_uuencoded_payload_with_binary_tail_recovers_url():
+    def uuenc(b):
+        out = io.BytesIO()
+        out.write(b"begin 644 f\n")
+        i = 0
+        while i < len(b):
+            out.write(binascii.b2a_uu(b[i:i + 45]))
+            i += 45
+        out.write(b"`\nend\n")
+        return out.getvalue()
+
+    payload = b"secret http://uu.evil.test/beacon " + bytes(range(200, 220))
+    rep = _engine().run_analysis(uuenc(payload))
+    assert "http://uu.evil.test/beacon" in rep["iocs"].get("urls", [])
+
+
+def test_random_binary_does_not_fabricate_network_iocs():
+    eng = _engine()
+    fabricated = 0
+    for _ in range(200):
+        rep = eng.run_analysis(os.urandom(512))
+        iocs = rep.get("iocs", {})
+        fabricated += len(iocs.get("urls", [])) + len(iocs.get("ipv4_public", []))
+    assert fabricated == 0

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -553,9 +553,15 @@ class TitanEngine:
         finished_wall = datetime.now(timezone.utc)
         duration_ms = int((time.monotonic() - (self._analysis_started_monotonic or 0)) * 1000)
 
-        # Extract IOCs from all text nodes
+        # Extract IOCs from every node's preview, not just Text-classified ones.
+        # Malware routinely embeds C2 URLs/IPs in otherwise-binary content (config
+        # blobs, shellcode, a readable URL followed by binary padding), which the
+        # Text-only filter silently dropped. content_preview exists for all nodes,
+        # and the IOC regexes are specific enough that binary noise contributes
+        # essentially no false positives (URLs need "http://", IPs are
+        # ipaddress-validated dotted quads).
         all_text = "\n".join(
-            node.content_preview for node in self.nodes if node.content_type == "Text"
+            node.content_preview for node in self.nodes if node.content_preview
         )
 
         report: Dict[str, Any] = {


### PR DESCRIPTION
## What

A full-engine stress test exposed a detection gap: `run_analysis` joined only `content_type == "Text"` node previews for IOC extraction. Malware routinely embeds C2 URLs/IPs in otherwise-binary content (config blobs, shellcode, or a readable URL followed by binary padding), which tips `looks_like_text` to `"Binary"` and **silently dropped those indicators**.

Concretely: a UU-encoded `"secret http://uu.evil.test/beacon " + os.urandom(20)` payload recovered its URL only **1/200** times, because the decoded node (readable URL + 20 binary bytes) classified as Binary and was excluded from extraction — even though `extract_iocs` finds the URL directly.

## Fix

Join **every** node's `content_preview` (which exists for all nodes) for IOC extraction.

The IOC regexes are specific enough that binary noise contributes essentially no false positives — URLs require `http://`, IPs are `ipaddress`-validated dotted quads. Measured **0 fake URLs / 0 fake IPs** across 1500 random-binary engine runs and 5000 random-binary previews.

## Impact
- UU-with-binary-tail URL recovery: **1/200 → 134/200**
- A raw binary blob with an embedded C2 URL is now extracted

## Tests

`tests/test_ioc_all_nodes.py`: URL and public IP embedded in a binary blob are extracted, a UU payload with a binary tail recovers its URL, and random binary fabricates no network IOCs (hallucination guard).

## Stress-test status

This completes the stress test: **0 crashes, 0 hangs** across ~5500 engine runs over nested multi-decoder chains + random/high-entropy inputs. The two bugs it surfaced are both fixed — the `|`-in-TLD email regex (#71, merged) and this Text-only IOC gap. Remaining observations (email regex over-matching on random text; base32/hex depth-1 scoring false-negatives) are documented heuristic limitations, not defects.

Full suite: **170 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_