### PR TITLE
Release v2.0.2: engine reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## 2.0.2 — Engine reliability fixes (2026-07-02)
+
+Reliability (engine no longer fails silently or nondeterministically):
+
+- Fix silent no-op analysis off the main thread and on Windows: SIGALRM-based
+  per-operation timeouts crashed where SIGALRM is unavailable, and the engine
+  swallowed the per-decoder error — every decoder/analyzer was skipped with no
+  warning. Timeouts now degrade to unguarded execution (the run-level
+  wall-clock deadline and memory bounds still apply).
+- Stop text-transform decoders (URL, HTML-entity, unicode-escape) from
+  hijacking binary decode chains: decoding with `errors="ignore"` silently
+  deleted non-UTF-8 bytes, reported the mangled output as a successful decode,
+  and could outscore the correct decoder (e.g. Gzip), killing the chain and
+  losing every IOC in ~6% of layered payloads. These decoders now require
+  valid UTF-8 input.
+- Reset smart-detection decoder state between `run_analysis()` calls, so
+  results on a reused engine no longer depend on what was analyzed earlier.
+- Register off-by-default decoders (uuencode/asn1/quoted-printable/base32)
+  when enabled via config — previously the config flags had no effect.
+
+Correctness:
+
+- Validate the full RFC 1950 zlib header (CINFO, FCHECK) instead of one
+  nibble, cutting false decode attempts on random binary data from ~6.5% to
+  ~0.07%.
+- Accept all valid unpadded base32 lengths (mod 8 in {0, 2, 4, 5, 7}).
+- Fix the UU decoder's stripped-whitespace retry slicing one character too
+  many (now matches CPython's reference formula).
+- Label PE machine type 0x01C4 as ARM Thumb-2 (ARMNT), not ARM64.
+- Restrict hex detection to strict hex digits (`int(x, 16)` also accepted
+  `0x`/sign/underscore forms that `unhexlify` rejects).
+- Align config decoder flags with the real decoder set (add
+  `base64url`/`pem`/`utf16`; remove nonexistent `base85`) and fix
+  `QuotedPrintableDecoder.can_decode` to return a bool.
+
+Testing:
+
+- 9 new regression tests covering each fix (199 total).
+- Verified with 600 hard-mode stress iterations (100% IOC recovery, was ~94%)
+  plus an adversarial harness: fuzzing, decompression bombs, nested-archive
+  fan-out, flood inputs, and determinism checks — all bounded and crash-free.
+
 ## 2.0.1 — Hardening & correctness (2026-06-30)
 
 Security / DoS resistance (untrusted-input hardening):

--- a/titan_decoder/__init__.py
+++ b/titan_decoder/__init__.py
@@ -1,6 +1,6 @@
 # Titan Decoder Engine
 # A comprehensive payload decoding and analysis framework
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __author__ = "PragmaConflux"
 __description__ = "Advanced payload decoding and analysis engine for cybersecurity"


### PR DESCRIPTION
## Summary

Version bump `2.0.1` → `2.0.2` and CHANGELOG entry for the engine reliability/correctness fixes merged in #79 (silent no-op analysis off the main thread and on Windows, text-transform decoders hijacking binary decode chains, smart-detection state leaks, config decoder registration, and the zlib/base32/hex/UU/PE correctness fixes). No code changes beyond version metadata and the changelog.

Followed `docs/RELEASING.md`: version bumped in `titan_decoder/__init__.py`, tests run, sdist+wheel built and `twine check` passed. The `v2.0.2` tag will be pushed after this merges.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed. (No flag or output contract changes in 2.0.2; CHANGELOG updated.)
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior. (Version metadata + changelog only.)

## Testing

- Command(s) run:

```bash
pytest -q                 # 199 passed
python -m build           # titan_decoder-2.0.2 sdist + wheel built
twine check dist/*        # PASSED (both)
```

- Notes: `titan-decoder --doctor` reports version 2.0.2 after install.

## Screenshots / Output (optional)

```
$ python -m build
Successfully built titan_decoder-2.0.2.tar.gz and titan_decoder-2.0.2-py3-none-any.whl
$ twine check dist/*
Checking dist/titan_decoder-2.0.2-py3-none-any.whl: PASSED
Checking dist/titan_decoder-2.0.2.tar.gz: PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBD3hFmfRXwL2uZHU2TnhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBD3hFmfRXwL2uZHU2TnhC)_