### PR TITLE
Recover single-byte XOR of ASCII-keyed configs (C2 URLs/commands)

### DIFF
--- a/tests/test_xor_singlebyte.py
+++ b/tests/test_xor_singlebyte.py
@@ -1,0 +1,69 @@
+"""Tests for single-byte XOR recovery of ASCII-keyed payloads.
+
+Real malware XORs config strings (C2 URLs, commands) with a single byte. When
+the key keeps the output in low ASCII (e.g. 0x5A) the ciphertext has no high
+bits, so the old high-bit gate skipped it entirely. And because XOR is a
+bijection (zero entropy change) with no printable gain when the ciphertext is
+already printable, the reveal scored 0 and was dropped -- so URL/command markers
+were added to the structural score. It must NOT scramble random/plain/hex data.
+"""
+
+import os
+import random
+
+from titan_decoder.decoders.base import XorDecoder
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.config import Config
+
+
+def _engine():
+    cfg = Config()
+    cfg.set("max_recursion_depth", 10)
+    return TitanEngine(cfg)
+
+
+def test_decoder_recovers_ascii_keyed_config():
+    dec = XorDecoder()
+    pt = b"config c2=http://malware.example/c2/panel"
+    ct = bytes(b ^ 0x5A for b in pt)  # low key -> no high bits in ciphertext
+    assert dec.can_decode(ct)
+    out, ok = dec.decode(ct)
+    assert ok and out == pt
+
+
+def test_engine_recovers_url_from_single_byte_xor():
+    eng = _engine()
+    recovered = 0
+    keys = [0x5A, 0x41, 0x13, 0xAA, 0x7F, 0x2E, 0x88, 0x11, 0x6C]
+    for key in keys:
+        ct = bytes(b ^ key for b in b"beacon http://malware.example/c2/x")
+        rep = eng.run_analysis(ct)
+        if "http://malware.example/c2/x" in rep["iocs"].get("urls", []):
+            recovered += 1
+    assert recovered >= len(keys) - 2  # allow a couple of key-ambiguity misses
+
+
+def test_does_not_scramble_plain_text_or_hex_or_base64():
+    dec = XorDecoder()
+    import base64
+    import binascii
+
+    for data in (
+        b"the quick brown fox jumps over the lazy dog repeatedly",
+        binascii.hexlify(os.urandom(60)),
+        base64.b64encode(os.urandom(60)),
+    ):
+        out, ok = dec.decode(data) if dec.can_decode(data) else (data, False)
+        # Either declined, or accepted only without changing the data.
+        assert not (ok and out != data)
+
+
+def test_no_hallucinated_iocs_on_random_binary():
+    eng = _engine()
+    random.seed(11)
+    fabricated = 0
+    for _ in range(200):
+        rep = eng.run_analysis(os.urandom(random.randint(50, 512)))
+        iocs = rep.get("iocs", {})
+        fabricated += len(iocs.get("urls", [])) + len(iocs.get("emails", [])) + len(iocs.get("ipv4_public", []))
+    assert fabricated == 0

--- a/titan_decoder/core/scoring.py
+++ b/titan_decoder/core/scoring.py
@@ -55,6 +55,16 @@ class ScoringEngine:
         re.compile(rb"import\s+\w+"),  # Import statement
         re.compile(rb"function\s+\w+"),  # Function definition
         re.compile(rb"class\s+\w+"),  # Class definition
+        # Network / command indicators: a decode that reveals a URL or a shell/
+        # PowerShell invocation is meaningful even when it yields no entropy
+        # reduction or printable gain. Single-byte XOR is a bijection, so a
+        # printable-ASCII-keyed config (e.g. a C2 URL) scores 0 on those
+        # components; rewarding these markers lets the reveal clear the score
+        # threshold and be followed instead of dropped.
+        re.compile(rb"https?://"),  # URL
+        re.compile(rb"[Pp]ower[Ss]hell"),  # PowerShell
+        re.compile(rb"cmd\.exe"),  # cmd
+        re.compile(rb"/bin/(?:ba)?sh"),  # POSIX shell
     ]
 
     @classmethod

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -396,44 +396,81 @@ class Rot13Decoder(Decoder):
         return "ROT13"
 
 
+def _build_xor_score_table() -> list:
+    """Per-byte text-likeness weights for scoring single-byte-XOR candidates."""
+    table = [-1.5] * 256  # non-printable bytes: strong penalty
+    for i in range(32, 127):
+        table[i] = 0.1  # other printable ASCII
+    for i in range(0x30, 0x3A):
+        table[i] = 0.4  # digits
+    for i in range(0x41, 0x5B):
+        table[i] = 0.6  # uppercase
+    for i in range(0x61, 0x7B):
+        table[i] = 1.0  # lowercase
+    for ch in b"./:@-_?=&%+":
+        table[ch] = 0.4  # URL / path punctuation
+    table[0x20] = 1.0  # space (strong text signal)
+    for ch in (0x09, 0x0A, 0x0D):
+        table[ch] = 0.3  # tab / newlines
+    return table
+
+
+_XOR_SCORE = _build_xor_score_table()
+
+
+def _xor_text_likeness(data: bytes) -> float:
+    """Higher => more like readable text/commands/URLs. Range roughly [-1.5, 1.0]."""
+    if not data:
+        return -1.0
+    return sum(_XOR_SCORE[b] for b in data) / len(data)
+
+
 class XorDecoder(Decoder):
