### PR TITLE
Interactive UI: save output + install docs + optional PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,33 @@ jobs:
             dist/*.tar.gz
             dist/*.sigstore*
             docs/sbom.cdx.json
+
+      # Hand the built (unsigned) distributions to the optional publish job.
+      - name: Stash distributions for PyPI publish
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+
+  # Optional PyPI publish. Disabled by default so it can never break a release:
+  # it only runs once the maintainer opts in by setting the repository variable
+  # PUBLISH_TO_PYPI=true AND configuring a PyPI Trusted Publisher for this
+  # workflow (https://docs.pypi.org/trusted-publishers/). No API token needed.
+  publish-pypi:
+    needs: build-sign
+    if: ${{ vars.PUBLISH_TO_PYPI == 'true' }}
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write  # trusted publishing (OIDC), no stored token required
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ Interactive UI:
   auto-detect shows the recursive decode tree plus extracted IOCs. New
   `titan_decoder/interactive.py` module with unit tests that drive the loop via
   injected I/O (no real TTY required).
+- Interactive UI can now save results to disk: after a single-decoder decode it
+  offers to write the raw decoded bytes to a file, and after an auto-detect run
+  it offers to save the full JSON report. Blank input skips (the default), and
+  missing parent directories are created.
+
+Packaging / install:
+
+- Document installing without cloning:
+  `pip install "git+https://github.com/pragmaconflux/titan1.git"` (and a `pipx`
+  variant). README now covers the Python 3.10+ requirement and the
+  Debian/Ubuntu `externally-managed-environment` (PEP 668) venv workaround.
+- Add an **optional** PyPI publish job to the release workflow, gated behind the
+  `PUBLISH_TO_PYPI` repository variable and PyPI Trusted Publishing (OIDC, no
+  stored token). It is disabled by default and cannot affect existing releases
+  until a maintainer opts in.
 
 Reproducible builds:
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,44 @@ Maintainers:
 
 ### 1. Install
 
+The core engine has **no external dependencies** and needs **Python 3.10+**.
+
+**Option A — install directly from GitHub (no clone needed):**
+
 ```bash
-# Clone repository
+pip install "git+https://github.com/pragmaconflux/titan1.git"
+```
+
+**Option B — clone, then install:**
+
+```bash
 git clone https://github.com/pragmaconflux/titan1.git
 cd titan1
-
-# Install core (no external dependencies required)
-pip install -e .
-
-# Optional: install enrichment/advanced feature dependencies
-pip install -e '.[enrichment]'
+pip install .            # or: pip install -e .   (editable, for development)
 ```
+
+Optional enrichment/advanced-feature dependencies:
+
+```bash
+pip install "titan-decoder[enrichment] @ git+https://github.com/pragmaconflux/titan1.git"
+# or, from a clone:  pip install -e '.[enrichment]'
+```
+
+> **Hit `error: externally-managed-environment`?** Modern Debian/Ubuntu block
+> installing into the system Python (PEP 668). Use a virtual environment:
+>
+> ```bash
+> python3 -m venv .venv          # needs python3-venv (apt install python3-venv)
+> source .venv/bin/activate      # Windows: .venv\Scripts\activate
+> pip install .                  # now works inside the venv
+> ```
+>
+> Re-run `source .venv/bin/activate` in each new terminal; `deactivate` to exit.
+> Prefer a globally-available command? Use [pipx](https://pipx.pypa.io):
+> `pipx install "git+https://github.com/pragmaconflux/titan1.git"`.
+
+Either way you get two commands: **`titan`** (interactive UI) and
+**`titan-decoder`** (scriptable CLI).
 
 ### 2. Try the interactive UI (no flags to memorize)
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -46,8 +46,9 @@ def test_registry_has_expected_decoders():
 
 def test_specific_decoder_base64_roundtrip():
     payload = base64.b64encode(b"Hello Titan!").decode()
-    # menu=2 (pick decoder), decoder=1 (Base64), input=1 (text), payload, quit
-    rc, text = _run(["2", "1", "1", payload, "q"])
+    # menu=2 (pick decoder), decoder=1 (Base64), input=1 (text), payload,
+    # ""=skip the save prompt, quit
+    rc, text = _run(["2", "1", "1", payload, "", "q"])
     assert rc == 0
     assert "Decoded with Base64" in text
     assert "Hello Titan!" in text
@@ -62,8 +63,9 @@ def test_specific_decoder_reports_failure_cleanly():
 
 
 def test_hex_input_mode():
-    # Hex *input mode* (2) turns "48656c6c6f" into b"Hello", then we ROT13 it.
-    rc, text = _run(["2", "1", "2", "48656c6c6f", "q"])  # Base64 on b"Hello"
+    # Hex *input mode* (2) turns "48656c6c6f" into b"Hello", then we Base64 it.
+    # Trailing "" safely skips the save prompt whether the decode succeeds or not.
+    rc, text = _run(["2", "1", "2", "48656c6c6f", "", "q"])  # Base64 on b"Hello"
     assert rc == 0
     # b"Hello" is not valid base64 padding-wise -> clean failure is fine; the
     # point is the hex input mode parsed without crashing.
@@ -78,10 +80,42 @@ def test_hex_input_mode_rejects_bad_hex():
 
 def test_auto_detect_extracts_iocs():
     payload = base64.b64encode(b"beacon to http://evil.example.com/c2").decode()
-    rc, text = _run(["1", "1", payload, "q"])  # auto-detect, text input
+    # auto-detect, text input, ""=skip the "save report" prompt, quit
+    rc, text = _run(["1", "1", payload, "", "q"])
     assert rc == 0
     assert "Auto-analysis complete" in text
     assert "evil.example.com" in text
+
+
+def test_save_decoded_output_to_file(tmp_path):
+    out_file = tmp_path / "decoded.bin"
+    payload = base64.b64encode(b"Hello Titan!").decode()
+    # decode Base64, then save the decoded bytes to out_file
+    rc, text = _run(["2", "1", "1", payload, str(out_file), "q"])
+    assert rc == 0
+    assert "Saved" in text
+    assert out_file.read_bytes() == b"Hello Titan!"
+
+
+def test_save_creates_missing_parent_dirs(tmp_path):
+    out_file = tmp_path / "nested" / "sub" / "out.bin"
+    plain = b"deep enough to pass base64 detection"
+    payload = base64.b64encode(plain).decode()
+    rc, text = _run(["2", "1", "1", payload, str(out_file), "q"])
+    assert rc == 0
+    assert out_file.read_bytes() == plain
+
+
+def test_save_report_json(tmp_path):
+    report_file = tmp_path / "report.json"
+    payload = base64.b64encode(b"see http://evil.example.com/x").decode()
+    rc, text = _run(["1", "1", payload, str(report_file), "q"])
+    assert rc == 0
+    assert report_file.exists()
+    import json as _json
+
+    data = _json.loads(report_file.read_text())
+    assert "nodes" in data and "iocs" in data
 
 
 def test_list_decoders_action():

--- a/titan_decoder/interactive.py
+++ b/titan_decoder/interactive.py
@@ -15,6 +15,7 @@ the loop can be driven with injected input/output streams.
 from __future__ import annotations
 
 import binascii
+import json
 import os
 import sys
 from dataclasses import dataclass
@@ -357,6 +358,23 @@ class InteractiveApp:
         self._print(self.st.red("  Unknown choice."))
         return None
 
+    # -- output persistence -------------------------------------------------
+
+    def _maybe_save(self, data: bytes, prompt: str) -> None:
+        """Offer to write ``data`` to a file. Blank input skips (the default)."""
+        path_s = self._ask(f"  {prompt} (path, or Enter to skip): ").strip().strip("'\"")
+        if not path_s:
+            return
+        path = Path(os.path.expanduser(path_s))
+        try:
+            if path.parent and not path.parent.exists():
+                path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+        except OSError as e:
+            self._print(self.st.red(f"  Could not write {path}: {e}"))
+            return
+        self._print(self.st.green(f"  Saved {len(data)} byte(s) → {path}"))
+
     # -- menu actions -------------------------------------------------------
 
     def _configured_engine(self) -> TitanEngine:
@@ -393,6 +411,9 @@ class InteractiveApp:
             return
         self._print()
         self._print(format_engine_summary(self.st, report))
+        self._print()
+        report_json = json.dumps(report, indent=2).encode("utf-8")
+        self._maybe_save(report_json, "Save full JSON report to")
 
     def action_pick_decoder(self) -> None:
         self._print()
@@ -422,6 +443,9 @@ class InteractiveApp:
             return
         self._print()
         self._print(format_decode_result(self.st, choice.label, source_len, decoded, success))
+        if success and decoded:
+            self._print()
+            self._maybe_save(decoded, "Save decoded output to")
 
     def action_list_decoders(self) -> None:
         self._print()


### PR DESCRIPTION
## Summary

Three follow-ups to the interactive `titan` UI (from #91):

**1. Save results to disk (new UI feature).**
- After a **single-decoder** decode, the UI offers to write the raw decoded bytes to a file.
- After an **auto-detect** run, it offers to save the full JSON report.
- Blank input skips (the default); missing parent directories are created automatically.

**2. Install docs — including install-without-cloning.**
- Documents `pip install "git+https://github.com/pragmaconflux/titan1.git"` (and a `pipx` variant) so users don't have to clone.
- Adds the **Python 3.10+** requirement and a fix for the Debian/Ubuntu `error: externally-managed-environment` (PEP 668) via a virtual environment — a real error a user hit during setup.

**3. Optional PyPI publish (opt-in, safe by default).**
- Adds a `publish-pypi` job to the release workflow using PyPI **Trusted Publishing** (OIDC — no stored token).
- Gated behind the `PUBLISH_TO_PYPI` repository variable, so it is **disabled by default** and cannot affect existing tagged releases until a maintainer explicitly opts in and configures a Trusted Publisher on PyPI.

All changes stay dependency-light and offline-first; no analysis logic changed.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q          # 354 passed, 1 skipped
ruff check         # clean
python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"   # workflow YAML valid
printf 'q\n' | python -m titan_decoder.interactive                               # UI launches
```

- Notes: Added 3 tests for the save feature (raw-bytes save, parent-dir creation, JSON-report save) and updated existing interactive tests for the new save prompt. All flows driven via injected I/O — no real TTY required.

## Screenshots / Output (optional)

Saving decoded output:

```
✓ Decoded with Base64
  Decoded text:
    Hello Titan!

  Save decoded output to (path, or Enter to skip): out.bin
  Saved 12 byte(s) → out.bin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc)_