### PR TITLE
Fix engine bugs from full review: threaded/Windows silent failure, decoder gating, state leaks

### DIFF
--- a/tests/test_engine_hardening_fixes.py
+++ b/tests/test_engine_hardening_fixes.py
@@ -15,6 +15,7 @@ Covers:
 import base64
 import binascii
 import random
+import re
 import struct
 import threading
 import zlib
@@ -130,3 +131,51 @@ def test_pe_armnt_machine_not_mislabeled_arm64():
     (_, meta_json), = analyzer.analyze(bytes(data))
     assert b'"ARM Thumb-2"' in meta_json
     assert b"ARM64" not in meta_json
+
+
+def test_text_transform_decoders_do_not_fire_on_binary():
+    # URL/HTML-entity/unicode-escape decoders used errors="ignore", which on
+    # binary input silently deleted every non-UTF-8 byte; the mangled output
+    # differed from the input, so the "decode" was reported successful and its
+    # apparent entropy reduction outscored the correct decoder (e.g. Gzip),
+    # killing the real decode chain. They must only fire on valid UTF-8 text.
+    from titan_decoder.decoders.base import (
+        HTMLEntityDecoder,
+        UnicodeEscapeDecoder,
+        URLDecoder,
+    )
+
+    binary = bytes(range(256)) + b" %41 + &amp; \\u0041 "
+    for dec in (URLDecoder(), HTMLEntityDecoder(), UnicodeEscapeDecoder()):
+        assert not dec.can_decode(binary), dec.name
+        out, ok = dec.decode(binary)
+        assert not ok and out == binary, dec.name
+    # Genuine text payloads still decode.
+    out, ok = URLDecoder().decode(b"http%3A%2F%2Fexample.com%2Fx")
+    assert ok and out == b"http://example.com/x"
+    out, ok = HTMLEntityDecoder().decode(b"a &amp; b &#65;")
+    assert ok and out == b"a & b A"
+    out, ok = UnicodeEscapeDecoder().decode(b"\\u0068\\u0069 there")
+    assert ok and out == b"hi there"
+
+
+def test_gzip_stream_with_percent_bytes_not_hijacked():
+    import gzip as _gzip
+    import json as _json
+
+    # Find a payload whose *compressed* bytes contain a %XX trigram, i.e. the
+    # exact situation where URLDecoder previously outscored Gzip and broke the
+    # chain (observed nondeterministically in the stress scenario runner).
+    for i in range(20000):
+        inner = _json.dumps(
+            {"c2": "https://stress.example/v2/checkin", "nonce": i}
+        ).encode()
+        blob = _gzip.compress(inner)
+        if re.search(rb"%[0-9A-Fa-f]{2}", blob):
+            break
+    else:  # pragma: no cover - search space makes this effectively impossible
+        raise AssertionError("could not construct trigger payload")
+
+    eng = TitanEngine(Config())
+    rep = eng.run_analysis(base64.b64encode(blob))
+    assert any("stress.example" in u for u in rep["iocs"]["urls"]), rep["iocs"]

