### PR TITLE
Interactive UI: add session-scoped aggressive auto-detect toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Interactive UI:
   offers to write the raw decoded bytes to a file, and after an auto-detect run
   it offers to save the full JSON report. Blank input skips (the default), and
   missing parent directories are created.
+- Interactive UI gains an **aggressive auto-detect** toggle (Options → [3]). When
+  on, an auto-detect run enables the opt-in decoders
+  (Base32/UUencode/Quoted-Printable/ASN.1), searches deeper, and lowers the
+  keep-threshold so weaker/shorter decodes survive — useful for hands-on testing.
+  It is strictly session-scoped: the settings are applied per-run to the engine
+  config and fully restored when toggled off, so the core-engine defaults used by
+  `titan-decoder`, the test suite, and real analysis runs are never changed.
 
 Packaging / install:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ This launches an interactive console where you can:
 - **Choose a specific decoder** — pick Base64, Hex, XOR, Gzip, ROT13, URL, and
   more from a menu, then feed it text, a hex string, or a file.
 
+You can also **save the decoded output** (or the full JSON report) to a file
+when prompted after a decode.
+
+Under **Options** you can switch the analysis profile, toggle offline mode, and
+turn on **aggressive auto-detect** — a session-only mode that enables the opt-in
+decoders (Base32/UUencode/Quoted-Printable/ASN.1), searches deeper, and keeps
+weaker/shorter decodes. It's handy for hands-on testing (noisier for real
+triage), and it never changes the defaults used by `titan-decoder` or your
+analysis runs.
+
 It's the same engine and decoders the `titan-decoder` CLI uses, just menu-driven.
 (You can also reach it via `titan-decoder --interactive` / `-i`.)
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -125,6 +125,49 @@ def test_list_decoders_action():
     assert "Base64" in text
 
 
+def test_options_toggle_aggressive():
+    # Open options, toggle aggressive (3), back (b), quit. The menu should now
+    # advertise aggressive mode.
+    rc, text = _run(["4", "3", "b", "q"])
+    assert rc == 0
+    assert "Aggressive auto-detect is now on" in text
+    assert "aggressive" in text  # main-menu options line reflects it
+
+
+def test_aggressive_engine_enables_optin_decoders_and_lowers_threshold():
+    app = InteractiveApp(input_fn=lambda p: "", out=io.StringIO(), style=Style(False))
+
+    base = app._configured_engine()
+    base_names = {d.name for d in base.decoders}
+    # Opt-in decoders are off by default.
+    assert "Base32" not in base_names
+    assert base.pruning_engine.min_score_threshold == app._baseline_min_score
+
+    app.aggressive = True
+    agg = app._configured_engine()
+    agg_names = {d.name for d in agg.decoders}
+    # All four opt-in decoders are now enabled ("ASN.1" is the ASN1 decoder name).
+    for name in ("Base32", "UUEncode", "QuotedPrintable", "ASN.1"):
+        assert name in agg_names
+    assert agg.pruning_engine.min_score_threshold == 0.0
+    assert agg.MAX_RECURSION_DEPTH >= 6
+
+
+def test_aggressive_toggle_is_reversible():
+    # Flipping aggressive on then off must return to exactly the baseline, no
+    # matter the toggle order — the core-engine defaults must not drift.
+    app = InteractiveApp(input_fn=lambda p: "", out=io.StringIO(), style=Style(False))
+    baseline = {d.name for d in app._configured_engine().decoders}
+
+    app.aggressive = True
+    app._configured_engine()  # mutates session config
+    app.aggressive = False
+    restored = app._configured_engine()
+
+    assert {d.name for d in restored.decoders} == baseline
+    assert restored.pruning_engine.min_score_threshold == app._baseline_min_score
+
+
 def test_options_change_profile():
     # Open options, set profile to full, back, then quit; the menu should now
     # reflect the new profile.

--- a/titan_decoder/interactive.py
+++ b/titan_decoder/interactive.py
@@ -291,6 +291,15 @@ class InteractiveApp:
         # Session options.
         self.profile: str = "fast"  # safe | fast | full
         self.offline: bool = True
+        # Aggressive auto-detect (session-only). When on, auto-detect enables the
+        # opt-in decoders, searches deeper, and lowers the keep-threshold so
+        # weaker/short decodes survive. It is applied per-run to the engine
+        # config only — the core-engine defaults the CLI/tests rely on are never
+        # touched. Baselines are captured so the toggle is fully reversible
+        # regardless of how many times it's flipped in a session.
+        self.aggressive: bool = False
+        self._baseline_decoders = dict(self.config.get("decoders", {}) or {})
+        self._baseline_min_score = self.config.get("min_score_threshold", 0.01)
 
     # -- low-level I/O helpers ---------------------------------------------
 
@@ -377,8 +386,18 @@ class InteractiveApp:
 
     # -- menu actions -------------------------------------------------------
 
+    # Opt-in decoders that "aggressive" mode switches on for auto-detect.
+    _AGGRESSIVE_DECODERS = ("base32", "uuencode", "quoted_printable", "asn1")
+
     def _configured_engine(self) -> TitanEngine:
-        """Build an engine honouring the session's profile/offline options."""
+        """Build an engine honouring the session's profile / aggressive options.
+
+        Every setting is (re)applied on each call, so the resulting engine
+        reflects the *current* toggle state no matter how the options were
+        flipped. Aggressive settings are layered on top of the profile and are
+        restored to the captured baselines when the toggle is off — so turning
+        aggressive on and back off returns to exactly the normal behaviour.
+        """
         cfg = self.config
         if self.profile == "safe":
             cfg.set("max_recursion_depth", 3)