-    """Single-byte XOR decoder with best guess."""
+    """Single-byte XOR decoder.
+
+    Brute-forces all 256 keys and picks the one that best reveals readable
+    text/commands/URLs using a text-likeness score, not raw printable count --
+    printable count cannot choose among the several all-printable candidates a
+    single-byte XOR produces, which is why an ASCII-XOR'd config (e.g. a C2 URL
+    keyed with 0x5A, whose ciphertext has no high bits) was previously missed.
+
+    Accepts only a clearly text-like reveal that beats reading the bytes as-is,
+    so it does not scramble already-readable, random, hex, or base64 data.
+    """
 
     def can_decode(self, data: bytes) -> bool:
-        """Check if data might be XOR encoded."""
-        if len(data) < 8:
+        n = len(data)
+        if n < 8 or n > 512:  # keep the 256-key brute force cheap and bounded
             return False
-
-        # Check if data has some structure that suggests XOR encoding
-        # Look for patterns that are common in XOR-encoded data
-        # High entropy but some repeating patterns
-        diversity = len(set(data)) / len(data)
-        if diversity < 0.5:  # Low diversity suggests not XOR
+        if len(set(data)) < 8:  # near-uniform / padding is not XOR'd text
             return False
-
-        # Check for potential XOR patterns (like English text with high bit set)
-        high_bit_count = sum(1 for b in data if b & 0x80)
-        high_bit_ratio = high_bit_count / len(data)
-        if high_bit_ratio < 0.1:  # Not enough high bits
+        # hex/base64 have dedicated decoders; don't XOR-scramble them.
+        if looks_like_hex(data) or looks_like_base64(data):
             return False
-
         return True
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         from ..utils.helpers import looks_like_text
 
-        best_score = 0
+        raw = _xor_text_likeness(data)
+        best = raw
         best_out = data
-
-        for key in range(256):
-            decoded = bytes(b ^ key for b in data)
-            score = sum(1 for b in decoded if 32 <= b <= 126)  # Printable ASCII
-            if score > best_score:
-                best_score = score
+        best_key = 0
+        for key in range(1, 256):
+            decoded = data.translate(bytes(i ^ key for i in range(256)))
+            score = _xor_text_likeness(decoded)
+            if score > best:
+                best = score
                 best_out = decoded
+                best_key = key
 
-        # Only return if it looks like text and score is good
-        if looks_like_text(best_out) and best_score > len(best_out) * 0.6:
+        # Require a genuine, clearly text-like reveal that beats the raw reading.
+        if (
+            best_key != 0
+            and best >= 0.70
+            and best >= raw + 0.20
+            and looks_like_text(best_out)
+        ):
             return best_out, True
         return data, False
 


### PR DESCRIPTION
## What

Closes the last live-stress gap: single-byte XOR of a config string keyed with a low byte (e.g. `0x5A`) — the classic way malware hides C2 URLs/commands. Two things blocked it:

1. **`XorDecoder.can_decode` required `high_bit_ratio >= 0.1`**, but XOR of ASCII text with a low key stays in low ASCII (no high bits), so it was never tried.
2. **XOR is a bijection** (zero entropy change) and, when the ciphertext is already printable, yields no printable gain — so `calculate_decode_score` returned **0.0** and the reveal was dropped below `min_score_threshold` even after decoding correctly.

## Fix

**`XorDecoder`:**
- `can_decode` drops the high-bit gate; bounds length to ≤512 (keeps the 256-key brute force cheap via a fast `bytes.translate` loop) and skips near-uniform, hex, and base64 data (which have dedicated decoders).
- `decode` picks the key by a **text-likeness score** (spaces / lowercase / URL punctuation), not raw printable count — printable count can't choose among the several all-printable candidates a single-byte XOR produces. It accepts only a clearly text-like reveal that beats reading the bytes as-is.

**Scoring:** add URL / PowerShell / `cmd.exe` / shell markers to `STRUCTURE_PATTERNS`, so a decode that reveals a URL or command clears the threshold and is followed — a general win for base32/hex reveals too, not just XOR (XOR's bijection means structure is the *only* signal available).

## Results

- Full real-world live-stress corpus: **15/16 → 16/16**
- XOR end-to-end URL recovery: **8/9** across keys (the occasional miss is inherent single-byte-XOR key ambiguity)
- **0 fabricated IOCs and 0 spurious XOR nodes** over 1500 random-binary engine runs
- Plain text / hex / base64 are **not** scrambled

## Tests

`tests/test_xor_singlebyte.py`: decoder recovers ASCII-keyed config, engine recovers URL across 9 keys, no scrambling of plain/hex/base64, and no hallucinated IOCs on random binary.

Full suite: **190 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_