### PR TITLE
docs: document the interactive `titan` UI in USAGE / README / announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Docs:
+
+- Document the interactive `titan` UI in the day-to-day guide
+  (`docs/USAGE.md`) — a dedicated "Interactive mode" section covering
+  auto-detect vs. single-decoder, saving output, and the aggressive toggle —
+  and note both entry points (`titan` / `titan-decoder`). Add the interactive
+  UI to the README feature list and the announcement quick-start.
+
 Tests:
 
 - Make `test_utf16_decoder.py` deterministic. The random-binary

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ python -c 'import json; r=json.load(open("report.json")); print((r.get("risk_ass
 ## 📋 Features
 
 ### Core Capabilities
+- **Two ways to run** — the interactive **`titan`** menu (auto-detect or pick a
+  decoder; input text/hex/a file; save decoded output or the JSON report; opt-in
+  aggressive mode) and the scriptable **`titan-decoder`** CLI, over the same engine.
 - **21 Built-in Decoders (+ plugins)** — 17 always on, 4 opt-in:
   - *Always on (17):* Base64, RecursiveBase64, Base64URL, PEM, Gzip, Bz2, LZMA, Zlib, Hex, XOR, ROT13, URL decode, HTML entities, Unicode escape, UTF-16, PDF, OLE
   - *Opt-in (4):* Base32, UUEncode, ASN.1, QuotedPrintable — see [Opt-in decoders](#opt-in-decoders) below

--- a/docs/ANNOUNCEMENT.md
+++ b/docs/ANNOUNCEMENT.md
@@ -17,7 +17,9 @@ Open-sourcing **Titan Decoder**: a payload decoding + forensic analysis engine f
 - JSONL export + local vault history/search
 
 Repo: https://github.com/pragmaconflux/titan1
-Quick start:
+Quick start (interactive menu — no flags to memorize):
+`titan`
+Quick start (scriptable CLI):
 `titan-decoder --file suspicious.bin --progress --enable-detections --out report.json`
 
 Pipeline-friendly (quiet + JSONL events):

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,13 +26,52 @@ From the repo root:
 
   - `pip install -r requirements-optional.txt`
 
+Installing gives you **two commands**:
+
+- **`titan`** — the interactive, menu-driven UI (see below). Easiest way in.
+- **`titan-decoder`** — the scriptable CLI used throughout the rest of this guide.
+
 Run the CLI:
 
 - `titan-decoder --help`
 
-If `titan-decoder` isn’t on your PATH yet, you can run:
+If the commands aren’t on your PATH yet, you can run them as modules:
 
-- `python -m titan_decoder.cli --help`
+- `python -m titan_decoder.cli --help`   (the `titan-decoder` CLI)
+- `python -m titan_decoder.interactive`  (the `titan` UI)
+
+## Interactive mode (the `titan` command)
+
+If you’d rather not memorize flags, just run:
+
+```bash
+titan          # or: titan-decoder --interactive   (same thing)
+```
+
+You get a menu:
+
+- **[1] Auto-detect & decode** — paste a payload (or point at a file) and let the
+  full engine recursively decode it and extract IOCs. It prints the decode tree
+  and any indicators found.
+- **[2] Choose a specific decoder** — pick one decoder (Base64, Hex, XOR, ROT13,
+  Gzip, URL, UTF-16, …) and feed it typed text, a hex string, or a file. Good for
+  short/simple test strings, which single-decoder mode handles directly.
+- **[3] List available decoders**.
+- **[4] Options** — switch the analysis profile (safe/fast/full), toggle
+  offline/online, and turn on **aggressive auto-detect**.
+
+After a decode you can **save the output**: single-decoder mode offers to write
+the raw decoded bytes to a file, and auto-detect offers to save the full JSON
+report (the same structure documented below).
+
+**Aggressive auto-detect** (Options → [3]) makes an auto-detect run try harder:
+it enables the opt-in decoders (Base32/UUencode/Quoted-Printable/ASN.1), searches
+deeper, and keeps weaker/shorter decodes. It’s handy for hands-on testing but
+noisier for real triage. It is **session-only** — it never changes the defaults
+used by `titan-decoder` or a real analysis run.
+
+It’s the same engine and decoders as the CLI, so anything you can do here you can
+also script with `titan-decoder` (below).
 
 ## The 3 “starter” commands (copy/paste)
 


### PR DESCRIPTION
## Summary

Documentation sync for the interactive `titan` UI. The UI shipped in earlier PRs (#91/#92/#94) and was covered in the README Quick Start, but the **day-to-day usage guide and the feature list still only referenced the `titan-decoder` CLI**. This closes that gap:

- **`docs/USAGE.md`** — adds a dedicated **"Interactive mode (the `titan` command)"** section (auto-detect vs. single-decoder, saving decoded output / JSON report, the aggressive auto-detect toggle) and notes **both entry points** (`titan` and `titan-decoder`, including their `python -m` forms).
- **`README.md`** — adds the interactive UI to the Core Capabilities feature list ("Two ways to run").
- **`docs/ANNOUNCEMENT.md`** — shows `titan` as the no-flags quick start alongside the scriptable CLI command.

Docs-only — no code or behavior changes; both entry points still import cleanly.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not. — _Docs-only; no code paths changed. Verified `titan_decoder.interactive`/`cli` still import._
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
python -c "import titan_decoder.interactive, titan_decoder.cli"   # imports OK
```

- Notes: No source files touched, so the test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc)_