--- a/tests/test_engine_hardening_fixes.py
+++ b/tests/test_engine_hardening_fixes.py
@@ -1,0 +1,132 @@
+"""Regression tests for engine review fixes.
+
+Covers:
+- config-enabled off-by-default decoders are actually registered
+- smart-detection decoder enablement resets between run_analysis() calls
+- timeout_context degrades gracefully off the main thread (Windows/worker
+  threads), instead of crashing and silently disabling every decoder
+- ZlibDecoder validates the full RFC 1950 header (FCHECK), not just the
+  low nibble of the first byte
+- Base32Decoder accepts all valid unpadded lengths (mod 8 in {0,2,4,5,7})
+- looks_like_hex rejects int()-isms unhexlify can't decode ("0x", "+", "_")
+- PE machine 0x01C4 is ARMNT (ARM Thumb-2), not ARM64
+"""
+
+import base64
+import binascii
+import random
+import struct
+import threading
+import zlib
+
+from titan_decoder.config import Config
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.decoders.base import Base32Decoder, ZlibDecoder
+from titan_decoder.utils.helpers import looks_like_hex
+
+
+def _uu_sample(payload: bytes) -> bytes:
+    return b"begin 644 t.bin\n" + binascii.b2a_uu(payload) + b"`\nend\n"
+
+
+def test_config_enabled_optional_decoder_is_registered():
+    cfg = Config()
+    cfg._config["decoders"]["uuencode"] = True
+    eng = TitanEngine(cfg)
+    assert eng.uuencoder.enabled
+    assert eng.uuencoder in eng.decoders
+
+
+def test_smart_detection_state_resets_between_runs():
+    eng = TitanEngine(Config())
+    assert not eng.uuencoder.enabled
+
+    # First run trips smart detection and enables the UU decoder mid-run.
+    rep = eng.run_analysis(_uu_sample(b"beacon http://uu.example/c2 padding"))
+    assert any("uu.example" in u for u in rep["iocs"]["urls"])
+
+    # A later, unrelated run must start from the configured baseline again.
+    eng.run_analysis(b"plain text, nothing encoded here at all")
+    assert not eng.uuencoder.enabled
+    assert eng.uuencoder not in eng.decoders
+
+    # And smart detection still re-enables it when needed.
+    rep = eng.run_analysis(_uu_sample(b"second http://uu2.example/c2 padding"))
+    assert any("uu2.example" in u for u in rep["iocs"]["urls"])
+
+
+def test_engine_decodes_from_worker_thread():
+    # SIGALRM-based timeouts are unavailable off the main thread; the engine
+    # must fall back to unguarded execution rather than (silently) failing
+    # every decoder call.
+    result = {}
+
+    def worker():
+        eng = TitanEngine(Config())
+        data = base64.b64encode(b"beacon http://thread.example/c2 and padding")
+        result["report"] = eng.run_analysis(data)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+    assert any("thread.example" in u for u in result["report"]["iocs"]["urls"])
+
+
+def test_zlib_header_validation():
+    dec = ZlibDecoder()
+    # Real zlib streams at every compression level are accepted.
+    for level in range(10):
+        assert dec.can_decode(zlib.compress(b"payload " * 32, level))
+    # Deflate nibble but invalid FCHECK / CINFO are rejected.
+    assert not dec.can_decode(b"\x78\x00rest")  # 0x7800 % 31 != 0
+    assert not dec.can_decode(b"\x88\x0cxxxx")  # CINFO > 7
+    # False-positive rate on random data should be ~1/496, not ~6%.
+    rng = random.Random(1337)
+    hits = sum(
+        1
+        for _ in range(20000)
+        if dec.can_decode(bytes([rng.randrange(256), rng.randrange(256)]) + b"xx")
+    )
+    assert hits < 100
+
+
+def test_base32_accepts_all_valid_unpadded_lengths():
+    dec = Base32Decoder(enabled=True)
+    # 11..15 input bytes produce unpadded lengths of 18,20,21,23,24
+    # (mod 8 = 2,4,5,7,0); all are valid and must decode round-trip.
+    for n in (11, 12, 13, 14, 15):
+        payload = bytes(range(n))
+        enc = base64.b32encode(payload).rstrip(b"=")
+        assert dec.can_decode(enc), (n, len(enc) % 8)
+        out, ok = dec.decode(enc)
+        assert ok and out == payload
+    # Impossible unpadded lengths stay rejected.
+    assert not dec.can_decode(b"A" * 17)  # mod 8 == 1
+    assert not dec.can_decode(b"A" * 19)  # mod 8 == 3
+
+
+def test_looks_like_hex_is_strict():
+    assert looks_like_hex(b"1f2a3b4c")
+    assert looks_like_hex(b"  DEADBEEF  ")
+    assert not looks_like_hex(b"0x1f2a3b4c")  # int(,16) accepted this
+    assert not looks_like_hex(b"1f_2a3b4c5d")  # underscore separators
+    assert not looks_like_hex(b"+1f2a3b4c5d")  # sign prefix
+    assert not looks_like_hex(b"")
+
+
+def test_pe_armnt_machine_not_mislabeled_arm64():
+    from titan_decoder.core.analyzers.base import PEAnalyzer
+
+    # Minimal PE: DOS header with e_lfanew=64, then "PE\0\0" + COFF header
+    # with machine 0x01C4 (ARMNT / ARM Thumb-2).
+    data = bytearray(200)
+    data[0:2] = b"MZ"
+    data[60:64] = struct.pack("<I", 64)
+    data[64:68] = b"PE\x00\x00"
+    data[68:88] = struct.pack("<HHIIIHH", 0x01C4, 1, 0, 0, 0, 0, 0)
+
+    analyzer = PEAnalyzer()
+    assert analyzer.can_analyze(bytes(data))
+    (_, meta_json), = analyzer.analyze(bytes(data))
+    assert b'"ARM Thumb-2"' in meta_json
+    assert b"ARM64" not in meta_json

