### PR TITLE
Make XOR hallucination-guard test deterministic (fix flaky test)

### DIFF
--- a/tests/test_xor_singlebyte.py
+++ b/tests/test_xor_singlebyte.py
@@ -60,10 +60,16 @@ def test_does_not_scramble_plain_text_or_hex_or_base64():
 
 def test_no_hallucinated_iocs_on_random_binary():
     eng = _engine()
-    random.seed(11)
+    # Deterministic byte source: os.urandom ignores random.seed, which made this
+    # non-deterministic. URLs and validated public IPs require "http://" or a
+    # routable dotted quad and are effectively impossible to fabricate from
+    # random bytes; the email/domain regexes intentionally over-match on noise
+    # ("leads, not proof"), so they are excluded from this hallucination guard.
+    rng = random.Random(11)
     fabricated = 0
     for _ in range(200):
-        rep = eng.run_analysis(os.urandom(random.randint(50, 512)))
+        data = bytes(rng.randrange(256) for _ in range(rng.randint(50, 512)))
+        rep = eng.run_analysis(data)
         iocs = rep.get("iocs", {})
-        fabricated += len(iocs.get("urls", [])) + len(iocs.get("emails", [])) + len(iocs.get("ipv4_public", []))
+        fabricated += len(iocs.get("urls", [])) + len(iocs.get("ipv4_public", []))
     assert fabricated == 0


### PR DESCRIPTION
## What

An engine integrity sweep caught a flaky test introduced in #77.

`test_no_hallucinated_iocs_on_random_binary` called `random.seed(11)` but drew bytes from `os.urandom`, which **ignores** that seed — so the input was actually non-deterministic. It also asserted **zero emails**, but the email/domain IOC regexes intentionally over-match on random noise ("leads, not proof"), so ~4/6000 random blobs yield an email-shaped string → intermittent CI failure.

## Fix

- Use a seeded `random.Random` byte source (deterministic across runs and Python versions).
- Assert only on `urls` + `ipv4_public`, which require `http://` or a routable dotted quad and are effectively impossible to fabricate from random bytes.

Verified: **0 fabricated URLs / public IPs over 6000 random-binary engine runs**, and the test passes deterministically (5/5 repeat runs, full suite twice).

## Context

Part of a full cleanup + integrity sweep. The repo itself is clean (no tracked build/cache artifacts — all gitignored; no dead modules; `correlation.py` is opt-in-wired; the `tools/` stress script is functional). Integrity checks all pass: 35 modules import cleanly, all `.py` compile, engine wiring + `DECODER_COSTS` aligned (no orphans), report validates against the schema, seeded runs are deterministic, CLI works end-to-end.

Full suite: **190 passed** (twice, no flakes), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy28YJdZhuddMxF5ZgKW71)_