@@ -389,6 +408,20 @@ class InteractiveApp:
         elif self.profile == "full":
             cfg.set("max_recursion_depth", 8)
             cfg.set("max_node_count", 200)
+
+        # Start decoders/threshold from the captured baseline every time.
+        decoders = dict(self._baseline_decoders)
+        if self.aggressive:
+            for name in self._AGGRESSIVE_DECODERS:
+                decoders[name] = True
+            cfg.set("min_score_threshold", 0.0)
+            # Deepen the search a little, but never *below* the profile's budget.
+            cfg.set("max_recursion_depth", max(int(cfg.get("max_recursion_depth", 5)), 6))
+            cfg.set("max_node_count", max(int(cfg.get("max_node_count", 100)), 200))
+        else:
+            cfg.set("min_score_threshold", self._baseline_min_score)
+        cfg.set("decoders", decoders)
+
         return TitanEngine(cfg)
 
     def action_auto_detect(self) -> None:
@@ -397,7 +430,8 @@ class InteractiveApp:
             return
         data, source_len = payload
         self._print()
-        self._print(self.st.dim("  Running full engine (auto-detect)…"))
+        mode = " [aggressive]" if self.aggressive else ""
+        self._print(self.st.dim(f"  Running full engine (auto-detect){mode}…"))
         try:
             if self.offline:
                 from .core.offline_guard import block_network
@@ -468,6 +502,10 @@ class InteractiveApp:
             self._print(
                 f"    [2] Network           : {self.st.cyan('offline' if self.offline else 'online')}"
             )
+            self._print(
+                f"    [3] Aggressive auto-detect : {self.st.cyan('on' if self.aggressive else 'off')}"
+                f"  {self.st.dim('(opt-in decoders, deeper search, keep weak decodes)')}"
+            )
             self._print("    [b] Back")
             sel = self._ask(self.st.cyan("  options> ")).strip().lower()
             if sel in ("b", "back", ""):
@@ -486,6 +524,19 @@ class InteractiveApp:
                     self.offline = False
                 else:
                     self._print(self.st.red("    Unknown value."))
+            elif sel == "3":
+                # Simple toggle. Aggressive only affects auto-detect ([1] on the
+                # main menu); single-decoder mode is unchanged.
+                self.aggressive = not self.aggressive
+                state = "on" if self.aggressive else "off"
+                self._print(self.st.green(f"    Aggressive auto-detect is now {state}."))
+                if self.aggressive:
+                    self._print(
+                        self.st.dim(
+                            "    Heads-up: expect more (and weaker) results — good for "
+                            "hands-on testing, noisier for real triage."
+                        )
+                    )
             else:
                 self._print(self.st.red("    Unknown choice."))
 
@@ -505,10 +556,11 @@ class InteractiveApp:
         self._print()
         self._print(st.bold("  What would you like to do?"))
         net = "offline" if self.offline else "online"
+        agg = ", aggressive" if self.aggressive else ""
         self._print(f"    [1] {st.green('Auto-detect & decode')}   {st.dim('(run the full engine)')}")
         self._print("    [2] Choose a specific decoder")
         self._print("    [3] List available decoders")
-        self._print(f"    [4] Options {st.dim(f'(profile={self.profile}, {net})')}")
+        self._print(f"    [4] Options {st.dim(f'(profile={self.profile}, {net}{agg})')}")
         self._print("    [q] Quit")
         return self._ask(st.cyan("  titan> ")).strip().lower()
 


### PR DESCRIPTION
## Summary

Adds an opt-in **aggressive auto-detect** toggle to the interactive `titan` UI (Options → `[3]`), for hands-on testing of short/simple payloads — the safe alternative to loosening the core engine's thresholds globally.

When enabled, an **auto-detect** run:
- enables the opt-in decoders (**Base32 / UUencode / Quoted-Printable / ASN.1**),
- searches deeper (recursion depth / node budget raised), and
- lowers the keep-threshold (`min_score_threshold` → `0.0`) so weaker/shorter decodes survive.

**Why this design (and not the previously proposed engine patches):** the changes are layered onto the *per-run* engine config in `_configured_engine()` and restored from captured baselines when the toggle is off. So it is **strictly session-scoped** — the core-engine defaults relied on by the `titan-decoder` CLI, the test suite, and real analysis runs are never modified. Single-decoder mode is unaffected. This gives the "try harder on demand" behavior without the false-positive/precision regressions that globally lowering thresholds or broadening the IOC regex would cause.

Demonstrated difference on a doubly-Base64'd payload:

```
normal:     node_count=2, depth=3, min_score=0.01
aggressive: node_count=3, depth=6, min_score=0.0
```

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q          # 357 passed, 1 skipped
ruff check         # clean
printf '4\n3\nb\nq\n' | python -m titan_decoder.interactive   # toggle works via the UI
```

- Notes: Added 3 tests — the menu toggle, that aggressive enables the four opt-in decoders and sets `min_score_threshold=0.0`, and that flipping aggressive on then off returns the engine to exactly the baseline (guards against default drift). Core-engine defaults and all existing tests are unchanged.

## Screenshots / Output (optional)

```
  Options
    [1] Analysis profile : fast  (safe / fast / full)
    [2] Network           : offline
    [3] Aggressive auto-detect : on  (opt-in decoders, deeper search, keep weak decodes)
    [b] Back
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc)_