--- a/titan_decoder/config.py
+++ b/titan_decoder/config.py
@@ -45,6 +45,8 @@ class Config:
         "decoders": {
             "base64": True,
             "recursive_base64": True,
+            "base64url": True,
+            "pem": True,
             "gzip": True,
             "bz2": True,
             "lzma": True,
@@ -58,7 +60,7 @@ class Config:
             "url": True,
             "html_entity": True,
             "unicode_escape": True,
-            "base85": True,
+            "utf16": True,
             # Off-by-default decoders (require smart detection)
             "uuencode": False,
             "asn1": False,

--- a/titan_decoder/core/analyzers/base.py
+++ b/titan_decoder/core/analyzers/base.py
@@ -434,7 +434,9 @@ class PEAnalyzer(Analyzer):
                 0x0200: "IA64",
                 0x8664: "x64",
                 0x01C0: "ARM",
-                0x01C4: "ARM64",
+                # 0x01C4 is IMAGE_FILE_MACHINE_ARMNT (32-bit ARM Thumb-2),
+                # not ARM64 (0xAA64) — mislabeling it corrupts triage.
+                0x01C4: "ARM Thumb-2",
                 0xAA64: "ARM64",
             }
 

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -208,6 +208,20 @@ class TitanEngine:
         self.base32_decoder = Base32Decoder(
             enabled=self.config.get("decoders", {}).get("base32", False)
         )
+        # Remember the configured enablement so smart-detection changes made
+        # during one run can be undone before the next (run_analysis resets to
+        # this baseline). Decoders explicitly enabled via config must also be
+        # registered here — previously they were constructed enabled but never
+        # added to self.decoders, so the config flags had no effect.
+        self._optional_decoder_baseline = [
+            (self.uuencoder, self.uuencoder.enabled),
+            (self.asn1_decoder, self.asn1_decoder.enabled),
+            (self.qp_decoder, self.qp_decoder.enabled),
+            (self.base32_decoder, self.base32_decoder.enabled),
+        ]
+        for decoder, enabled in self._optional_decoder_baseline:
+            if enabled:
+                self.decoders.append(decoder)
 
         # Initialize analyzers
         self.analyzers: List[Analyzer] = []
@@ -542,6 +556,19 @@ class TitanEngine:
         if best_score < self.pruning_engine.min_score_threshold:
             node.pruned = True
 
+    def _reset_optional_decoders(self) -> None:
+        """Restore off-by-default decoders to their configured baseline.
+
+        Smart detection enables these decoders mid-run and appends them to
+        self.decoders; without a reset that state leaked into subsequent
+        run_analysis() calls on the same engine, making results depend on what
+        was analyzed earlier.
+        """
+        for decoder, enabled in self._optional_decoder_baseline:
+            decoder.enabled = enabled
+            if not enabled and decoder in self.decoders:
+                self.decoders.remove(decoder)
+
     def run_analysis(self, input_data: bytes) -> Dict[str, Any]:
         """Run full analysis on input data."""
         analysis_id = str(uuid.uuid4())
@@ -557,6 +584,7 @@ class TitanEngine:
         self._seen_hashes = set()
         self._node_cap_reached = False
         self.decision_trace = []
+        self._reset_optional_decoders()
         self.analyze_blob(input_data, None, 0)
 
         finished_wall = datetime.now(timezone.utc)

--- a/titan_decoder/core/resource_manager.py
+++ b/titan_decoder/core/resource_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import signal
+import threading
 from contextlib import contextmanager
 from typing import Optional
 import logging
@@ -30,7 +31,28 @@ class ResourceManager:
 
     @contextmanager
     def timeout_context(self, seconds: int, operation_name: str = "operation"):
