### PR TITLE
Add interactive menu-driven UI ('titan' command)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+Interactive UI:
+
+- Add a menu-driven interactive console, launched with the new `titan` command
+  (or `titan-decoder --interactive` / `-i`). Instead of memorizing CLI flags,
+  users get a menu to auto-detect & fully decode a payload, or pick a specific
+  decoder (Base64, Hex, XOR, Gzip, ROT13, URL, UTF-16, …) and feed it typed
+  text, a hex string, or a file. It's a thin, stdlib-only presentation layer
+  over the same engine and decoders the `titan-decoder` CLI drives — no analysis
+  logic is duplicated. Results render as decoded text or a hexdump, and
+  auto-detect shows the recursive decode tree plus extracted IOCs. New
+  `titan_decoder/interactive.py` module with unit tests that drive the loop via
+  injected I/O (no real TTY required).
+
 Reproducible builds:
 
 - Make the sdist byte-reproducible. `bdist_wheel` honors `SOURCE_DATE_EPOCH`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,25 @@ pip install -e .
 pip install -e '.[enrichment]'
 ```
 
-### 2. Analyze Your First File
+### 2. Try the interactive UI (no flags to memorize)
+
+Prefer a menu over command-line flags? Just run:
+
+```bash
+titan
+```
+
+This launches an interactive console where you can:
+
+- **Auto-detect & decode** — paste a payload (or point at a file) and let the
+  full engine recursively decode it and extract IOCs, or
+- **Choose a specific decoder** — pick Base64, Hex, XOR, Gzip, ROT13, URL, and
+  more from a menu, then feed it text, a hex string, or a file.
+
+It's the same engine and decoders the `titan-decoder` CLI uses, just menu-driven.
+(You can also reach it via `titan-decoder --interactive` / `-i`.)
+
+### 3. Analyze Your First File (scriptable CLI)
 
 ```bash
 # Quick analysis
@@ -55,7 +73,7 @@ titan-decoder --file suspicious.bin --out report.json \\
     --evidence firewall:/path/flows.csv
 ```
 
-### 3. View Results
+### 4. View Results
 
 ```bash
 # Check the report (no jq required)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ Source = "https://github.com/pragmaconflux/titan1"
 Issues = "https://github.com/pragmaconflux/titan1/issues"
 
 [project.scripts]
