### PR TITLE
docs: rewrite and expand README Credits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,11 +404,34 @@ License: MIT (see LICENSE).
 
 ## 🙏 Credits
 
-Built for the cybersecurity community.
+Titan Decoder Engine is built for — and with — the cybersecurity community: the
+malware analysts, incident responders, digital forensics examiners, and law
+enforcement teams who reverse-engineer hostile payloads every day. Thank you for
+the bug reports, sample submissions, and field feedback that shape each release.
 
-**Key Technologies:**
-- Python 3.10+ (stdlib only for core)
-- Optional: psutil, geoip2, python-whois, yara-python, requests
+**Maintained by** [PragmaConflux](https://github.com/pragmaconflux) and released
+under the [MIT License](LICENSE). Contributions are welcome — see
+[CONTRIBUTING.md](CONTRIBUTING.md) to get started, and please review our
+[Code of Conduct](CODE_OF_CONDUCT.md) and [Security Policy](SECURITY.md).
+
+**Core stack**
+- Python 3.10+ — the decoding engine and all 21 core modules run on the standard
+  library alone, with no external dependencies required.
+
+**Optional integrations** (see [requirements-optional.txt](requirements-optional.txt))
+enable enrichment and advanced analysis features:
+
+| Library | Used for |
+| --- | --- |
+| [psutil](https://github.com/giampaolo/psutil) | Runtime resource governor (per-module CPU/memory limits) |
+| [geoip2](https://github.com/maxmind/GeoIP2-python) | Geolocation enrichment of extracted network IOCs |
+| [python-whois](https://github.com/richardpenman/whois) | Domain registration lookups during IOC enrichment |
+| [yara-python](https://github.com/VirusTotal/yara-python) | Signature-based detection over decoded payloads |
+| [requests](https://github.com/psf/requests) | Optional network-backed enrichment lookups |
+| [PyYAML](https://github.com/yaml/pyyaml) | Loading detection rule packs and configuration |
+
+Gratitude to the maintainers of these projects and to the broader open-source
+security ecosystem their work makes possible.
 
 ---
 


### PR DESCRIPTION
## Summary

Fleshes out the sparse README **Credits** section and fixes a documentation inconsistency.

- Expanded "Built for the cybersecurity community" into a proper community acknowledgement (analysts, IR, forensics, LE).
- Added attribution: maintainer (PragmaConflux), MIT license, and pointers to `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md`.
- Clarified the core stack (21 core modules run on the stdlib alone, no external deps).
- Added a third-party credits table linking each optional library to its project and stating what it's used for.
- **Fix:** the old "Key Technologies" list omitted `PyYAML`, which is present in `requirements-optional.txt`; the list now matches.

Docs-only change — no code, flags, or output contracts affected.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [ ] I ran tests locally (`pytest -q`) or explain why not. — _Docs-only change (README.md); no code paths affected._
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

Not run — this PR only edits `README.md` and touches no code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDN3tXRdSbE1adKoRn6ERB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDN3tXRdSbE1adKoRn6ERB)_