### PR TITLE
Add PEM/certutil armor decoder

### DIFF
--- a/tests/test_pem_decoder.py
+++ b/tests/test_pem_decoder.py
@@ -1,0 +1,57 @@
+"""Tests for PemArmorDecoder (certutil / PEM base64 armor).
+
+certutil -encode and PEM wrap base64 between -----BEGIN X----- / -----END X-----
+lines; malware smuggles payloads inside fake CERTIFICATE blocks and unpacks them
+with certutil -decode. The armor stops the plain base64 detector from firing.
+"""
+
+import os
+import base64
+
+from titan_decoder.decoders.base import PemArmorDecoder
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.config import Config
+
+
+def _pem(raw: bytes, label: str = "CERTIFICATE") -> bytes:
+    b = base64.b64encode(raw).decode()
+    body = "\n".join(b[i:i + 64] for i in range(0, len(b), 64))
+    return f"-----BEGIN {label}-----\n{body}\n-----END {label}-----\n".encode()
+
+
+def test_decodes_certutil_armor():
+    dec = PemArmorDecoder()
+    enc = _pem(b"payload http://malware.example/c2/cert dropper")
+    assert dec.can_decode(enc)
+    out, ok = dec.decode(enc)
+    assert ok and b"http://malware.example/c2/cert" in out
+
+
+def test_multiple_blocks_concatenated():
+    dec = PemArmorDecoder()
+    blob = _pem(b"first http://malware.example/a") + _pem(b"second http://malware.example/b", "PRIVATE KEY")
+    out, ok = dec.decode(blob)
+    assert ok
+    assert b"http://malware.example/a" in out and b"http://malware.example/b" in out
+
+
+def test_engine_recovers_url_and_pe_from_pem():
+    cfg = Config()
+    cfg.set("max_recursion_depth", 10)
+    # Fake "certificate" that actually smuggles a PE with an embedded URL.
+    pe = b"MZ" + b"\x00" * 80 + b" http://malware.example/embed.exe " + b"\x00" * 20
+    rep = TitanEngine(cfg).run_analysis(_pem(pe))
+    assert "http://malware.example/embed.exe" in rep["iocs"].get("urls", [])
+
+
+def test_no_fire_without_armor():
+    dec = PemArmorDecoder()
+    assert dec.can_decode(base64.b64encode(b"plain base64 no armor here")) is False
+    assert dec.can_decode(b"just some text") is False
+
+
+def test_no_crash_on_malformed_and_no_random_fp():
+    dec = PemArmorDecoder()
+    for bad in (b"-----BEGIN X-----", b"-----BEGIN A-----\n@@@\n-----END A-----", b""):
+        assert dec.decode(bad) == (bad, False) or isinstance(dec.decode(bad), tuple)
+    assert sum(1 for _ in range(2000) if dec.can_decode(os.urandom(200))) == 0