+titan = "titan_decoder.interactive:main"
 titan-decoder = "titan_decoder.cli:main"
 
 # Keep these lists in sync with requirements-dev.txt / requirements-optional.txt.

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,132 @@
+"""Tests for the interactive menu-driven UI (``titan`` command).
+
+The UI is a thin presentation layer over the engine/decoders, so these tests
+drive the loop with injected input/output streams (no real TTY) and assert the
+observable behavior: the right decoder runs, results render, and bad input is
+handled without crashing the loop.
+"""
+
+import base64
+import io
+
+from titan_decoder.interactive import (
+    InteractiveApp,
+    Style,
+    build_decoder_registry,
+    format_decode_result,
+    _hexdump,
+)
+
+
+def _run(script):
+    """Drive the app with a scripted list of input lines; return stdout text."""
+    it = iter(script)
+
+    def fake_input(prompt=""):
+        return next(it)
+
+    out = io.StringIO()
+    app = InteractiveApp(input_fn=fake_input, out=out, style=Style(False))
+    rc = app.run()
+    return rc, out.getvalue()
+
+
+def test_registry_has_expected_decoders():
+    reg = build_decoder_registry()
+    keys = {c.key for c in reg}
+    # A representative spread across the decoder families.
+    for expected in ("base64", "hex", "url", "rot13", "xor", "gzip", "utf16"):
+        assert expected in keys
+    # Every entry's factory yields a working decoder instance.
+    for choice in reg:
+        dec = choice.factory()
+        assert hasattr(dec, "decode")
+        assert dec.name
+
+
+def test_specific_decoder_base64_roundtrip():
+    payload = base64.b64encode(b"Hello Titan!").decode()
+    # menu=2 (pick decoder), decoder=1 (Base64), input=1 (text), payload, quit
+    rc, text = _run(["2", "1", "1", payload, "q"])
+    assert rc == 0
+    assert "Decoded with Base64" in text
+    assert "Hello Titan!" in text
+
+
+def test_specific_decoder_reports_failure_cleanly():
+    # Base64 decoder on clearly non-base64 bytes should report a clean failure,
+    # not raise or exit the loop.
+    rc, text = _run(["2", "1", "1", "!!! not base64 !!!", "q"])
+    assert rc == 0
+    assert "could not decode" in text
+
+
+def test_hex_input_mode():
+    # Hex *input mode* (2) turns "48656c6c6f" into b"Hello", then we ROT13 it.
+    rc, text = _run(["2", "1", "2", "48656c6c6f", "q"])  # Base64 on b"Hello"
+    assert rc == 0
+    # b"Hello" is not valid base64 padding-wise -> clean failure is fine; the
+    # point is the hex input mode parsed without crashing.
+    assert "Base64" in text
+
+
+def test_hex_input_mode_rejects_bad_hex():
+    rc, text = _run(["2", "5", "2", "zzzz", "q"])  # Hex decoder, bad hex input
+    assert rc == 0
+    assert "Not valid hex" in text
+
+
+def test_auto_detect_extracts_iocs():
+    payload = base64.b64encode(b"beacon to http://evil.example.com/c2").decode()
+    rc, text = _run(["1", "1", payload, "q"])  # auto-detect, text input
+    assert rc == 0
+    assert "Auto-analysis complete" in text
+    assert "evil.example.com" in text
+
+
+def test_list_decoders_action():
+    rc, text = _run(["3", "q"])
+    assert rc == 0
+    assert "decoders available" in text
+    assert "Base64" in text
+
+
+def test_options_change_profile():
+    # Open options, set profile to full, back, then quit; the menu should now
+    # reflect the new profile.
+    rc, text = _run(["4", "1", "full", "b", "q"])
+    assert rc == 0
+    assert "profile=full" in text
+
+
+def test_eof_quits_gracefully():
+    # A StopIteration from the scripted input surfaces as EOFError-like; feed a
+    # real EOF by exhausting the script mid-prompt.
+    def eof_input(prompt=""):
+        raise EOFError
+
+    out = io.StringIO()
+    app = InteractiveApp(input_fn=eof_input, out=out, style=Style(False))
+    assert app.run() == 0
+    assert "Bye." in out.getvalue()
+
+
+def test_hexdump_format():
+    dump = _hexdump(b"ABC\x00\xff")
+    assert "00000000" in dump
+    assert "41 42 43 00 ff" in dump
+    # Printable ASCII shown, non-printable as dots.
+    assert "ABC.." in dump
+
+
+def test_format_decode_result_binary_uses_hexdump():
+    st = Style(False)
+    out = format_decode_result(st, "Gzip", 10, b"\x00\x01\x02\x03\xff\xfe", True)
+    assert "hexdump" in out.lower()
+
+
+def test_style_disabled_has_no_ansi():
+    st = Style(False)
+    assert st.red("x") == "x"
+    st2 = Style(True)
+    assert "\033[" in st2.red("x")

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -26,6 +26,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="version",
         version=f"titan-decoder {TITAN_VERSION}",
     )
