### PR TITLE
Harden rule packs: validation, duplicate-ID checks, and limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+Rule packs:
+
+- Harden rule packs with enforced validation, duplicate-ID checks, and
+  limits (completing the roadmap item). `validate_rule_def` /
+  `validate_rule_pack` (`titan_decoder/core/rule_packs.py`) check ids
+  (required, ≤64 chars, `TITAN-` prefix reserved for built-ins so packs
+  cannot impersonate them), rule types, regex patterns (non-empty, ≤2048
+  chars, must compile), flags (IGNORECASE/MULTILINE/DOTALL only), severity
+  (low/medium/high/critical), `ioc_types` (non-empty, ≤16, `min_each` in
+  [1, 10000]), and `attack_ids` (≤16, `T1234`/`T1234.001` form). Packs are
+  capped at 200 rules; beyond that the whole pack is rejected, since each
+  `content_regex` evaluation has bounded-but-real cost.
+- Enforcement at load: the engine skips invalid rules and duplicate ids
+  (within a pack, across packs, and against built-ins — first definition
+  wins) with a logged warning instead of loading them as silent no-op
+  rules, and records per-pack `rules_loaded`/`rules_skipped` counts in
+  `meta.rule_packs`.
+- `--rules-validate` is now a deep, strict gate: it runs the full per-rule
+  validation and duplicate-ID check, reports every problem per rule in its
+  JSON output, and exits non-zero on any error (previously it only checked
+  that the file parsed).
+- Fixture packs (valid, duplicate-ID, invalid-rules) in
+  `tests/fixtures/rule_packs/` back a new validation test suite
+  (`tests/test_rule_pack_validation.py`), including engine load-time
+  behavior and CLI exit codes.
+
 Threat Intelligence Engine:
 
 - Resolve the six catalog techniques that had no built-in producer. Four gain

--- a/docs/DETECTION_AND_RISK.md
+++ b/docs/DETECTION_AND_RISK.md
@@ -20,7 +20,31 @@ flowchart LR
 
 ## Rule packs
 
-External rule packs should have stable IDs, explicit versions, bounded expressions, duplicate-ID validation, and fixtures. Treat rule packs as trusted configuration and review them before use.
+External rule packs must have stable IDs, explicit versions, and bounded expressions. Treat rule packs as trusted configuration and review them before use.
+
+Validation is enforced, not advisory, in two places with different strictness:
+
+- **At load time** the engine validates every rule definition and skips
+  invalid ones with a logged warning instead of loading them as silent
+  no-ops. Duplicate IDs are rejected — within a pack, across packs, and
+  against built-in rules (first definition wins) — and the `TITAN-` ID
+  prefix is reserved, so a pack rule cannot impersonate a built-in.
+  Per-pack `rules_loaded`/`rules_skipped` counts land in the report's
+  `meta.rule_packs`.
+- **`titan-decoder --rules-validate <pack>`** performs the same deep
+  validation as a strict gate: every problem is reported per rule and the
+  command exits non-zero. Run it in CI for any pack you maintain.
+
+Enforced limits (constants in `titan_decoder/core/rule_packs.py`): at most
+200 rules per pack (the whole pack is rejected beyond that — each
+`content_regex` costs bounded-but-real evaluation time), 2048-character
+patterns, 64-character IDs, 16 `ioc_types` per rule with `min_each` in
+`[1, 10000]`, 16 `attack_ids` per rule in `T1234`/`T1234.001` form, regex
+flags limited to IGNORECASE/MULTILINE/DOTALL, and severity one of
+low/medium/high/critical. Patterns must compile at validation time.
+
+Fixture packs demonstrating valid, duplicate-ID, and invalid rules live in
+`tests/fixtures/rule_packs/` and back `tests/test_rule_pack_validation.py`.
 
 ## ATT&CK metadata
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,11 +20,11 @@ This roadmap separates shipped features from planned work.
 - Threat-intelligence precision hardening and calibration corpus with CI gate
 - Catalog/producer parity: every ATT&CK catalog entry has a built-in producer or an explicit rule-pack-only designation
 - Repeatable performance benchmarks with a committed baseline and CI regression gate
