### PR TITLE
Add URL-safe base64 decoder (RFC 4648 §5)

### DIFF
--- a/tests/test_base64url_decoder.py
+++ b/tests/test_base64url_decoder.py
@@ -1,0 +1,46 @@
+"""Tests for Base64UrlDecoder (RFC 4648 section 5: '-'/'_' for '+'/'/').
+
+Used by JWTs and web-based C2. It must fire only when '-' or '_' is present so
+it never competes with the standard base64 decoders, and must not false-positive
+on random data.
+"""
+
+import os
+import base64
+
+from titan_decoder.decoders.base import Base64UrlDecoder
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.config import Config
+
+
+def test_decodes_urlsafe_base64():
+    dec = Base64UrlDecoder()
+    raw = b"config c2=http://malware.example/c2/url?x=1" + b"\xfb\xff"
+    enc = base64.urlsafe_b64encode(raw)
+    assert (b"-" in enc) or (b"_" in enc)
+    assert dec.can_decode(enc)
+    out, ok = dec.decode(enc)
+    assert ok and out == raw
+
+
+def test_does_not_touch_standard_base64():
+    dec = Base64UrlDecoder()
+    std = base64.b64encode(b"hello world some padding here")
+    # Standard base64 has no '-'/'_' -> the url decoder must decline it.
+    if b"-" not in std and b"_" not in std:
+        assert dec.can_decode(std) is False
+
+
+def test_end_to_end_url_recovery():
+    cfg = Config()
+    cfg.set("max_recursion_depth", 10)
+    raw = b"cfg http://malware.example/c2/url?x=1" + b"\xfb\xff"
+    enc = base64.urlsafe_b64encode(raw)
+    rep = TitanEngine(cfg).run_analysis(enc)
+    assert "http://malware.example/c2/url?x=1" in rep["iocs"].get("urls", [])
+
+
+def test_no_false_positive_on_random():
+    dec = Base64UrlDecoder()
+    fp = sum(1 for _ in range(3000) if dec.can_decode(os.urandom(64)))
+    assert fp == 0

--- a/tests/test_scoring_costs.py
+++ b/tests/test_scoring_costs.py
@@ -16,6 +16,7 @@ from titan_decoder.core.analyzers.base import (
 from titan_decoder.decoders.base import (
     Base64Decoder,
     RecursiveBase64Decoder,
+    Base64UrlDecoder,
     GzipDecoder,
     Bz2Decoder,
     LzmaDecoder,
@@ -38,9 +39,9 @@ from titan_decoder.decoders.base import (
 ALL_NAMES = {
     d().name
     for d in (
-        Base64Decoder, RecursiveBase64Decoder, GzipDecoder, Bz2Decoder, LzmaDecoder,
-        ZlibDecoder, HexDecoder, Rot13Decoder, XorDecoder, PDFDecoder, OLEDecoder,
-        Utf16Decoder,
+        Base64Decoder, RecursiveBase64Decoder, Base64UrlDecoder, GzipDecoder,
+        Bz2Decoder, LzmaDecoder, ZlibDecoder, HexDecoder, Rot13Decoder, XorDecoder,
+        PDFDecoder, OLEDecoder, Utf16Decoder,
     )
 } | {
     UUDecoder().name, ASN1Decoder().name, QuotedPrintableDecoder().name,

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -12,6 +12,7 @@ from ..decoders.base import (
     Decoder,
     Base64Decoder,
     RecursiveBase64Decoder,
+    Base64UrlDecoder,
     GzipDecoder,
     Bz2Decoder,
     LzmaDecoder,
@@ -162,6 +163,8 @@ class TitanEngine:
             self.decoders.append(RecursiveBase64Decoder())
         if self.config.get("decoders", {}).get("base64", True):
             self.decoders.append(Base64Decoder())
+        if self.config.get("decoders", {}).get("base64url", True):
+            self.decoders.append(Base64UrlDecoder())
         if self.config.get("decoders", {}).get("gzip", True):
             self.decoders.append(GzipDecoder(max_decompressed))
         if self.config.get("decoders", {}).get("bz2", True):

--- a/titan_decoder/core/scoring.py
+++ b/titan_decoder/core/scoring.py
@@ -26,6 +26,7 @@ class ScoringEngine:
     DECODER_COSTS = {
         "Base64": 1,
         "RecursiveBase64": 2,
+        "Base64URL": 2,
         "Gzip": 3,
         "Bz2": 3,
         "LZMA": 4,

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -117,6 +117,45 @@ class RecursiveBase64Decoder(Decoder):
         return "RecursiveBase64"
 
 
+class Base64UrlDecoder(Decoder):
+    """URL-safe base64 (RFC 4648 section 5): '-' and '_' replace '+' and '/'.
+
+    Used by JWTs and web-based C2. It only fires when the data actually contains
+    '-' or '_' -- standard base64 (which never contains those) is left to the
+    Base64/RecursiveBase64 decoders, so the two never compete.
+    """
+
+    _RE = re.compile(rb"^[A-Za-z0-9_-]+={0,2}$")
+
+    def can_decode(self, data: bytes) -> bool:
+        s = data.strip()
+        if len(s) < 16:
+            return False
+        if b"-" not in s and b"_" not in s:
+            return False  # plain base64 -> handled by the standard decoders
+        if not self._RE.match(s):
+            return False
+        try:
+            base64.urlsafe_b64decode(s + b"=" * (-len(s) % 4))
+            return True
+        except Exception:
+            return False
+
+    def decode(self, data: bytes) -> Tuple[bytes, bool]:
+        try:
+            s = data.strip()
+            out = base64.urlsafe_b64decode(s + b"=" * (-len(s) % 4))
+            if out and out != data:
+                return out, True
+            return data, False
+        except Exception:
+            return data, False
+
+    @property
+    def name(self) -> str:
+        return "Base64URL"
+
+
 class GzipDecoder(Decoder):
     """Gzip decompressor."""
 


### PR DESCRIPTION
## What

A live stress test found the engine couldn't decode **URL-safe base64** (`-`/`_` in place of `+`/`/`), which is used by JWTs and web-based C2. `looks_like_base64` rejects `-`/`_`, so the standard Base64/RecursiveBase64 decoders never touched such payloads and a base64url-wrapped C2 URL was left undecoded.

## Fix

Add `Base64UrlDecoder`. It fires **only** when the data actually contains `-` or `_` (standard base64 never does), matches the URL-safe alphabet, and validates by decoding. This keeps it strictly disjoint from the standard base64 decoders — they never compete.

Measured **0 false positives** over 3000 random-binary inputs. Registered in the engine and added to `DECODER_COSTS`.

## Tests

`tests/test_base64url_decoder.py`: decodes url-safe base64, declines standard base64 (no interference), end-to-end URL recovery through the engine, and no random false positives. Updated `test_scoring_costs`.

## Live-stress status

This brings the expanded real-world corpus to essentially full coverage. Remaining known gaps, reported (not fixed here):
- **PEM/`certutil`-armored base64** — needs armor-stripping / embedded-region extraction (a container feature rather than a decoder).
- **Single-byte XOR with a low key** — `XorDecoder.can_decode` requires high-bit presence; removing that gate would brute-force everything and add false positives.

Full suite: **181 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_