--- a/tests/test_scoring_costs.py
+++ b/tests/test_scoring_costs.py
@@ -17,6 +17,7 @@ from titan_decoder.decoders.base import (
     Base64Decoder,
     RecursiveBase64Decoder,
     Base64UrlDecoder,
+    PemArmorDecoder,
     GzipDecoder,
     Bz2Decoder,
     LzmaDecoder,
@@ -39,9 +40,9 @@ from titan_decoder.decoders.base import (
 ALL_NAMES = {
     d().name
     for d in (
-        Base64Decoder, RecursiveBase64Decoder, Base64UrlDecoder, GzipDecoder,
-        Bz2Decoder, LzmaDecoder, ZlibDecoder, HexDecoder, Rot13Decoder, XorDecoder,
-        PDFDecoder, OLEDecoder, Utf16Decoder,
+        Base64Decoder, RecursiveBase64Decoder, Base64UrlDecoder, PemArmorDecoder,
+        GzipDecoder, Bz2Decoder, LzmaDecoder, ZlibDecoder, HexDecoder, Rot13Decoder,
+        XorDecoder, PDFDecoder, OLEDecoder, Utf16Decoder,
     )
 } | {
     UUDecoder().name, ASN1Decoder().name, QuotedPrintableDecoder().name,

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -13,6 +13,7 @@ from ..decoders.base import (
     Base64Decoder,
     RecursiveBase64Decoder,
     Base64UrlDecoder,
+    PemArmorDecoder,
     GzipDecoder,
     Bz2Decoder,
     LzmaDecoder,
@@ -165,6 +166,8 @@ class TitanEngine:
             self.decoders.append(Base64Decoder())
         if self.config.get("decoders", {}).get("base64url", True):
             self.decoders.append(Base64UrlDecoder())
+        if self.config.get("decoders", {}).get("pem", True):
+            self.decoders.append(PemArmorDecoder())
         if self.config.get("decoders", {}).get("gzip", True):
             self.decoders.append(GzipDecoder(max_decompressed))
         if self.config.get("decoders", {}).get("bz2", True):

--- a/titan_decoder/core/scoring.py
+++ b/titan_decoder/core/scoring.py
@@ -27,6 +27,7 @@ class ScoringEngine:
         "Base64": 1,
         "RecursiveBase64": 2,
         "Base64URL": 2,
+        "PEM": 2,
         "Gzip": 3,
         "Bz2": 3,
         "LZMA": 4,

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -156,6 +156,48 @@ class Base64UrlDecoder(Decoder):
         return "Base64URL"
 
 
+class PemArmorDecoder(Decoder):
+    """Decode PEM / ``certutil``-armored base64 bodies.
+
+    ``certutil -encode`` and PEM wrap base64 between ``-----BEGIN X-----`` and
+    ``-----END X-----`` lines. Malware smuggles executables/scripts inside fake
+    "CERTIFICATE" blocks and unpacks them with ``certutil -decode``; the armor
+    lines and dashes stop the plain base64 detector from firing. Extract the
+    body of each block and base64-decode it (concatenating multiple blocks).
+    """
+
+    _BLOCK = re.compile(
+        rb"-----BEGIN [^-\r\n]*-----(.*?)-----END [^-\r\n]*-----",
+        re.DOTALL,
+    )
+
+    def can_decode(self, data: bytes) -> bool:
+        if b"-----BEGIN " not in data or b"-----END " not in data:
+            return False
+        return self._BLOCK.search(data) is not None
+
+    def decode(self, data: bytes) -> Tuple[bytes, bool]:
+        try:
+            out = bytearray()
+            for match in self._BLOCK.finditer(data):
+                body = b"".join(match.group(1).split())  # strip line wrapping
+                if not body:
+                    continue
+                try:
+                    out += base64.b64decode(body + b"=" * (-len(body) % 4))
+                except Exception:
+                    continue
+            if out:
+                return bytes(out), True
+            return data, False
+        except Exception:
+            return data, False
+
+    @property
+    def name(self) -> str:
+        return "PEM"
+
+
 class GzipDecoder(Decoder):
     """Gzip decompressor."""
 


### PR DESCRIPTION
## What

Closes the last remaining gap from the live stress test: **PEM / `certutil`-armored base64**.

`certutil -encode` and PEM wrap base64 between `-----BEGIN X-----` / `-----END X-----` lines. Malware smuggles executables/scripts inside fake `CERTIFICATE` blocks and unpacks them with `certutil -decode`. The armor lines and dashes stop `looks_like_base64` from firing, so a certutil-armored C2 URL was left undecoded.

## Fix

Add `PemArmorDecoder`: extract the body of each `-----BEGIN…-----END…` block, strip line wrapping, and base64-decode it (concatenating multiple blocks). It only fires when both armor markers **and** a valid block are present.

- **0 false positives** over random input
- No crashes on malformed armor (BEGIN without END, empty body, non-base64 body)
- Registered in the engine and added to `DECODER_COSTS`

## Impact

- certutil-armored payloads now decode; a fake "certificate" smuggling a PE with an embedded URL is cracked and the URL extracted.
- Multi-block PEM (cert chains) decodes all blocks.

## Tests

`tests/test_pem_decoder.py`: certutil body decode, multi-block concatenation, PE-smuggled-in-cert end-to-end URL recovery, no-fire without armor, and malformed/no-random-FP guards. Updated `test_scoring_costs`.

## Live-stress status

Both real-world corpora now at full coverage except **single-byte XOR with a low key** — a deliberate `XorDecoder` heuristic limitation (requiring high-bit presence avoids a 256×n brute force on all data + false-positive decodes), reported previously.

Full suite: **186 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_