### PR TITLE
docs: document intelligence layer and engine roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ New here and feeling lost? Start with the practical walkthrough in [docs/USAGE.m
 Maintainers:
 - Release checklist: [docs/RELEASING.md](docs/RELEASING.md)
 - Community post templates: [docs/ANNOUNCEMENT.md](docs/ANNOUNCEMENT.md)
+- Intelligence Layer: [docs/INTELLIGENCE.md](docs/INTELLIGENCE.md)
+- Engine roadmap: [docs/ROADMAP.md](docs/ROADMAP.md)
 
 ### 1. Install
 
@@ -98,6 +100,10 @@ titan-decoder --file suspicious.bin --out report.json
 # With progress and detections
 titan-decoder --file payload.dat --progress --enable-detections --out report.json
 
+# Add deterministic intelligence and a readable explanation
+titan-decoder --file payload.dat --enable-detections --explain \
+    --intelligence-out intelligence.json --out report.json
+
 # Full law enforcement package
 titan-decoder --file evidence.bin --profile full --enable-detections \\
     --forensics-out forensics.json --ioc-out iocs.json --ioc-format misp \\
@@ -158,6 +164,7 @@ python -c 'import json; r=json.load(open("report.json")); print((r.get("risk_ass
 - **Evidence Links**: Reason codes + confidence for key correlations
 - **7 Detection Rules**: Deep Base64 nesting, Office macro+network IOCs, LOLBin patterns, packed/encrypted payload heuristics, multi-stage infrastructure, XOR+C2, malicious PDF
 - **Risk Scoring**: 0-100 heuristic threat assessment (CLEAN/LOW/MEDIUM/HIGH/CRITICAL)
+- **Deterministic Intelligence Layer**: explainable scoring, classifications, scored signals, and top-artifact prioritization; see [docs/INTELLIGENCE.md](docs/INTELLIGENCE.md)
 - **Enrichment**: Geo/WHOIS/YARA (optional, requires config) with deterministic local cache + refresh control
 
 ### Export & Reporting

--- a/docs/INTELLIGENCE.md
+++ b/docs/INTELLIGENCE.md
@@ -1,0 +1,54 @@
+# Titan Intelligence Layer
+
+Titan's Intelligence Layer is a deterministic, dependency-free analysis stage that explains why decoded content deserves attention and which nodes an analyst should review first.
+
+## Implemented now
+
+- Deterministic 0–100 intelligence scoring
+- Analyst-oriented classifications
+- Explainable scored signals
+- Prioritized decoded artifacts
+- `--explain` human-readable output
+- `--intelligence-out` JSON export
+- Offline operation with no added runtime dependencies
+
+The current layer is heuristic and deterministic. It is **not** a generative AI model and does not upload report data.
+
+## Classifications
+
+| Score | Classification |
+|---:|---|
+| 0–15 | `CLEAN` |
+| 16–35 | `LOW_RISK_ARTIFACT` |
+| 36–60 | `SUSPICIOUS_OBJECT` |
+| 61–80 | `HIGH_RISK_PAYLOAD` |
+| 81–100 | `LIKELY_MALICIOUS` |
+
+## CLI examples
+
+```bash
+titan-decoder --file suspicious.bin --enable-detections --explain --out report.json
+```
+
+```bash
+titan-decoder --file suspicious.bin --enable-detections \
+  --intelligence-out intelligence.json --out report.json
+```
+
+`--explain` writes to stderr so JSON stdout remains pipeline-safe.
+
+## Local AI assistant roadmap
+
+A future optional local assistant may summarize reports, answer questions about nodes and provenance, and draft analyst handoffs.
+
+Requirements:
+
+- Optional and disabled by default
+- Local/offline first
+- No automatic execution or autonomous network access
+- Clear separation between Titan facts and model inference
+- Bounded input, output, time, and memory
+- Graceful fallback to deterministic output
+- A fully working backend before adding multiple adapters
+
+Potential backends include llama.cpp-compatible local runtimes and OpenAI-compatible local endpoints. ONNX support requires choosing a concrete model and tokenizer contract.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,40 @@
+# Titan Decoder Engine Roadmap
+
+This roadmap separates shipped features from planned work.
+
+## Shipped
+
+- Recursive decoder/analyzer graph
+- Provenance, hashes, entropy, and transformation confidence
+- Structural PDF and OLE/CFB parsing
+- IOC extraction and evidence ingestion
+- Detection rules and risk scoring
+- Resource limits and offline guard
+- Deterministic Intelligence Layer
+
+## Highest-value next work
+
+1. Formalize the `intelligence` report schema and compatibility tests.
+2. Build a deterministic intelligence calibration corpus.
+3. Add intelligence to Markdown/HTML case reports.
+4. Add intelligence annotations to JSON/DOT/Mermaid graphs.
+5. Add evidence-backed MITRE ATT&CK mappings.
+6. Add repeatable performance benchmarks before optimization.
+7. Strengthen rule packs with schema versions, duplicate-ID checks, fixtures, and limits.
+8. Improve cross-source evidence correlation while preserving provenance.
+
+## Optional local AI assistant
+
+Build this after the deterministic report contract is stable.
+
+Planned capabilities:
+
+- Summarize a completed report
+- Explain nodes, signals, and provenance
+- Draft an analyst handoff
+- Answer questions with node-ID or signal-code references
+- Suggest evidence-backed next steps
+
+Recommended order:
+
+Documentation/schema → calibration tests → report/graph integration → ATT&CK mapping → benchmarks → stable local-model interface → one tested backend → analyst chat UI.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -97,6 +97,14 @@ Optional output modes:
 - Include a decision trace in the JSON report (helpful for debugging scoring/pruning):
   - `titan-decoder --file suspicious.bin --trace --out report.json`
 
+- Print the deterministic Intelligence Layer explanation:
+  - `titan-decoder --file suspicious.bin --enable-detections --explain --out report.json`
+
+- Write the Intelligence Layer result separately:
+  - `titan-decoder --file suspicious.bin --enable-detections --intelligence-out intelligence.json --out report.json`
+
+  This is deterministic analysis, not a generative AI model. See [INTELLIGENCE.md](INTELLIGENCE.md).
+
 - Save a shareable HTML case report:
   - `titan-decoder --file evidence.bin --report-out case_report.html --report-format html`
 


### PR DESCRIPTION
## Summary

Documents the deterministic Titan Intelligence Layer and adds a prioritized roadmap for future engine improvements and the optional local AI assistant.

### Changes

- Updates the README with Intelligence Layer usage and links
- Adds Intelligence Layer CLI examples to the usage guide
- Adds `docs/INTELLIGENCE.md`
- Adds `docs/ROADMAP.md`
- Clearly separates implemented deterministic analysis from planned generative AI functionality

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

```bash
python -m pytest -q