+- Rule-pack hardening: enforced validation, duplicate-ID checks (including built-in impersonation), per-pack limits, fixtures, and a strict `--rules-validate` gate
 
 ## Highest-value next work
 
-1. Strengthen rule packs with duplicate-ID checks, fixtures, and limits.
-2. Improve cross-source evidence correlation while preserving provenance.
+1. Improve cross-source evidence correlation while preserving provenance.
 
 ## Optional local AI assistant
 

--- a/tests/fixtures/rule_packs/duplicate-ids.json
+++ b/tests/fixtures/rule_packs/duplicate-ids.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "pack": {"name": "Fixture Duplicate IDs", "version": "1.0.0"},
+  "rules": [
+    {
+      "id": "DUP-001",
+      "name": "First definition",
+      "severity": "low",
+      "type": "content_regex",
+      "pattern": "first"
+    },
+    {
+      "id": "DUP-001",
+      "name": "Second definition with the same id",
+      "severity": "high",
+      "type": "content_regex",
+      "pattern": "second"
+    }
+  ]
+}

--- a/tests/fixtures/rule_packs/invalid-rules.json
+++ b/tests/fixtures/rule_packs/invalid-rules.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "pack": {"name": "Fixture Invalid Rules", "version": "1.0.0"},
+  "rules": [
+    {
+      "id": "BAD-REGEX",
+      "name": "Unbalanced parenthesis",
+      "type": "content_regex",
+      "pattern": "(unclosed"
+    },
+    {
+      "id": "BAD-TYPE",
+      "name": "Unknown rule type",
+      "type": "yara"
+    },
+    {
+      "id": "BAD-MISSING-PATTERN",
+      "name": "content_regex without a pattern",
+      "type": "content_regex"
+    },
+    {
+      "id": "TITAN-001",
+      "name": "Impersonates a built-in rule id",
+      "type": "content_regex",
+      "pattern": "anything"
+    },
+    {
+      "id": "BAD-ATTACK-IDS",
+      "name": "Malformed technique ids",
+      "type": "content_regex",
+      "pattern": "fine",
+      "attack_ids": ["1059", "T1059.001"]
+    },
+    {
+      "id": "BAD-MIN-EACH",
+      "name": "min_each out of range",
+      "type": "ioc_present",
+      "ioc_types": ["urls"],
+      "min_each": 0
+    },
+    {
+      "id": "BAD-FLAGS",
+      "name": "Unknown regex flag",
+      "type": "content_regex",
+      "pattern": "fine",
+      "flags": ["VERBOSE"]
+    },
+    {
+      "id": "BAD-SEVERITY",
+      "name": "Unknown severity",
+      "type": "content_regex",
+      "pattern": "fine",
+      "severity": "informational"
+    }
+  ]
+}

--- a/tests/fixtures/rule_packs/valid-pack.json
+++ b/tests/fixtures/rule_packs/valid-pack.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "pack": {"name": "Fixture Valid Pack", "version": "1.0.0"},
+  "rules": [
+    {
+      "id": "FIX-001",
+      "name": "PowerShell download cradle",
+      "description": "PowerShell retrieval verb in decoded content",
+      "severity": "high",
+      "type": "content_regex",
+      "pattern": "powershell.{0,200}downloadstring",
+      "flags": ["IGNORECASE", "DOTALL"],
+      "attack_ids": ["T1059.001", "T1105"]
+    },
+    {
+      "id": "FIX-002",
+      "name": "Multi-channel infrastructure",
+      "description": "URLs and public IPs both present",
+      "severity": "medium",
+      "type": "ioc_present",
+      "ioc_types": ["urls", "ipv4_public"],
+      "min_each": 1
+    }
+  ]
+}