-        """Context manager for enforcing timeouts on operations."""
+        """Context manager for enforcing timeouts on operations.
+
+        SIGALRM-based timeouts only work on POSIX and only from the main
+        thread. Elsewhere (Windows, worker threads) ``signal.signal`` raises,
+        and since the engine swallows per-decoder exceptions that would
+        silently disable every decoder/analyzer — so fall back to running the
+        operation unguarded instead. The run-level wall-clock deadline and
+        memory checks in the engine still bound the overall analysis.
+        """
+        can_use_alarm = (
+            hasattr(signal, "SIGALRM")
+            and threading.current_thread() is threading.main_thread()
+        )
+        if not can_use_alarm or seconds <= 0:
+            if not can_use_alarm:
+                logger.debug(
+                    "SIGALRM unavailable (platform/thread); running %s without "
+                    "a per-operation timeout",
+                    operation_name,
+                )
+            yield
+            return
 
         def timeout_handler(signum, frame):
             raise TimeoutError(f"{operation_name} exceeded {seconds}s timeout")

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -12,6 +12,7 @@ from ..utils.helpers import (
     looks_like_gzip,
     looks_like_bz2,
     looks_like_hex,
+    looks_like_text,
 )
 
 
@@ -453,8 +454,6 @@ class XorDecoder(Decoder):
         return True
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
-        from ..utils.helpers import looks_like_text
-
         raw = _xor_text_likeness(data)
         best = raw
         best_out = data
@@ -903,18 +902,30 @@ class Base32Decoder(Decoder):
 
 
 class URLDecoder(Decoder):
-    """URL percent-encoding decoder."""
+    """URL percent-encoding decoder.
+
+    Percent-encoding is a text transport, so this only fires on valid UTF-8
+    input. Decoding with ``errors="ignore"`` on binary data silently deleted
+    every non-UTF-8 byte and the mangled output still compared unequal to the
+    input, so the "decode" was reported successful — and the byte destruction
+    looked like entropy reduction, letting this decoder outscore the correct
+    one (e.g. Gzip on a gzip stream that happens to contain ``%XX``) and kill
+    the real decode chain. The same fix applies to HTMLEntityDecoder and
+    UnicodeEscapeDecoder below.
+    """
 
     def can_decode(self, data: bytes) -> bool:
+        if not looks_like_text(data):
+            return False
         try:
-            text = data.decode("utf-8", errors="ignore")
+            text = data.decode("utf-8")
             return bool(re.search(r"%[0-9A-Fa-f]{2}", text))
         except Exception:
             return False
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            text = data.decode("utf-8", errors="ignore")
+            text = data.decode("utf-8")
             # Use a bytearray: byte concatenation in a loop (result += ...) is
             # O(n^2) and hangs on percent-heavy payloads.
             result = bytearray()
@@ -945,11 +956,13 @@ class URLDecoder(Decoder):
 
 
 class HTMLEntityDecoder(Decoder):
-    """HTML entity decoder."""
+    """HTML entity decoder (text-only; see URLDecoder docstring)."""
 
     def can_decode(self, data: bytes) -> bool:
+        if not looks_like_text(data):
+            return False
         try:
-            text = data.decode("utf-8", errors="ignore")
+            text = data.decode("utf-8")
             return bool(
                 re.search(r"&#(?:\d+|x[0-9A-Fa-f]+);|&[a-z]+;", text, re.IGNORECASE)
             )
@@ -968,7 +981,7 @@ class HTMLEntityDecoder(Decoder):
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            text = data.decode("utf-8", errors="ignore")
+            text = data.decode("utf-8")
 
             # Single-pass substitution: the previous char-by-char scan sliced
             # text[i:] and re-ran the regex for every character (O(n^2)), which
@@ -999,18 +1012,20 @@ class HTMLEntityDecoder(Decoder):
 
 
 class UnicodeEscapeDecoder(Decoder):
-    """Unicode escape sequences decoder."""
+    """Unicode escape sequences decoder (text-only; see URLDecoder docstring)."""
 
     def can_decode(self, data: bytes) -> bool:
+        if not looks_like_text(data):
+            return False
         try:
-            text = data.decode("utf-8", errors="ignore")
+            text = data.decode("utf-8")
             return bool(re.search(r"\\u[0-9A-Fa-f]{4}|\\U[0-9A-Fa-f]{8}", text))
         except Exception:
             return False
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
-            text = data.decode("utf-8", errors="ignore")
+            text = data.decode("utf-8")
             result = []
             i = 0
 

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -272,15 +272,18 @@ class ZlibDecoder(Decoder):
         self.max_output_size = max_output_size
 
     def can_decode(self, data: bytes) -> bool:
-        # ZLIB compressed data typically starts with compression method
-        # This is a heuristic - ZLIB doesn't have a fixed header like GZIP
+        # Validate the full RFC 1950 header instead of only the low nibble of
+        # the first byte: that alone matched ~6% of random binary data and
+        # triggered a doomed decompression attempt on every such node.
         if len(data) < 2:
             return False
-        # Check for ZLIB header (compression method and flags)
-        # First byte: Compression method (8 = deflate)
-        # Second byte: Flags
-        compression_method = data[0] & 0x0F
-        return compression_method == 8  # Deflate compression
+        cmf, flg = data[0], data[1]
+        if cmf & 0x0F != 8:  # CM: 8 = deflate
+            return False
+        if cmf >> 4 > 7:  # CINFO: window size may not exceed 32KB
+            return False
+        # FCHECK: header bytes as a big-endian value must be divisible by 31.
+        return ((cmf << 8) | flg) % 31 == 0
 
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
@@ -709,9 +712,10 @@ class UUDecoder(Decoder):
                     out += binascii.a2b_uu(line)
                 except binascii.Error:
                     # Some encoders strip trailing whitespace; recompute the
-                    # expected byte count from the length char and retry.
-                    nbytes = (((line[0] - 32) & 0x3F) * 4 + 5) // 3
-                    out += binascii.a2b_uu(line[: nbytes + 1])
+                    # expected line length (length char + data chars, same
+                    # formula as CPython's uu module) and retry on that slice.
+                    nchars = (((line[0] - 32) & 0x3F) * 4 + 5) // 3
+                    out += binascii.a2b_uu(line[:nchars])
 
             decoded = bytes(out)
             if decoded:
@@ -836,7 +840,7 @@ class QuotedPrintableDecoder(Decoder):
         try:
             text = data.decode("ascii")
             # Look for typical quoted-printable patterns
-            return "=" in text and re.search(r"=[0-9A-F]{2}", text, re.IGNORECASE)
+            return bool(re.search(r"=[0-9A-F]{2}", text, re.IGNORECASE))
         except Exception:
             return False
 
@@ -871,7 +875,10 @@ class Base32Decoder(Decoder):
             # Base32 uses A-Z and 2-7, typically multiple of 8
             if not re.match(r"^[A-Z2-7=]+$", text):
                 return False
-            if len(text) % 8 != 0 and len(text) % 8 != 7:  # Allow for missing padding
+            # Padded input is a multiple of 8; with padding stripped the only
+            # lengths base32 can produce are 2/4/5/7 (mod 8). The old check
+            # only allowed 0 and 7, rejecting valid unpadded input.
+            if len(text) % 8 not in (0, 2, 4, 5, 7):
                 return False
             return len(text) >= 16  # Need reasonable length
         except Exception:

--- a/titan_decoder/utils/helpers.py
+++ b/titan_decoder/utils/helpers.py
@@ -82,12 +82,14 @@ def looks_like_hex(data: bytes) -> bool:
     """Check if data looks like hex encoded."""
     try:
         text = data.decode("ascii").strip()
-        if len(text) % 2 != 0:
-            return False
-        int(text, 16)
-        return True
-    except Exception:
+    except UnicodeDecodeError:
         return False
+    if not text or len(text) % 2 != 0:
+        return False
+    # Strict hex-digit check. ``int(text, 16)`` also accepts forms unhexlify
+    # rejects ("0x" prefixes, +/- signs, "_" separators), so the decoder was
+    # offered data it could never decode.
+    return bool(re.fullmatch(r"[0-9a-fA-F]+", text))
 
 
 # =========================


### PR DESCRIPTION
## Summary

Full examination of the engine code (`core/engine.py`, decoders, analyzers, scoring, smart detection, resource manager, config) with diagnostics (`pytest`, `--doctor`) and integrity checks (byte-compile, `ruff`, end-to-end decode chains, vault store/search round-trip), followed by full-scale stress testing. Ten bugs found and fixed, each confirmed by reproduction first:

**From the code review (commit 1):**

