### PR TITLE
Fix UU smart-detection regex to accept space (0x20) in data lines

### DIFF
--- a/tests/test_uu_detection_spaces.py
+++ b/tests/test_uu_detection_spaces.py
@@ -1,0 +1,40 @@
+"""Regression: UU smart-detection must accept the full 0x20..0x60 alphabet.
+
+The line class was [`!-_], which excludes space (0x20). binascii.b2a_uu emits
+space for the value 0, so real UUencoded data lines containing spaces failed to
+match, and _detect_uuencode under-counted lines and missed valid files -- the
+UUEncode decoder is off-by-default and only enabled by this detection.
+"""
+
+import io
+import binascii
+
+from titan_decoder.core.smart_detection import SmartDetectionEngine
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.config import Config
+
+
+def _uuenc(b: bytes) -> bytes:
+    out = io.BytesIO()
+    out.write(b"begin 644 f\n")
+    i = 0
+    while i < len(b):
+        out.write(binascii.b2a_uu(b[i:i + 45]))
+        i += 45
+    out.write(b"`\nend\n")
+    return out.getvalue()
+
+
+def test_uu_with_space_chars_is_detected():
+    # This payload encodes to UU lines that contain 0x20 space characters.
+    enc = _uuenc(b"stage http://malware.example/stage2/uu")
+    detections = dict(SmartDetectionEngine().detect_format(enc))
+    assert "uuencode" in detections
+
+
+def test_engine_recovers_url_from_uuencoded_payload():
+    cfg = Config()
+    cfg.set("max_recursion_depth", 10)
+    enc = _uuenc(b"stage http://malware.example/stage2/uu")
+    rep = TitanEngine(cfg).run_analysis(enc)
+    assert "http://malware.example/stage2/uu" in rep["iocs"].get("urls", [])

--- a/titan_decoder/core/smart_detection.py
+++ b/titan_decoder/core/smart_detection.py
@@ -47,7 +47,12 @@ class SmartDetectionEngine:
                 lines = text.split("\n")
                 uu_line_count = 0
                 for line in lines:
-                    if re.match(r"^[`!-_]{1,60}$", line):
+                    # UUencode uses the alphabet 0x20 (space) .. 0x60 (backtick);
+                    # a full data line is 61 chars (1 length byte + 60 data). The
+                    # old class [`!-_] excluded space (0x20), which b2a_uu emits
+                    # for the value 0, so real UU lines containing spaces failed
+                    # to match and detection under-counted / missed valid files.
+                    if re.match(r"^[\x20-\x60]{1,61}$", line):
                         uu_line_count += 1
                     elif line.startswith("end"):
                         break


### PR DESCRIPTION
## What

A live stress test with real-world-style obfuscated payloads found that UUencoded payloads containing space characters were never decoded.

`_detect_uuencode` counts UU body lines with the class `[\`!-_]`, which spans `0x60` and `0x21-0x5F` but **excludes space (0x20)**. `binascii.b2a_uu` emits `0x20` for the value 0, so any UU data line containing a space failed the per-line match; detection under-counted lines and missed otherwise-valid files. Since the UUEncode decoder is off-by-default and only enabled by this detection, such payloads were left as an undecoded leaf (e.g. a UU-wrapped dropper string was never cracked).

## Fix

Use the correct UUencode alphabet `0x20..0x60` and allow full 61-char lines: `[\x20-\x60]{1,61}`. Detection still requires the specific `begin NNN name` header, so false-positive risk stays low.

## Tests

`tests/test_uu_detection_spaces.py`: a space-containing UU blob is detected and its URL recovered end-to-end.

## Live-stress context

This was 1 of 4 misses in a 16-technique real-world corpus (PowerShell `-enc`, multi-stage base64, gzip/zlib, XOR, hex, base64-PE, quoted-printable, base32, UU, URL-pct, `\u`-escape, HTML-entity, deep nesting). The two `ps_enc_*` misses are the UTF-16 (PowerShell `-EncodedCommand`) gap, handled separately. The `xor_singlebyte` miss is a conservative heuristic limitation (XOR of ASCII with a low key leaves no high bits, so `XorDecoder.can_decode` skips it; removing that gate would run a 256×n brute force on everything and add false positives) — reported, not changed.

Full suite: **170 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_