--- a/tests/test_rule_pack_validation.py
+++ b/tests/test_rule_pack_validation.py
@@ -1,0 +1,224 @@
+"""Rule-pack hardening: duplicate-ID checks, validation, and limits.
+
+Fixture packs live in tests/fixtures/rule_packs/. The same validation runs
+in two places with different strictness: the engine skips bad rules with a
+warning and keeps analyzing, while `--rules-validate` reports every problem
+and exits non-zero.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from titan_decoder.core.detection_rules import CorrelationRulesEngine
+from titan_decoder.core.rule_packs import (
+    MAX_PATTERN_LENGTH,
+    MAX_RULES_PER_PACK,
+    RulePackError,
+    load_rule_pack,
+    validate_rule_def,
+    validate_rule_pack,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "rule_packs"
+VALID_PACK = FIXTURES / "valid-pack.json"
+DUPLICATE_PACK = FIXTURES / "duplicate-ids.json"
+INVALID_PACK = FIXTURES / "invalid-rules.json"
+
+
+def _write_pack(tmp_path, rules, name="Generated Pack"):
+    path = tmp_path / "pack.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pack": {"name": name, "version": "0.0.1"},
+                "rules": rules,
+            }
+        )
+    )
+    return path
+
+
+# --- validate_rule_pack ----------------------------------------------------
+
+
+def test_valid_fixture_pack_passes_validation():
+    result = validate_rule_pack(VALID_PACK)
+    assert result["ok"], result["errors"]
+    assert result["errors"] == []
+    assert result["name"] == "Fixture Valid Pack"
+    assert result["rule_count"] == 2
+
+
+def test_duplicate_ids_within_pack_fail_validation():
+    result = validate_rule_pack(DUPLICATE_PACK)
+    assert not result["ok"]
+    assert any("duplicate rule id" in e for e in result["errors"])
+
+
+@pytest.mark.parametrize(
+    "label, fragment",
+    [
+        ("BAD-REGEX", "invalid regex pattern"),
+        ("BAD-TYPE", "unknown rule type"),
+        ("BAD-MISSING-PATTERN", "non-empty 'pattern'"),
+        ("TITAN-001", "reserved for built-in rules"),
+        ("BAD-ATTACK-IDS", "malformed attack_ids"),
+        ("BAD-MIN-EACH", "'min_each' must be an integer"),
+        ("BAD-FLAGS", "unknown flags"),
+        ("BAD-SEVERITY", "unknown severity"),
+    ],
+)
+def test_invalid_fixture_rules_each_report_their_problem(label, fragment):
+    result = validate_rule_pack(INVALID_PACK)
+    assert not result["ok"]
+    assert any(
+        e.startswith(f"{label}:") and fragment in e for e in result["errors"]
+    ), (label, result["errors"])
+
+
+def test_unreadable_pack_reports_load_error(tmp_path):
+    missing = tmp_path / "nope.json"
+    result = validate_rule_pack(missing)
+    assert not result["ok"]
+    assert result["errors"]
+
+
+# --- limits ------------------------------------------------------------------
+
+
+def test_pack_over_rule_limit_is_rejected_at_load(tmp_path):
+    rules = [
+        {"id": f"GEN-{i:04d}", "type": "content_regex", "pattern": "x"}
+        for i in range(MAX_RULES_PER_PACK + 1)
+    ]
+    path = _write_pack(tmp_path, rules)
+    with pytest.raises(RulePackError, match="exceeding the limit"):
+        load_rule_pack(path)
+    # The engine skips the whole pack (warning) instead of crashing.
+    engine = CorrelationRulesEngine([path])
+    assert engine.rule_packs == []
+    assert all(rule.rule_id.startswith("TITAN-") for rule in engine.rules)
+
+
+def test_pattern_over_length_limit_is_flagged():
+    problems = validate_rule_def(
+        {
+            "id": "GEN-0001",
+            "type": "content_regex",
+            "pattern": "a" * (MAX_PATTERN_LENGTH + 1),
+        }
+    )
+    assert any("exceeds" in p for p in problems)
+
+
+def test_id_over_length_limit_is_flagged():
+    problems = validate_rule_def(
+        {"id": "X" * 65, "type": "content_regex", "pattern": "x"}
+    )
+    assert any("'id' exceeds" in p for p in problems)
+
+
+# --- engine load-time enforcement -------------------------------------------
+
+
+def test_engine_skips_duplicates_first_definition_wins(tmp_path):
+    engine = CorrelationRulesEngine([DUPLICATE_PACK])
+    dup_rules = [r for r in engine.rules if r.rule_id == "DUP-001"]
+    assert len(dup_rules) == 1
+    assert dup_rules[0].name == "First definition"
+    meta = engine.rule_packs[0]
+    assert meta["rules_loaded"] == 1
+    assert meta["rules_skipped"] == 1
+
+
+def test_engine_skips_cross_pack_duplicates(tmp_path):
+    first = _write_pack(
+        tmp_path,
+        [{"id": "X-001", "type": "content_regex", "pattern": "first"}],
+        name="First Pack",
+    )
+    second = tmp_path / "second.json"
+    second.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pack": {"name": "Second Pack", "version": "0.0.1"},
+                "rules": [
+                    {"id": "X-001", "type": "content_regex", "pattern": "second"}
+                ],
+            }
+        )
+    )
+    engine = CorrelationRulesEngine([first, second])
+    matches = [r for r in engine.rules if r.rule_id == "X-001"]
+    assert len(matches) == 1
+    assert matches[0].source["pack"] == "First Pack"
+    assert engine.rule_packs[1]["rules_skipped"] == 1
+
+
+def test_engine_rejects_builtin_id_impersonation_and_keeps_valid_rules():
+    engine = CorrelationRulesEngine([INVALID_PACK])
+    # The pack's TITAN-001 must not replace or duplicate the built-in.
+    titan_001 = [r for r in engine.rules if r.rule_id == "TITAN-001"]
+    assert len(titan_001) == 1
+    assert getattr(titan_001[0], "source", {"type": "builtin"}).get(
+        "type", "builtin"
+    ) == "builtin"
+    # Every fixture rule is invalid, so none load.
+    meta = engine.rule_packs[0]
+    assert meta["rules_loaded"] == 0
+    assert meta["rules_skipped"] == 8
+
+
+def test_engine_loads_valid_rules_and_reports_counts():
+    engine = CorrelationRulesEngine([VALID_PACK])
+    meta = engine.rule_packs[0]
+    assert meta["rules_loaded"] == 2
+    assert meta["rules_skipped"] == 0
+    report = {"nodes": [{"content_preview": "powershell iex downloadstring"}]}
+    detections = engine.evaluate_all(report, {})
+    assert any(d["rule_id"] == "FIX-001" for d in detections)
+    fired = next(d for d in detections if d["rule_id"] == "FIX-001")
+    assert fired["attack_ids"] == ["T1059.001", "T1105"]
+
+
+# --- CLI --rules-validate ----------------------------------------------------
+
+
+def _run_cli_validate(monkeypatch, capsys, *paths):
+    from titan_decoder import cli
+
+    argv = ["titan-decoder"]
+    for p in paths:
+        argv.extend(["--rules-validate", str(p)])
+    monkeypatch.setattr("sys.argv", argv)
+    try:
+        cli.main()
+        code = 0
+    except SystemExit as e:
+        code = e.code or 0
+    return code, json.loads(capsys.readouterr().out)
+
+
+def test_cli_rules_validate_passes_valid_pack(monkeypatch, capsys):
+    code, payload = _run_cli_validate(monkeypatch, capsys, VALID_PACK)
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["results"][0]["errors"] == []
+
+
+def test_cli_rules_validate_fails_on_rule_problems(monkeypatch, capsys):
+    code, payload = _run_cli_validate(
+        monkeypatch, capsys, VALID_PACK, DUPLICATE_PACK
+    )
+    assert code == 1
+    assert payload["ok"] is False
+    by_path = {r["path"]: r for r in payload["results"]}
+    assert by_path[str(VALID_PACK)]["ok"] is True
+    assert any(
+        "duplicate rule id" in e
+        for e in by_path[str(DUPLICATE_PACK)]["errors"]
+    )

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -357,27 +357,14 @@ def handle_info_commands(args, config) -> "int | None":
         print(json.dumps({"rule_packs": packs}, indent=2))
         return 0
 
-    # Validate rule packs and exit.
+    # Validate rule packs and exit. Deep validation: structural load errors,
+    # the per-pack rule limit, per-rule definition problems, and duplicate ids
+    # all surface as errors and fail the command.
     if args.rules_validate:
-        results = []
-        ok = True
-        from titan_decoder.core.rule_packs import load_rule_pack
+        from titan_decoder.core.rule_packs import validate_rule_pack
 
-        for p in args.rules_validate:
-            try:
-                info, rules = load_rule_pack(Path(p))
-                results.append(
-                    {
-                        "path": str(p),
-                        "ok": True,
-                        "name": info.name,
-                        "version": info.version,
-                        "rule_count": len(rules),
-                    }
-                )
-            except Exception as e:
-                ok = False
-                results.append({"path": str(p), "ok": False, "error": str(e)})
+        results = [validate_rule_pack(Path(p)) for p in args.rules_validate]
+        ok = all(r["ok"] for r in results)
         print(json.dumps({"ok": ok, "results": results}, indent=2))
         return 0 if ok else 1
 

--- a/titan_decoder/core/detection_rules.py
+++ b/titan_decoder/core/detection_rules.py
@@ -55,8 +55,21 @@ class CorrelationRulesEngine:
             self.load_rule_packs(rule_pack_paths)
 
     def load_rule_packs(self, paths: List[Path]) -> None:
-        """Load rule packs (JSON/YAML) and append their rules."""
-        from .rule_packs import load_rule_pack, evaluate_pack_rule
+        """Load rule packs (JSON/YAML) and append their rules.
+
+        Every rule definition is validated (see rule_packs.validate_rule_def);
+        invalid rules and duplicate ids — within a pack, across packs, or
+        colliding with a built-in rule — are skipped with a warning rather
+        than loaded as silent no-ops. Per-pack loaded/skipped counts are
+        recorded in ``self.rule_packs`` (and therefore in report meta).
+        """
+        from .rule_packs import (
+            evaluate_pack_rule,
+            load_rule_pack,
+            validate_rule_def,
+        )
+
+        seen_ids = {rule.rule_id for rule in self.rules}
 
         for p in paths:
             try:
@@ -65,26 +78,47 @@ class CorrelationRulesEngine:
                 logger.warning("Failed to load rule pack %s: %s", p, e)
                 continue
 
-            self.rule_packs.append(
-                {
-                    "name": info.name,
-                    "version": info.version,
-                    "schema_version": info.schema_version,
-                    "path": info.path,
-                }
-            )
+            pack_meta: Dict[str, Any] = {
+                "name": info.name,
+                "version": info.version,
+                "schema_version": info.schema_version,
+                "path": info.path,
+                "rules_loaded": 0,
+                "rules_skipped": 0,
+            }
+            self.rule_packs.append(pack_meta)
 
-            for rule_def in rules:
-                if not isinstance(rule_def, dict):
+            for index, rule_def in enumerate(rules):
+                problems = validate_rule_def(rule_def)
+                rid = (
+                    rule_def.get("id") if isinstance(rule_def, dict) else None
+                )
+                label = (
+                    rid if isinstance(rid, str) and rid else f"rules[{index}]"
+                )
+                if problems:
+                    pack_meta["rules_skipped"] += 1
+                    logger.warning(
+                        "Skipping invalid rule %s in pack %s: %s",
+                        label,
+                        info.name,
+                        "; ".join(problems),
+                    )
                     continue
-                rid = str(rule_def.get("id") or "")
-                if not rid:
+                rid = str(rid)
+                if rid in seen_ids:
+                    pack_meta["rules_skipped"] += 1
+                    logger.warning(
+                        "Skipping rule %s in pack %s: duplicate of an "
+                        "already-loaded rule id",
+                        rid,
+                        info.name,
+                    )
                     continue
+                seen_ids.add(rid)
                 name = str(rule_def.get("name") or rid)
                 desc = str(rule_def.get("description") or "")
                 severity = str(rule_def.get("severity") or "low").lower()
-                if severity not in {"low", "medium", "high", "critical"}:
-                    severity = "low"
                 attack_ids = rule_def.get("attack_ids")
                 if not isinstance(attack_ids, list):
                     attack_ids = []
@@ -113,6 +147,7 @@ class CorrelationRulesEngine:
                     },
                 )
                 self.rules.append(rule)
+                pack_meta["rules_loaded"] += 1
 
     def _load_starter_rules(self):
         """Load built-in starter detection rules."""

--- a/titan_decoder/core/rule_packs.py
+++ b/titan_decoder/core/rule_packs.py
@@ -28,6 +28,31 @@ Optional per-rule metadata:
   corroborating evidence (IDs must exist in the bundled ATT&CK catalog to be
   reported there).
 
+Validation and limits
+---------------------
+Rule definitions are validated (``validate_rule_def``) both at load time —
+the engine skips invalid or duplicate rules with a logged warning — and by
+``titan-decoder --rules-validate``, which reports every problem per rule and
+exits non-zero. Enforced constraints:
+
+- at most ``MAX_RULES_PER_PACK`` rules per pack (the whole pack is rejected
+  beyond that — each ``content_regex`` costs bounded-but-real evaluation
+  time, so an unbounded pack is a resource-exhaustion vector);
+- rule ``id`` is required, at most ``MAX_ID_LENGTH`` characters, and must not
+  use the reserved ``TITAN-`` prefix (built-in rules own it; a pack rule
+  cannot impersonate one);
+- duplicate ids are rejected — within a pack, across packs, and against
+  built-in rules (first definition wins at load time);
+- ``content_regex`` patterns must be non-empty, compile, and stay within
+  ``MAX_PATTERN_LENGTH``; ``flags`` may only name IGNORECASE, MULTILINE,
+  DOTALL;
+- ``ioc_present`` requires a non-empty ``ioc_types`` list of at most
+  ``MAX_IOC_TYPES_PER_RULE`` strings and an integer ``min_each`` in
+  ``[1, MAX_MIN_EACH]``;
+- ``severity``, when present, must be low/medium/high/critical;
+- ``attack_ids``, when present, must be at most ``MAX_ATTACK_IDS_PER_RULE``
+  well-formed technique IDs (``T1234`` / ``T1234.001``).
+
 Security note
 -------------
 A ``content_regex`` pattern is supplied by whoever authors the rule pack and is
@@ -61,6 +86,24 @@ logger = logging.getLogger(__name__)
 # re's C match loop, so the bound is enforced by running the match in a separate
 # process that can be terminated.
 CONTENT_REGEX_TIMEOUT_SECONDS = 2.0
+
+# Validation limits (see the module docstring). Each content_regex evaluation
+# has a bounded but real cost, so the per-pack rule cap is the primary
+# resource-exhaustion guard; the rest keep individual definitions sane.
+MAX_RULES_PER_PACK = 200
+MAX_ID_LENGTH = 64
+MAX_PATTERN_LENGTH = 2048
+MAX_IOC_TYPES_PER_RULE = 16
+MAX_MIN_EACH = 10_000
+MAX_ATTACK_IDS_PER_RULE = 16
+
+# Built-in rules own this prefix; pack rules must not impersonate them.
+RESERVED_ID_PREFIX = "TITAN-"
+
+_ALLOWED_TYPES = frozenset({"content_regex", "ioc_present"})
+_ALLOWED_FLAGS = frozenset({"IGNORECASE", "MULTILINE", "DOTALL"})
+_ALLOWED_SEVERITIES = frozenset({"low", "medium", "high", "critical"})
+_ATTACK_ID_PATTERN = re.compile(r"^T\d{4}(?:\.\d{3})?$")
 
 
 @dataclass(frozen=True)
@@ -113,10 +156,163 @@ def load_rule_pack(path: Path) -> tuple[RulePackInfo, List[Dict[str, Any]]]:
     rules = raw.get("rules") or []
     if not isinstance(rules, list):
         raise RulePackError("rules must be an array")
+    if len(rules) > MAX_RULES_PER_PACK:
+        raise RulePackError(
+            f"pack declares {len(rules)} rules, exceeding the limit of "
+            f"{MAX_RULES_PER_PACK}"
+        )
 
     return RulePackInfo(
         name=name, version=version, schema_version=schema_version, path=str(path)
     ), rules
+
+
+def validate_rule_def(rule_def: Any) -> List[str]:
+    """Validate a single rule definition; return a list of problems.
+
+    Used both by the engine at load time (invalid rules are skipped with a
+    warning) and by ``--rules-validate`` (problems are reported per rule and
+    the command exits non-zero).
+    """
+    if not isinstance(rule_def, dict):
+        return ["rule must be an object"]
+    problems: List[str] = []
+
+    rid = rule_def.get("id")
+    if not isinstance(rid, str) or not rid.strip():
+        problems.append("missing or empty 'id'")
+    elif len(rid) > MAX_ID_LENGTH:
+        problems.append(f"'id' exceeds {MAX_ID_LENGTH} characters")
+    elif rid.upper().startswith(RESERVED_ID_PREFIX):
+        problems.append(
+            f"'{RESERVED_ID_PREFIX}' id prefix is reserved for built-in rules"
+        )
+
+    rtype = (rule_def.get("type") or "").strip()
+    if rtype not in _ALLOWED_TYPES:
+        problems.append(
+            f"unknown rule type {rtype!r} (expected one of "
+            f"{sorted(_ALLOWED_TYPES)})"
+        )
+
+    flags = rule_def.get("flags")
+    if flags is not None:
+        if not isinstance(flags, list):
+            problems.append("'flags' must be an array")
+            flags = None
+        else:
+            unknown = [
+                f for f in flags
+                if not isinstance(f, str) or f.upper() not in _ALLOWED_FLAGS
+            ]
+            if unknown:
+                problems.append(
+                    f"unknown flags {unknown!r} (expected "
+                    f"{sorted(_ALLOWED_FLAGS)})"
+                )
+
+    if rtype == "content_regex":
+        pattern = rule_def.get("pattern")
+        if not isinstance(pattern, str) or not pattern:
+            problems.append("content_regex requires a non-empty 'pattern'")
+        elif len(pattern) > MAX_PATTERN_LENGTH:
+            problems.append(
+                f"'pattern' exceeds {MAX_PATTERN_LENGTH} characters"
+            )
+        else:
+            try:
+                re.compile(pattern, _resolve_flags(flags))
+            except re.error as e:
+                problems.append(f"invalid regex pattern: {e}")
+
+    if rtype == "ioc_present":
+        ioc_types = rule_def.get("ioc_types")
+        if (
+            not isinstance(ioc_types, list)
+            or not ioc_types
+            or not all(isinstance(t, str) and t for t in ioc_types)
+        ):
+            problems.append(
+                "ioc_present requires a non-empty 'ioc_types' array of strings"
+            )
+        elif len(ioc_types) > MAX_IOC_TYPES_PER_RULE:
+            problems.append(
+                f"'ioc_types' exceeds {MAX_IOC_TYPES_PER_RULE} entries"
+            )
+        min_each = rule_def.get("min_each", 1)
+        if (
+            not isinstance(min_each, int)
+            or isinstance(min_each, bool)
+            or not 1 <= min_each <= MAX_MIN_EACH
+        ):
+            problems.append(
+                f"'min_each' must be an integer in [1, {MAX_MIN_EACH}]"
+            )
+
+    severity = rule_def.get("severity")
+    if severity is not None and (
+        not isinstance(severity, str)
+        or severity.lower() not in _ALLOWED_SEVERITIES
+    ):
+        problems.append(
+            f"unknown severity {severity!r} (expected "
+            f"{sorted(_ALLOWED_SEVERITIES)})"
+        )
+
+    attack_ids = rule_def.get("attack_ids")
+    if attack_ids is not None:
+        if not isinstance(attack_ids, list):
+            problems.append("'attack_ids' must be an array")
+        elif len(attack_ids) > MAX_ATTACK_IDS_PER_RULE:
+            problems.append(
+                f"'attack_ids' exceeds {MAX_ATTACK_IDS_PER_RULE} entries"
+            )
+        else:
+            malformed = [
+                t for t in attack_ids
+                if not isinstance(t, str) or not _ATTACK_ID_PATTERN.match(t)
+            ]
+            if malformed:
+                problems.append(
+                    f"malformed attack_ids {malformed!r} (expected "
+                    "T1234 or T1234.001 form)"
+                )
+
+    return problems
+
+
+def validate_rule_pack(path: Path) -> Dict[str, Any]:
+    """Deep-validate a rule pack; the backing check for --rules-validate.
+
+    Loads the pack (structural errors and the per-pack rule limit surface
+    here), then validates every rule definition and checks for duplicate ids
+    within the pack. Returns ``{"path", "ok", "errors", ...}``; ``ok`` is
+    True only when there are no errors at all.
+    """
+    result: Dict[str, Any] = {"path": str(path), "ok": False, "errors": []}
+    try:
+        info, rules = load_rule_pack(Path(path))
+    except Exception as e:
+        result["errors"].append(str(e))
+        return result
+
+    result["name"] = info.name
+    result["version"] = info.version
+    result["rule_count"] = len(rules)
+
+    seen_ids: set = set()
+    for index, rule_def in enumerate(rules):
+        rid = rule_def.get("id") if isinstance(rule_def, dict) else None
+        label = rid if isinstance(rid, str) and rid else f"rules[{index}]"
+        for problem in validate_rule_def(rule_def):
+            result["errors"].append(f"{label}: {problem}")
+        if isinstance(rid, str) and rid:
+            if rid in seen_ids:
+                result["errors"].append(f"{label}: duplicate rule id")
+            seen_ids.add(rid)
+
+    result["ok"] = not result["errors"]
+    return result
 
 
 def _resolve_flags(flags: Optional[List[str]]) -> int:


### PR DESCRIPTION
## Summary

Completes the roadmap item "Strengthen rule packs with duplicate-ID checks, fixtures, and limits." Previously a pack could shadow built-in `TITAN-*` rule IDs, define the same ID twice (both loaded), ship rules that silently evaluated as always-False (bad regex, unknown type, missing pattern), and declare unlimited rules — while `--rules-validate` only checked that the file parsed.

- **Validation** — new `validate_rule_def` / `validate_rule_pack` in `titan_decoder/core/rule_packs.py`: IDs required, ≤64 chars, `TITAN-` prefix reserved for built-ins (no impersonation); known rule types only; `content_regex` patterns non-empty, ≤2048 chars, must compile; flags limited to IGNORECASE/MULTILINE/DOTALL; severity one of low/medium/high/critical; `ioc_present` requires non-empty `ioc_types` (≤16) and integer `min_each` in [1, 10000]; `attack_ids` ≤16 entries in `T1234`/`T1234.001` form.
- **Limits** — packs capped at `MAX_RULES_PER_PACK` (200) and rejected wholesale beyond it: each `content_regex` evaluation has bounded-but-real cost under the existing ReDoS guard, so an unbounded pack is a resource-exhaustion vector.
- **Load-time enforcement** — the engine skips invalid rules and duplicate IDs (within a pack, across packs, and against built-ins; first definition wins) with a logged warning instead of loading them as silent no-ops, and records per-pack `rules_loaded`/`rules_skipped` counts in `meta.rule_packs`.
- **`--rules-validate` is now a strict gate** — deep per-rule validation, every problem reported in the JSON output, non-zero exit on any error.
- **Fixtures** — valid, duplicate-ID, and invalid-rules packs in `tests/fixtures/rule_packs/` back the new `tests/test_rule_pack_validation.py` (20 tests: per-problem-class validator coverage, limit enforcement, engine first-wins/impersonation behavior, CLI exit codes).

Docs: enforced-validation section in `docs/DETECTION_AND_RISK.md`, module docstring, changelog; roadmap item moved to shipped.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q          # 479 passed (459 existing + 20 new validation tests)
ruff check .       # clean
mypy titan_decoder # clean
```

- Notes: verified end-to-end via the CLI — `--rules-validate` on the invalid fixture reports all eight problems with precise messages and exits 1; an analysis run loading the valid + duplicate fixture packs records `2 loaded / 0 skipped` and `1 loaded / 1 skipped` in `meta.rule_packs`, with the valid pack's rule firing and carrying its `attack_ids`. All fixture packs are synthetic.

## Screenshots / Output (optional)

```
$ titan-decoder --rules-validate tests/fixtures/rule_packs/invalid-rules.json
{
  "ok": false,
  "results": [{
    "errors": [
      "BAD-REGEX: invalid regex pattern: missing ), unterminated subpattern at position 0",
      "BAD-TYPE: unknown rule type 'yara' (expected one of ['content_regex', 'ioc_present'])",
      "TITAN-001: 'TITAN-' id prefix is reserved for built-in rules",
      "BAD-ATTACK-IDS: malformed attack_ids ['1059'] (expected T1234 or T1234.001 form)",
      ...
    ]
  }]
}  # exit code 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7cgZXLUyHZtjRfMjia5xd

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7cgZXLUyHZtjRfMjia5xd)_