### PR TITLE
Make the sdist byte-reproducible via post-build tar normalization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,13 @@ jobs:
 
       - name: Reproducible build
         # Pin SOURCE_DATE_EPOCH to the tagged commit time for byte-reproducible
-        # sdist/wheel artifacts.
+        # sdist/wheel artifacts. bdist_wheel honors it natively; the sdist does
+        # not (setuptools embeds filesystem mtimes), so it is normalized by
+        # tools/repack_sdist.py after the build.
         run: |
           export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
           python -m build
+          python tools/repack_sdist.py dist/*.tar.gz
 
       - name: Sign artifacts (Sigstore, keyless)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+Reproducible builds:
+
+- Make the sdist byte-reproducible. `bdist_wheel` honors `SOURCE_DATE_EPOCH`
+  but setuptools stores sdist tar members with filesystem mtimes, so every
+  build differed. New `tools/repack_sdist.py` normalizes the tarball (member
+  mtimes to `SOURCE_DATE_EPOCH`, ownership/modes, member order, gzip
+  timestamp) with a content-preservation self-check, and the release workflow
+  runs it after `python -m build`.
+
 Audit cleanup (post-roadmap):
 
 - Tolerate trailing bytes after a complete gzip/bz2/zlib/xz stream: zero

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -27,8 +27,21 @@ The distribution is built with `SOURCE_DATE_EPOCH` pinned so the sdist/wheel are
 byte-reproducible across build hosts:
 
 ```bash
-SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) python -m build
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+python -m build
+python tools/repack_sdist.py dist/*.tar.gz
 ```
+
+The wheel is reproducible from `python -m build` alone — `bdist_wheel` honors
+`SOURCE_DATE_EPOCH`. The sdist is not: setuptools stores each tar member with
+its **filesystem** mtime (at sub-second precision), which encodes the moment
+the build host checked out or generated the file. The
+[`tools/repack_sdist.py`](../tools/repack_sdist.py) step erases exactly that
+variance — member mtimes set to `SOURCE_DATE_EPOCH`, ownership and modes
+normalized, members sorted, gzip timestamp zeroed — while verifying the file
+contents are preserved byte-for-byte. The release workflow runs the same step,
+so an independent builder running the three commands above gets the published
+artifacts.
 
 Because the core has no compiled extensions and no runtime dependencies, a
 reproducible build is achievable end-to-end: two independent builders producing

--- a/tests/test_repack_sdist.py
+++ b/tests/test_repack_sdist.py
@@ -1,0 +1,126 @@
+"""Reproducible-sdist repack tests (tools/repack_sdist.py).
+
+setuptools writes sdist tar members with filesystem mtimes, so two otherwise
+identical builds differ. The repack tool must erase exactly that variance —
+and nothing else: contents byte-identical, unsupported members refused.
+"""
+
+import io
+import os
+import sys
+import tarfile
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from tools.repack_sdist import repack, repack_bytes, _read_members  # noqa: E402
+
+EPOCH = 1700000000
+
+
+def _make_sdist(path, mtime, order=None):
+    """Simulate a setuptools sdist: PAX format, float mtimes, root/root."""
+    files = {
+        "pkg-1.0/PKG-INFO": b"Metadata-Version: 2.4\nName: pkg\n",
+        "pkg-1.0/pkg/__init__.py": b"__version__ = '1.0'\n",
+        "pkg-1.0/setup.cfg": b"[metadata]\n",
+    }
+    names = order or sorted(files)
+    with tarfile.open(path, "w:gz", format=tarfile.PAX_FORMAT) as tf:
+        dirinfo = tarfile.TarInfo("pkg-1.0/")
+        dirinfo.type = tarfile.DIRTYPE
+        dirinfo.mode = 0o755
+        dirinfo.mtime = mtime
+        tf.addfile(dirinfo)
+        for name in names:
+            info = tarfile.TarInfo(name)
+            info.size = len(files[name])
+            info.mtime = mtime
+            tf.addfile(info, io.BytesIO(files[name]))
+    return files
+
+
+def test_two_builds_repack_byte_identical(tmp_path):
+    """Different build times and member order must converge to one byte string."""
+    a, b = tmp_path / "a.tar.gz", tmp_path / "b.tar.gz"
+    _make_sdist(a, mtime=1750000000.1234567)
+    _make_sdist(
+        b,
+        mtime=1760000000.7654321,
+        order=[
+            "pkg-1.0/setup.cfg",
+            "pkg-1.0/PKG-INFO",
+            "pkg-1.0/pkg/__init__.py",
+        ],
+    )
+    assert a.read_bytes() != b.read_bytes()
+
+    repack(str(a), EPOCH)
+    repack(str(b), EPOCH)
+    assert a.read_bytes() == b.read_bytes()
+
+
+def test_repack_is_idempotent_and_preserves_contents(tmp_path):
+    path = tmp_path / "s.tar.gz"
+    files = _make_sdist(path, mtime=1750000000.5)
+
+    repack(str(path), EPOCH)
+    first = path.read_bytes()
+    repack(str(path), EPOCH)
+    assert path.read_bytes() == first
+
+    with tarfile.open(path, "r:gz") as tf:
+        for name, data in files.items():
+            assert tf.extractfile(name).read() == data
+
+
+def test_metadata_normalized(tmp_path):
+    path = tmp_path / "s.tar.gz"
+    _make_sdist(path, mtime=1750000000.5)
+    repack(str(path), EPOCH)
+
+    # gzip container: mtime field zeroed (bytes 4-8 of the header).
+    raw = path.read_bytes()
+    assert raw[4:8] == b"\x00\x00\x00\x00"
+
+    with tarfile.open(path, "r:gz") as tf:
+        members = tf.getmembers()
+        assert [m.name for m in members] == sorted(m.name for m in members)
+        for m in members:
+            assert m.mtime == EPOCH
+            assert (m.uid, m.gid, m.uname, m.gname) == (0, 0, "root", "root")
+            assert m.mode == (0o755 if m.isdir() else 0o644)
+
+
+def test_refuses_unsupported_member_types(tmp_path):
+    path = tmp_path / "s.tar.gz"
+    with tarfile.open(path, "w:gz") as tf:
+        link = tarfile.TarInfo("pkg-1.0/evil")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        tf.addfile(link)
+    with pytest.raises(ValueError, match="unsupported member type"):
+        repack(str(path), EPOCH)
+
+
+def test_verify_catches_content_corruption(tmp_path, monkeypatch):
+    """The self-check must fail closed if the rewrite ever altered contents."""
+    path = tmp_path / "s.tar.gz"
+    _make_sdist(path, mtime=1750000000.5)
+    members = _read_members(str(path))
+    original = path.read_bytes()
+
+    corrupted = [
+        (info, data.replace(b"1.0", b"6.6") if data else data)
+        for info, data in members
+    ]
+    monkeypatch.setattr(
+        "tools.repack_sdist.repack_bytes",
+        lambda _members, epoch: repack_bytes(corrupted, epoch),
+    )
+    with pytest.raises(RuntimeError, match="does not match original"):
+        repack(str(path), EPOCH)
+    assert path.read_bytes() == original  # file left untouched

--- a/tools/repack_sdist.py
+++ b/tools/repack_sdist.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Deterministically repack an sdist tarball for reproducible builds.
+
+The supply-chain contract (docs/SUPPLY_CHAIN.md) is that two independent
+builders produce byte-identical artifacts. The wheel already holds: bdist_wheel
+honors SOURCE_DATE_EPOCH. The sdist does not — setuptools writes each tar
+member with its *filesystem* mtime (at sub-second precision, via PAX records),
+which encodes the moment the build host checked out or generated the file, so
+every build differs.
+
+This tool rewrites an sdist tar.gz with normalized metadata:
+
+- member mtimes set to SOURCE_DATE_EPOCH (integer seconds, so no float PAX
+  mtime records are emitted)
+- uid/gid 0 and uname/gname "root" (setuptools' own convention)
+- mode 0755 for directories and owner-executable files, 0644 otherwise
+- members sorted by path
+- gzip container written with mtime=0 and no embedded filename
+
+File contents are preserved exactly: the repack verifies the rewritten
+archive against the original member-for-member and refuses to replace the
+file on any mismatch.
+
+Usage:
+
+    SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \\
+        python tools/repack_sdist.py dist/*.tar.gz
+
+If SOURCE_DATE_EPOCH is unset, the last git commit time is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import os
+import subprocess
+import sys
+import tarfile
+
+
+def source_date_epoch() -> int:
+    env = os.environ.get("SOURCE_DATE_EPOCH")
+    if env is not None:
+        return int(env)
+    out = subprocess.run(
+        ["git", "log", "-1", "--pretty=%ct"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    return int(out.stdout.strip())
+
+
+def _read_members(path: str) -> list[tuple[tarfile.TarInfo, bytes | None]]:
+    members: list[tuple[tarfile.TarInfo, bytes | None]] = []
+    with tarfile.open(path, "r:gz") as tf:
+        for info in tf.getmembers():
+            if info.isreg():
+                fobj = tf.extractfile(info)
+                assert fobj is not None
+                members.append((info, fobj.read()))
+            elif info.isdir():
+                members.append((info, None))
+            else:
+                raise ValueError(
+                    f"{path}: unsupported member type {info.type!r} for "
+                    f"{info.name!r}; refusing to repack"
+                )
+    return members
+
+
+def repack_bytes(
+    members: list[tuple[tarfile.TarInfo, bytes | None]], epoch: int
+) -> bytes:
+    """Serialize members into a deterministic tar.gz byte string."""
+    tar_buf = io.BytesIO()
+    with tarfile.open(fileobj=tar_buf, mode="w", format=tarfile.PAX_FORMAT) as tf:
+        for info, data in sorted(members, key=lambda m: m[0].name):
+            norm = tarfile.TarInfo(info.name)
+            norm.type = info.type
+            norm.size = info.size
+            norm.mtime = epoch
+            norm.uid = norm.gid = 0
+            norm.uname = norm.gname = "root"
+            executable = info.isdir() or (info.mode & 0o100)
+            norm.mode = 0o755 if executable else 0o644
+            tf.addfile(norm, io.BytesIO(data) if data is not None else None)
+
+    gz_buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=gz_buf, mode="wb", compresslevel=9, mtime=0) as gz:
+        gz.write(tar_buf.getvalue())
+    return gz_buf.getvalue()
+
+
+def _verify(original: list[tuple[tarfile.TarInfo, bytes | None]], new: bytes) -> None:
+    rewritten: dict[str, bytes | None] = {}
+    with tarfile.open(fileobj=io.BytesIO(new), mode="r:gz") as tf:
+        for info in tf.getmembers():
+            fobj = tf.extractfile(info) if info.isreg() else None
+            rewritten[info.name] = fobj.read() if fobj is not None else None
+    expected = {info.name: data for info, data in original}
+    if rewritten != expected:
+        raise RuntimeError("repacked archive does not match original contents")
+
+
+def repack(path: str, epoch: int) -> tuple[str, str]:
+    """Rewrite *path* in place; returns (old_sha256, new_sha256)."""
+    with open(path, "rb") as f:
+        old_digest = hashlib.sha256(f.read()).hexdigest()
+
+    members = _read_members(path)
+    new_bytes = repack_bytes(members, epoch)
+    _verify(members, new_bytes)
+
+    tmp = path + ".repack.tmp"
+    with open(tmp, "wb") as f:
+        f.write(new_bytes)
+    os.replace(tmp, path)
+    return old_digest, hashlib.sha256(new_bytes).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("paths", nargs="+", help="sdist .tar.gz file(s) to repack")
+    parser.add_argument(
+        "--epoch",
+        type=int,
+        default=None,
+        help="timestamp override (default: $SOURCE_DATE_EPOCH, else last commit time)",
+    )
+    args = parser.parse_args(argv)
+
+    epoch = args.epoch if args.epoch is not None else source_date_epoch()
+    for path in args.paths:
+        old, new = repack(path, epoch)
+        status = "unchanged" if old == new else "normalized"
+        print(f"{path}: {status}\n  sha256 {new}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

An integrity check of the supply-chain pipeline found that the sdist is not byte-reproducible: `bdist_wheel` honors `SOURCE_DATE_EPOCH`, but setuptools stores sdist tar members with **filesystem** mtimes (sub-second precision, via PAX records), so two otherwise identical builds always differ. That breaks the promise in `docs/SUPPLY_CHAIN.md` that independent builders can verify published artifacts by rebuilding them — it held for the wheel only.

This PR adds `tools/repack_sdist.py`, a deterministic post-build normalizer:

- member mtimes set to `SOURCE_DATE_EPOCH` (integer seconds — no float PAX mtime records)
- uid/gid 0, uname/gname `root`, modes 0755/0644
- members sorted by path; gzip container written with `mtime=0` and no embedded filename
- fails closed: verifies member-for-member that contents are preserved, and refuses archives with unexpected member types (e.g. symlinks)

The release workflow now runs it right after `python -m build`, and `docs/SUPPLY_CHAIN.md` documents the exact commands an independent builder needs.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`).
- [x] I updated docs if flags/output contracts changed (SUPPLY_CHAIN.md, CHANGELOG; no runtime flag/output changes).
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior (stdlib-only tool; strictly increases determinism).

## Testing

- Command(s) run:

```bash
pytest -q                    # 350 passed (5 new in tests/test_repack_sdist.py)
ruff check .                 # clean
mypy titan_decoder tools/repack_sdist.py   # clean
SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) python -m build   # run twice
python tools/repack_sdist.py dist/*.tar.gz
```

- Notes: two independent builds of the same tree now produce byte-identical sdists after the repack (previously every build differed); wheel hashes unchanged and still identical. The repacked sdist installs via pip and `titan-decoder --doctor` reports `ok: true` from it. New tests cover convergence of two differing builds, idempotence, content preservation, metadata normalization (including the zeroed gzip timestamp), refusal of unsupported member types, and the fail-closed self-check.

## Screenshots / Output (optional)

```
# before: sdists differed every build      # after repack: byte-identical
build1  6a373482…  titan_decoder-2.0.2.tar.gz
build2  3a1f81a4…  titan_decoder-2.0.2.tar.gz
        ↓
build1  e0cc4a5b…  titan_decoder-2.0.2.tar.gz
build2  e0cc4a5b…  titan_decoder-2.0.2.tar.gz
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThQ16mXCFfsQpP3Ph1FouK

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThQ16mXCFfsQpP3Ph1FouK)_