### PR TITLE
docs: README accuracy pass against the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Docs:
 
+- README accuracy pass against the actual engine: corrected the "21 core
+  modules" wording (that number is the decoder count, not the module count),
+  noted case reports render Markdown **and** HTML, added the `decoders/cfb.py`
+  and `decoders/pdf.py` structural parsers to the architecture tree, and
+  labelled the STIX export as a minimal 2.1 bundle to match the implementation.
+  Verified every CLI flag, the Python API snippet, and the smoke-test command in
+  the README against the code.
+
 - Document the interactive `titan` UI in the day-to-day guide
   (`docs/USAGE.md`) — a dedicated "Interactive mode" section covering
   auto-detect vs. single-decoder, saving output, and the aggressive toggle —

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ python -c 'import json; r=json.load(open("report.json")); print((r.get("risk_ass
 - **Enrichment**: Geo/WHOIS/YARA (optional, requires config) with deterministic local cache + refresh control
 
 ### Export & Reporting
-- **IOC Formats**: JSON, CSV, STIX 2.1, MISP
+- **IOC Formats**: JSON, CSV, STIX 2.1 (minimal bundle), MISP
 - **Case Reports**: Markdown/HTML summaries for investigators
 - **Timeline Export**: CSV/JSON for Timesketch, Excel
 - **Evidence Timeline Export**: CSV/JSON from normalized `--evidence` inputs
@@ -394,7 +394,7 @@ titan_decoder/
 │   ├── device_forensics.py   # VM/mobile/burner detection
 │   ├── vault.py              # Local history/search store
 │   ├── ioc_export.py         # JSON/CSV/STIX/MISP export
-│   ├── case_report.py        # Markdown reports
+│   ├── case_report.py        # Markdown/HTML case reports
 │   ├── timeline.py           # Event timeline export
 │   ├── correlation.py        # IOC correlation cache
 │   ├── resource_manager.py   # Timeouts and limits
@@ -406,7 +406,9 @@ titan_decoder/
 │   └── analyzers/
 │       └── base.py           # ZIP, TAR, PE, ELF
 ├── decoders/
-│   └── base.py               # 21 built-in decoders (17 on, 4 opt-in) (+ plugins)
+│   ├── base.py               # 21 built-in decoders (17 on, 4 opt-in) (+ plugins)
+│   ├── cfb.py                # OLE/CFB compound-file parser (MS-OVBA)
+│   └── pdf.py                # PDF object-graph parser
 ├── plugins/                  # Plugin system
 └── utils/
     └── helpers.py            # IOC extraction, entropy
@@ -480,7 +482,7 @@ under the [MIT License](LICENSE). Contributions are welcome — see
 [Code of Conduct](CODE_OF_CONDUCT.md) and [Security Policy](SECURITY.md).
 
 **Core stack**
-- Python 3.10+ — the decoding engine and all 21 core modules run on the standard
+- Python 3.10+ — the decoding engine and every core module run on the standard
   library alone, with no external dependencies required.
 
 **Optional integrations** (see [requirements-optional.txt](requirements-optional.txt))


### PR DESCRIPTION
## Summary

Audited the README's claims line-by-line against the actual code and fixed the mismatches. Everything else was verified accurate and left unchanged.

**Corrected:**
- **"all 21 core modules"** (Credits) — `21` is the *decoder* count, not the module count (there are ~40 modules / 26 in `core/`). Reworded to "every core module".
- **`case_report.py` → "Markdown reports"** (architecture tree) — it also renders HTML (`to_html`). Now "Markdown/HTML case reports". (The Features list was already correct.)
- **Architecture tree omitted the structural parsers** the README prominently boasts about — added `decoders/cfb.py` (OLE/CFB, MS-OVBA) and `decoders/pdf.py` (PDF object graph).
- **"STIX 2.1"** — the exporter is explicitly `export_stix_minimal` ("minimal STIX 2.1-like bundle"); labelled it "STIX 2.1 (minimal bundle)" to match.

**Verified accurate against the code (no change needed):**
- Every `titan-decoder` CLI flag used in the README exists in the argparse parser.
- The smart-detection log string it quotes (`Enabled … decoder (confidence: N)`).
- The `fast`/`full` profile depth/node numbers (3/50 and 8/200).
- The **Python API snippet** — executed, runs clean and prints sensible output.
- The **smoke-test command** — executed, produces `node_count: 2`.
- Decoder counts (17 always-on + 4 opt-in = 21) match the 21 decoder classes.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not. — _Docs-only; verified the README's own API + smoke-test snippets execute against the code._
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

```bash
# every README --flag exists in the parser (only ruff/pytest/--help are external)
# python API snippet from the README:            runs, prints Risk/Detections/IOCs
# README smoke test (base64 'ZGF0YTogdGVzdA=='): node_count: 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFbYoJE4AKtiQfSrDkfTSc)_