- **Engine silently decoded nothing off the main thread / on Windows**: every decoder call runs inside a SIGALRM-based `timeout_context`; where SIGALRM is unavailable, `signal.signal` raised and the engine swallowed the per-decoder exception, skipping every decoder and analyzer with no error. Now degrades to unguarded execution (run-level wall-clock deadline and memory bounds still apply).
- **Config-enabled off-by-default decoders had no effect**: `uuencode`/`asn1`/`quoted_printable`/`base32` were constructed with `enabled=True` but never added to `self.decoders`. They are now registered at init.
- **Smart-detection state leaked across runs**: decoders enabled mid-run stayed enabled and stayed in the decoder list for later `run_analysis()` calls on the same engine, making results depend on what was analyzed earlier. State now resets to the configured baseline at the start of each run.
- **ZlibDecoder** matched ~6.5% of random binary data (only checked the low nibble of byte 0); now validates the full RFC 1950 header (CINFO, FCHECK), cutting false triggers to ~0.07% while accepting all real zlib levels.
- **Base32Decoder** rejected valid unpadded inputs with length mod 8 in {2, 4, 5}.
- **UUDecoder** stripped-whitespace retry sliced one char too many vs. CPython's `uu` reference formula.
- **PEAnalyzer** labeled machine type `0x01C4` (ARMNT / ARM Thumb-2) as "ARM64" — a triage-corrupting mislabel.
- **`looks_like_hex`** used `int(text, 16)`, accepting `0x`/sign/underscore forms that `unhexlify` can never decode.
- **QuotedPrintableDecoder.can_decode** returned `Match | None` instead of `bool`; **config** decoder flags now match the real decoder set (add `base64url`/`pem`/`utf16`, drop nonexistent `base85`).

**From stress testing (commit 2):**

- **Text-transform decoders hijacked binary decode chains**: `URLDecoder`, `HTMLEntityDecoder`, and `UnicodeEscapeDecoder` decoded input with `errors="ignore"`, which on binary data silently deletes every non-UTF-8 byte. The mangled output always differed from the input, so the "decode" reported success — and the byte destruction registered as entropy reduction, outscoring the correct decoder (Gzip 0.10 vs URLDecoder 0.22 on a gzip stream containing an accidental `%XX`) and killing the real decode chain. This made ~6% of hard-mode stress runs lose **every** IOC, nondeterministically (ZIP timestamps perturb the compressed stream). These text transports now require valid UTF-8 input before firing. After the fix: 0/600 hard-mode failures across three seeds.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed. (No flag or output contract changes; config decoder keys now match the engine's existing behavior.)
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior. (No new dependencies; the state-reset and text-decoder fixes make results *more* deterministic.)

## Testing

- Command(s) run:

```bash
pytest -q                      # 199 passed (9 new regression tests)
python -m ruff check titan_decoder tests   # clean
python -m compileall titan_decoder tests   # clean
titan-decoder --doctor         # ok: true
python tools/stress_scenario_careless_newbie_bank.py --iterations 200 --profile full --difficulty easy   # 200/200 IOC recovery
python tools/stress_scenario_careless_newbie_bank.py --iterations 200 --profile full --difficulty hard   # 200/200 IOC recovery (was 188/200)
```

- Notes: New tests in `tests/test_engine_hardening_fixes.py` cover each fix: worker-thread analysis, config-enabled optional decoders, cross-run state reset, zlib header validation, base32 unpadded lengths, strict hex detection, the ARMNT PE machine label, text-transform decoders refusing binary input, and a gzip-stream-with-`%XX` chain regression. Also ran an adversarial harness — 800 random/mutation fuzz inputs, gzip/bz2/lzma/zlib/PDF decompression bombs, 10^6-node nested-zip fan-out, 2000-entry ZIP/TAR archives, 1–2MB percent/entity/escape/hex floods, 30-layer base64 chains, determinism checks — all bounded and crash-free (peak RSS 231MB, worst case 10.9s where the per-decode timeout correctly aborted a PDF flate bomb).

## Screenshots / Output (optional)

```
$ pytest -q
199 passed in 10.06s

$ python tools/stress_scenario_careless_newbie_bank.py --iterations 200 --seed 1337 --profile full --difficulty hard
runs=200 avg_s=0.0385 p95_s=0.0432    # 200/200 runs recover planted IOCs

$ titan-decoder --doctor
{"ok": true, "python": "3.11.15", "version": "2.0.1", "schema_version": "1.1", ...}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBD3hFmfRXwL2uZHU2TnhC