+    parser.add_argument(
+        "--interactive",
+        "-i",
+        action="store_true",
+        help="Launch the interactive menu-driven UI (same as the 'titan' command)",
+    )
     parser.add_argument("--file", "-f", type=Path, help="Input file to analyze")
     parser.add_argument(
         "--batch", type=Path, help="Directory containing files to analyze in batch mode"
@@ -1008,6 +1014,13 @@ def main():
     evidence-before-analysis ordering — testable at the stage level.
     """
     args = build_parser().parse_args()
+
+    # Interactive UI: hand off to the menu-driven front end and exit. Kept as an
+    # early branch so none of the analysis-oriented argument validation runs.
+    if args.interactive:
+        from .interactive import main as interactive_main
+
+        sys.exit(interactive_main())
 
     # Note: no custom SIGINT handler here. Python's default KeyboardInterrupt is
     # the abort mechanism (caught around the analysis calls); a custom handler

--- a/titan_decoder/interactive.py
+++ b/titan_decoder/interactive.py
@@ -1,0 +1,528 @@
+#!/usr/bin/env python3
+"""Interactive, menu-driven front end for the Titan Decoder engine.
+
+This is the friendly "just run ``titan``" experience: instead of remembering
+CLI flags, the user gets a menu where they can pick a decoder (or let the engine
+auto-detect), paste a test payload or point at a file, and see the decoded
+result. It is a thin presentation layer over the exact same engine and decoders
+the ``titan-decoder`` CLI drives — no analysis logic lives here.
+
+Kept dependency-light (stdlib only) and structured so the pure pieces (the
+decoder registry, result formatting) are unit-testable without a real TTY, and
+the loop can be driven with injected input/output streams.
+"""
+
+from __future__ import annotations
+
+import binascii
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+from . import __version__ as TITAN_VERSION
+from .config import Config
+from .core.engine import TitanEngine
+from .decoders.base import (
+    ASN1Decoder,
+    Base32Decoder,
+    Base64Decoder,
+    Base64UrlDecoder,
+    Bz2Decoder,
+    Decoder,
+    GzipDecoder,
+    HexDecoder,
+    HTMLEntityDecoder,
+    LzmaDecoder,
+    OLEDecoder,
+    PDFDecoder,
+    PemArmorDecoder,
+    QuotedPrintableDecoder,
+    RecursiveBase64Decoder,
+    Rot13Decoder,
+    URLDecoder,
+    UnicodeEscapeDecoder,
+    Utf16Decoder,
+    UUDecoder,
+    XorDecoder,
+    ZlibDecoder,
+)
+from .utils.helpers import entropy, looks_like_text, sha256
+
+# ---------------------------------------------------------------------------
+# Terminal styling (ANSI, auto-disabled when not a TTY or NO_COLOR is set)
+# ---------------------------------------------------------------------------
+
+
+class Style:
+    """Tiny ANSI colour helper. Colours collapse to empty strings when the
+    output is not an interactive terminal, or when ``NO_COLOR`` is set, so piped
+    output stays clean."""
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+
+    def _wrap(self, code: str, text: str) -> str:
+        if not self.enabled:
+            return text
+        return f"\033[{code}m{text}\033[0m"
+
+    def bold(self, t: str) -> str:
+        return self._wrap("1", t)
+
+    def dim(self, t: str) -> str:
+        return self._wrap("2", t)
+
+    def cyan(self, t: str) -> str:
+        return self._wrap("36", t)
+
+    def green(self, t: str) -> str:
+        return self._wrap("32", t)
+
+    def yellow(self, t: str) -> str:
+        return self._wrap("33", t)
+
+    def red(self, t: str) -> str:
+        return self._wrap("31", t)
+
+    def magenta(self, t: str) -> str:
+        return self._wrap("35", t)
+
+
+def _color_enabled(stream) -> bool:
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("TITAN_NO_COLOR") is not None:
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+# ---------------------------------------------------------------------------
+# Decoder registry
+# ---------------------------------------------------------------------------
+
+# Reasonable cap for the one-shot single-decoder decompressors so a hostile
+# "zip bomb" test payload can't exhaust memory in the interactive UI.
+_MAX_DECOMPRESSED = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class DecoderChoice:
+    """A user-selectable decoder plus a short human description."""
+
+    key: str
+    label: str
+    description: str
+    factory: Callable[[], Decoder]
+
+
+def build_decoder_registry() -> List[DecoderChoice]:
+    """Return every decoder the user can pick by hand, in a friendly order.
+
+    Optional decoders that ship disabled-by-default in the engine (they are
+    normally only switched on by smart-detection) are constructed with
+    ``enabled=True`` here, because the user is explicitly asking for them.
+    """
+    return [
+        DecoderChoice("base64", "Base64", "Standard Base64 (handles line wrapping)", Base64Decoder),
+        DecoderChoice(
+            "recursive_base64",
+            "Recursive Base64",
+            "Repeatedly Base64-decode nested layers",
+            RecursiveBase64Decoder,
+        ),
+        DecoderChoice("base64url", "Base64 URL-safe", "URL/filename-safe Base64 alphabet", Base64UrlDecoder),
+        DecoderChoice("base32", "Base32", "RFC 4648 Base32", lambda: Base32Decoder(enabled=True)),
+        DecoderChoice("hex", "Hex", "Hexadecimal (e.g. 48656c6c6f)", HexDecoder),
+        DecoderChoice("url", "URL / percent", "URL percent-encoding (%20 etc.)", URLDecoder),
+        DecoderChoice("html_entity", "HTML entities", "HTML entities (&amp; &#65; ...)", HTMLEntityDecoder),
+        DecoderChoice(
+            "unicode_escape",
+            "Unicode escape",
+            r"\uXXXX / \xXX escape sequences",
+            UnicodeEscapeDecoder,
+        ),
+        DecoderChoice("utf16", "UTF-16", "UTF-16 text (with or without BOM)", Utf16Decoder),
+        DecoderChoice("rot13", "ROT13", "Caesar/ROT13 letter rotation", Rot13Decoder),
+        DecoderChoice("xor", "XOR (auto-key)", "Recover single/repeating-key XOR", XorDecoder),
+        DecoderChoice(
+            "quoted_printable",
+            "Quoted-Printable",
+            "MIME Quoted-Printable (=3D ...)",
+            lambda: QuotedPrintableDecoder(enabled=True),
+        ),
+        DecoderChoice("uuencode", "UUencode", "Classic uuencoded data", lambda: UUDecoder(enabled=True)),
+        DecoderChoice("pem", "PEM armor", "Strip PEM ----BEGIN----/----END---- armor", PemArmorDecoder),
+        DecoderChoice("gzip", "Gzip", "Gzip-compressed data", lambda: GzipDecoder(_MAX_DECOMPRESSED)),
+        DecoderChoice("zlib", "Zlib", "Zlib/deflate-compressed data", lambda: ZlibDecoder(_MAX_DECOMPRESSED)),
+        DecoderChoice("bz2", "Bzip2", "Bzip2-compressed data", lambda: Bz2Decoder(_MAX_DECOMPRESSED)),
+        DecoderChoice("lzma", "LZMA / XZ", "LZMA/XZ-compressed data", lambda: LzmaDecoder(_MAX_DECOMPRESSED)),
+        DecoderChoice("pdf", "PDF streams", "Extract/inflate PDF object streams", lambda: PDFDecoder(_MAX_DECOMPRESSED)),
+        DecoderChoice("ole", "OLE / CFB", "Parse OLE/CFB (legacy Office) streams", lambda: OLEDecoder(_MAX_DECOMPRESSED)),
+        DecoderChoice("asn1", "ASN.1 / DER", "Parse ASN.1 DER structures", lambda: ASN1Decoder(enabled=True)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Result formatting (pure — no I/O)
+# ---------------------------------------------------------------------------
+
+
+def _printable_ratio(data: bytes) -> float:
+    if not data:
+        return 0.0
+    printable = sum(1 for b in data if 0x20 <= b <= 0x7E or b in (0x09, 0x0A, 0x0D))
+    return printable / len(data)
+
+
+def _hexdump(data: bytes, max_bytes: int = 256) -> str:
+    """Classic offset / hex / ASCII hexdump of the first ``max_bytes`` bytes."""
+    out = []
+    view = data[:max_bytes]
+    for off in range(0, len(view), 16):
+        chunk = view[off : off + 16]
+        hex_part = " ".join(f"{b:02x}" for b in chunk)
+        hex_part = f"{hex_part:<47}"
+        ascii_part = "".join(chr(b) if 0x20 <= b <= 0x7E else "." for b in chunk)
+        out.append(f"  {off:08x}  {hex_part}  {ascii_part}")
+    if len(data) > max_bytes:
+        out.append(f"  ... ({len(data) - max_bytes} more bytes)")
+    return "\n".join(out)
+
+
+def format_decode_result(
+    st: Style, decoder_label: str, source_len: int, decoded: bytes, success: bool
+) -> str:
+    """Render a single-decoder result as a printable block."""
+    lines: List[str] = []
+    if not success or decoded is None:
+        lines.append(st.red(f"✗ {decoder_label} could not decode this input."))
+        lines.append(st.dim("  The bytes don't look like this format, or decoding failed."))
+        return "\n".join(lines)
+
+    is_text = looks_like_text(decoded)
+    lines.append(st.green(f"✓ Decoded with {decoder_label}"))
+    lines.append(
+        st.dim(
+            f"  {source_len} byte(s) in → {len(decoded)} byte(s) out"
+            f"   |  entropy {entropy(decoded):.2f}"
+            f"   |  sha256 {sha256(decoded)[:16]}…"
+        )
+    )
+    lines.append("")
+    if is_text or _printable_ratio(decoded) >= 0.85:
+        text = decoded.decode("utf-8", errors="replace")
+        preview = text if len(text) <= 4000 else text[:4000] + "\n… (truncated)"
+        lines.append(st.bold("  Decoded text:"))
+        for ln in preview.splitlines() or [""]:
+            lines.append("    " + ln)
+    else:
+        lines.append(st.bold("  Decoded bytes (hexdump):"))
+        lines.append(_hexdump(decoded))
+    return "\n".join(lines)
+
+
+def format_engine_summary(st: Style, report: dict) -> str:
+    """Render the auto-detect (full-engine) report as a readable summary."""
+    lines: List[str] = []
+    nodes = report.get("nodes", []) or []
+    lines.append(st.green(f"✓ Auto-analysis complete — {len(nodes)} node(s) in the decode tree"))
+    lines.append("")
+
+    # Decode tree: indent by depth, show the method that produced each node.
+    lines.append(st.bold("  Decode tree:"))
+    for node in nodes:
+        depth = int(node.get("depth", 0) or 0)
+        indent = "    " + "  " * depth
+        method = node.get("method") or "input"
+        ctype = node.get("content_type", "?")
+        dlen = node.get("decoded_length", node.get("source_length", 0))
+        marker = "•" if depth else "▸"
+        head = f"{indent}{marker} {st.cyan(method)}  {st.dim(f'[{ctype}, {dlen}B]')}"
+        lines.append(head)
+        preview = (node.get("content_preview") or "").strip()
+        if preview:
+            snippet = preview.replace("\n", " ")
+            if len(snippet) > 88:
+                snippet = snippet[:88] + "…"
+            lines.append(f"{indent}    {st.dim(snippet)}")
+
+    # IOCs, if any surfaced.
+    iocs = report.get("iocs", {}) or {}
+    total_iocs = sum(len(v) for v in iocs.values() if isinstance(v, list))
+    if total_iocs:
+        lines.append("")
+        lines.append(st.bold(f"  Indicators found ({total_iocs}):"))
+        for kind, values in sorted(iocs.items()):
+            if not values:
+                continue
+            shown = ", ".join(str(v) for v in values[:5])
+            more = f" (+{len(values) - 5} more)" if len(values) > 5 else ""
+            lines.append(f"    {st.yellow(kind)}: {shown}{more}")
+    else:
+        lines.append("")
+        lines.append(st.dim("  No indicators (URLs/IPs/hashes/…) extracted."))
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Interactive application
+# ---------------------------------------------------------------------------
+
+
+class InteractiveApp:
+    """The menu loop. I/O is injectable so the whole thing is testable."""
+
+    def __init__(
+        self,
+        input_fn: Callable[[str], str] = input,
+        out=None,
+        style: Optional[Style] = None,
+        config: Optional[Config] = None,
+    ):
+        self.input_fn = input_fn
+        self.out = out or sys.stdout
+        self.st = style if style is not None else Style(_color_enabled(self.out))
+        self.config = config or Config()
+        self.registry = build_decoder_registry()
+        # Session options.
+        self.profile: str = "fast"  # safe | fast | full
+        self.offline: bool = True
+
+    # -- low-level I/O helpers ---------------------------------------------
+
+    def _print(self, *parts: str) -> None:
+        print(*parts, file=self.out)
+
+    def _ask(self, prompt: str) -> str:
+        """Prompt for a line of input. EOF is treated as 'quit'."""
+        try:
+            return self.input_fn(prompt)
+        except EOFError:
+            raise _QuitSignal()
+
+    # -- payload acquisition ------------------------------------------------
+
+    def _read_payload(self) -> Optional[Tuple[bytes, int]]:
+        """Ask the user for input and return ``(data, source_len)`` or ``None``.
+
+        Offers three input styles: typed text, a hex string (handy for binary
+        test vectors), or a file path.
+        """
+        self._print()
+        self._print(self.st.bold("  How do you want to provide the input?"))
+        self._print("    [1] Type/paste text")
+        self._print("    [2] Enter a hex string (e.g. 48656c6c6f)")
+        self._print("    [3] Load from a file")
+        self._print("    [b] Back")
+        choice = self._ask(self.st.cyan("  input> ")).strip().lower()
+
+        if choice in ("b", "back", ""):
+            return None
+
+        if choice == "1":
+            raw = self._ask("  Text: ")
+            data = raw.encode("utf-8")
+            return data, len(data)
+
+        if choice == "2":
+            raw = self._ask("  Hex: ").strip().replace(" ", "").replace("\n", "")
+            try:
+                data = binascii.unhexlify(raw)
+            except (binascii.Error, ValueError) as e:
+                self._print(self.st.red(f"  Not valid hex: {e}"))
+                return None
+            return data, len(data)
+
+        if choice == "3":
+            path_s = self._ask("  File path: ").strip()
+            # Allow surrounding quotes pasted from a file manager / shell.
+            path_s = path_s.strip("'\"")
+            path = Path(os.path.expanduser(path_s))
+            if not path.exists() or not path.is_file():
+                self._print(self.st.red(f"  File not found: {path}"))
+                return None
+            try:
+                data = path.read_bytes()
+            except OSError as e:
+                self._print(self.st.red(f"  Could not read file: {e}"))
+                return None
+            if not data:
+                self._print(self.st.red("  File is empty."))
+                return None
+            return data, len(data)
+
+        self._print(self.st.red("  Unknown choice."))
+        return None
+
+    # -- menu actions -------------------------------------------------------
+
+    def _configured_engine(self) -> TitanEngine:
+        """Build an engine honouring the session's profile/offline options."""
+        cfg = self.config
+        if self.profile == "safe":
+            cfg.set("max_recursion_depth", 3)
+            cfg.set("max_node_count", 50)
+        elif self.profile == "fast":
+            cfg.set("max_recursion_depth", 3)
+            cfg.set("max_node_count", 50)
+        elif self.profile == "full":
+            cfg.set("max_recursion_depth", 8)
+            cfg.set("max_node_count", 200)
+        return TitanEngine(cfg)
+
+    def action_auto_detect(self) -> None:
+        payload = self._read_payload()
+        if payload is None:
+            return
+        data, source_len = payload
+        self._print()
+        self._print(self.st.dim("  Running full engine (auto-detect)…"))
+        try:
+            if self.offline:
+                from .core.offline_guard import block_network
+
+                with block_network():
+                    report = self._configured_engine().run_analysis(data)
+            else:
+                report = self._configured_engine().run_analysis(data)
+        except Exception as e:  # keep the UI alive on engine errors
+            self._print(self.st.red(f"  Analysis failed: {e}"))
+            return
+        self._print()
+        self._print(format_engine_summary(self.st, report))
+
+    def action_pick_decoder(self) -> None:
+        self._print()
+        self._print(self.st.bold("  Available decoders:"))
+        for i, choice in enumerate(self.registry, 1):
+            self._print(
+                f"    {self.st.cyan(f'{i:>2}')}) {choice.label:<18} {self.st.dim(choice.description)}"
+            )
+        self._print("    " + self.st.dim(" b) Back"))
+        sel = self._ask(self.st.cyan("  decoder> ")).strip().lower()
+        if sel in ("b", "back", ""):
+            return
+        if not sel.isdigit() or not (1 <= int(sel) <= len(self.registry)):
+            self._print(self.st.red("  Invalid selection."))
+            return
+        choice = self.registry[int(sel) - 1]
+
+        payload = self._read_payload()
+        if payload is None:
+            return
+        data, source_len = payload
+        decoder = choice.factory()
+        try:
+            decoded, success = decoder.decode(data)
+        except Exception as e:
+            self._print(self.st.red(f"  Decoder raised an error: {e}"))
+            return
+        self._print()
+        self._print(format_decode_result(self.st, choice.label, source_len, decoded, success))
+
+    def action_list_decoders(self) -> None:
+        self._print()
+        self._print(self.st.bold(f"  {len(self.registry)} decoders available:"))
+        for choice in self.registry:
+            self._print(f"    • {choice.label:<18} {self.st.dim(choice.description)}")
+        self._print()
+        self._print(
+            self.st.dim(
+                "  Tip: 'Auto-detect' chains these recursively and also runs the"
+            )
+        )
+        self._print(self.st.dim("  ZIP/TAR/PE/ELF analyzers and IOC extraction."))
+
+    def action_options(self) -> None:
+        while True:
+            self._print()
+            self._print(self.st.bold("  Options"))
+            self._print(f"    [1] Analysis profile : {self.st.cyan(self.profile)}  (safe / fast / full)")
+            self._print(
+                f"    [2] Network           : {self.st.cyan('offline' if self.offline else 'online')}"
+            )
+            self._print("    [b] Back")
+            sel = self._ask(self.st.cyan("  options> ")).strip().lower()
+            if sel in ("b", "back", ""):
+                return
+            if sel == "1":
+                val = self._ask("    Profile (safe/fast/full): ").strip().lower()
+                if val in ("safe", "fast", "full"):
+                    self.profile = val
+                else:
+                    self._print(self.st.red("    Unknown profile."))
+            elif sel == "2":
+                val = self._ask("    Network (offline/online): ").strip().lower()
+                if val in ("offline", "off"):
+                    self.offline = True
+                elif val in ("online", "on"):
+                    self.offline = False
+                else:
+                    self._print(self.st.red("    Unknown value."))
+            else:
+                self._print(self.st.red("    Unknown choice."))
+
+    # -- banner / menu ------------------------------------------------------
+
+    def _banner(self) -> None:
+        st = self.st
+        self._print()
+        self._print(st.cyan(st.bold("  ╔══════════════════════════════════════════════╗")))
+        self._print(st.cyan(st.bold("  ║           TITAN  DECODER  ENGINE               ║")))
+        self._print(st.cyan(st.bold(f"  ║   interactive console · v{TITAN_VERSION:<20}║")))
+        self._print(st.cyan(st.bold("  ╚══════════════════════════════════════════════╝")))
+        self._print(st.dim("  Decode payloads by hand or let the engine auto-detect."))
+
+    def _menu(self) -> str:
+        st = self.st
+        self._print()
+        self._print(st.bold("  What would you like to do?"))
+        net = "offline" if self.offline else "online"
+        self._print(f"    [1] {st.green('Auto-detect & decode')}   {st.dim('(run the full engine)')}")
+        self._print("    [2] Choose a specific decoder")
+        self._print("    [3] List available decoders")
+        self._print(f"    [4] Options {st.dim(f'(profile={self.profile}, {net})')}")
+        self._print("    [q] Quit")
+        return self._ask(st.cyan("  titan> ")).strip().lower()
+
+    def run(self) -> int:
+        self._banner()
+        try:
+            while True:
+                choice = self._menu()
+                if choice in ("q", "quit", "exit"):
+                    break
+                elif choice == "1":
+                    self.action_auto_detect()
+                elif choice == "2":
+                    self.action_pick_decoder()
+                elif choice == "3":
+                    self.action_list_decoders()
+                elif choice == "4":
+                    self.action_options()
+                elif choice == "":
+                    continue
+                else:
+                    self._print(self.st.red("  Unknown option — type 1, 2, 3, 4 or q."))
+        except (_QuitSignal, KeyboardInterrupt):
+            self._print()
+        self._print(self.st.dim("  Bye."))
+        return 0
+
+
+class _QuitSignal(Exception):
+    """Internal signal to unwind the loop on EOF (Ctrl+D)."""
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Console entry point for the ``titan`` command."""
+    # No flags today; accept and ignore argv so `python -m` / wrappers work and
+    # there's room to grow (e.g. --no-color) without breaking callers.
+    return InteractiveApp().run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a friendly, menu-driven front end so users can decode payloads without memorizing CLI flags. After cloning/installing, they just run:

```bash
titan
```

...and get an interactive console:

```
  What would you like to do?
    [1] Auto-detect & decode   (run the full engine)
    [2] Choose a specific decoder
    [3] List available decoders
    [4] Options (profile=fast, offline)
    [q] Quit
```

- **Auto-detect & decode** — paste a payload or load a file and run the full engine (recursive decode tree + IOC extraction).
- **Choose a specific decoder** — pick from 21 decoders (Base64, Hex, XOR, Gzip, ROT13, URL, UTF-16, PEM, …) and feed it typed text, a hex string, or a file.
- Results render as decoded text or a hexdump (with length/entropy/sha256); auto-detect shows the decode tree plus extracted indicators.

It's a thin, **stdlib-only** presentation layer over the *same* engine and decoders the `titan-decoder` CLI already drives — no analysis logic is duplicated. Also reachable via `titan-decoder --interactive` / `-i`. The interactive session defaults to offline + the `fast` profile (both changeable under Options), matching the offline-first posture for handling untrusted samples.

Changes:
- New `titan_decoder/interactive.py` module (menu loop with injectable I/O for testing).
- New `titan` console entry point in `pyproject.toml`; `--interactive` / `-i` flag on the existing CLI.
- `tests/test_interactive.py` — 12 tests driving the loop with scripted input (no real TTY).
- README + CHANGELOG updates.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q          # 351 passed, 1 skipped
ruff check         # clean
pip install -e . && printf 'q\n' | titan   # console command launches
```

- Notes: The new module is stdlib-only. Interactive flows were also driven end-to-end with scripted input (specific-decoder decode, auto-detect with IOC extraction, hex/file input modes, EOF/Ctrl-D handling).

## Screenshots / Output (optional)

Specific-decoder mode (Base64 of "Hello Titan!"):

```
✓ Decoded with Base64
  16 byte(s) in → 12 byte(s) out  |  entropy 3.42  |  sha256 29738c7d16fe2a85…
  Decoded text:
    Hello Titan!
```

Auto-detect mode (Base64-wrapped payload containing a URL):

```
✓ Auto-analysis complete — 2 node(s) in the decode tree
  Decode tree:
    ▸ DECODE_Base64  [Text, 39B]
      • ANALYZE  [Text, 39B]
          visit http://evil.example.com/login now
  Indicators found (2):
    domains: evil.example.com
    urls: http://evil.example.com/login
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc)_