### PR TITLE
Complete Phase 5: campaign clustering, timeline correlation, infrastructure reuse, shared payloads, attribution hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+Evidence correlation (Phase 5 milestone complete):
+
+- Campaign clustering (`titan_decoder/correlation/campaigns.py`): connected
+  components over the deterministic relationship graph, with stable
+  campaign IDs and per-campaign confidence
+  (`campaign-clusters-v1.0`).
+- Cross-case timeline correlation
+  (`titan_decoder/correlation/timeline_correlation.py`): links events from
+  different analyses within a configurable window; shared observable
+  metadata forms strong links, matching event kinds weaker ones. `None`
+  and nested metadata values are never compared
+  (`timeline-correlation-v1.0`).
+- Infrastructure reuse detection
+  (`titan_decoder/correlation/infrastructure.py`): domains, URLs, public
+  IPs, certificates, JA3/JA4, ASNs, nameservers, and WHOIS emails shared
+  across recorded analyses; private IP ranges excluded by design
+  (`infrastructure-reuse-v1.0`).
+- Shared payload detection
+  (`titan_decoder/correlation/payload_similarity.py`): per-report
+  fingerprints from node content hashes and decode chains, pairwise
+  scoring with an exact-hash-dominant weighting
+  (`shared-payload-v1.0`).
+- Evidence-backed attribution hints
+  (`titan_decoder/correlation/attribution.py`): per-pair hints combining
+  infrastructure, payload, and ATT&CK/tag overlap. Hints are explicitly
+  investigative leads and never actor identity claims
+  (`attribution-hints-v1.0`).
+- Report adapters (`titan_decoder/correlation/adapters.py`) translate
+  engine reports (meta/nodes/iocs/detections/threat_intelligence/evidence)
+  into correlation records: root hash from the root node's sha256, decode
+  chain from `decoder_used`/`method`, ATT&CK IDs from detections and
+  threat-intelligence techniques, timeline events from DFIR evidence
+  events.
+- Service orchestration
+  (`titan_decoder/correlation/service.py::analyze_milestone5`) runs the
+  full suite against the local SQLite database and returns the combined
+  `milestone-5-report-v1.0` result (schema in
+  `schemas/milestone-5-report-v1.0.schema.json`), including the analyst
+  view (`titan_decoder/correlation/views.py`; JSON/Markdown/HTML).
+- CLI integration: `--correlation-db`, `--correlation-out`,
+  `--correlation-min-score`, `--correlation-no-record`, `--campaign-out`,
+  `--campaign-min-score`, `--timeline-correlation-out`,
+  `--timeline-window-seconds`, `--infrastructure-reuse-out`,
+  `--shared-payload-out`, `--shared-payload-min-score`,
+  `--attribution-hints-out`, `--analyst-correlation-out`,
+  `--analyst-correlation-format`. Requesting any of them embeds the
+  correlation sections in the main JSON report.
+
 Rule packs:
 
 - Harden rule packs with enforced validation, duplicate-ID checks, and

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -82,6 +82,36 @@ titan-decoder --file sample.bin --offline --enable-enrichment
 
 Enrichment is explicit and optional. `--offline` prevents network-backed enrichment and should be used for isolated or evidentiary environments.
 
+## Cross-case correlation (Phase 5)
+
+```bash
+titan-decoder --file sample.bin \
+  --correlation-db cases.sqlite3 \
+  --correlation-out correlation.json \
+  --campaign-out campaigns.json \
+  --timeline-correlation-out timeline-links.json \
+  --infrastructure-reuse-out infra.json \
+  --shared-payload-out payloads.json \
+  --attribution-hints-out hints.json \
+  --analyst-correlation-out view.md --analyst-correlation-format markdown
+```
+
+Passing any of these flags runs the offline Phase 5 suite: the current
+analysis is scored against every analysis recorded in the local SQLite
+database (default `~/.titan_decoder/correlation.sqlite3`), campaigns are
+clustered, infrastructure reuse and shared payloads are detected, and
+evidence-backed attribution hints are derived. The sections are also
+embedded in the main JSON report under `correlation`, `campaigns`,
+`timeline_correlation`, `infrastructure_reuse`, `shared_payloads`, and
+`attribution_hints`.
+
+Tuning and behavior flags: `--correlation-min-score`,
+`--campaign-min-score`, `--shared-payload-min-score`,
+`--timeline-window-seconds`, and `--correlation-no-record` (correlate
+without persisting the current analysis). The analyst view renders as
+`json`, `markdown`, or `html`. See
+[EVIDENCE_CORRELATION.md](EVIDENCE_CORRELATION.md).
+
 ## Graph formats
 
 ```bash

--- a/docs/EVIDENCE_CORRELATION.md
+++ b/docs/EVIDENCE_CORRELATION.md
@@ -1,7 +1,10 @@
 # Evidence Correlation
 
-Phase 5.1 introduces the deterministic foundation for correlating Titan analyses
-across cases.
+Phase 5 correlates Titan analyses across cases. Phase 5.1 delivered the
+deterministic foundation (models, storage, scoring, timeline normalization);
+the completed milestone adds campaign clustering, timeline correlation,
+infrastructure reuse detection, shared payload detection, attribution hints,
+analyst views, and CLI integration.
 
 ## Design guarantees
 
@@ -32,8 +35,75 @@ behavioral tags provide corroboration, while decode-chain similarity helps
 surface related artifacts without being sufficient by itself to claim a
 campaign.
 
-## Scope
+## Milestone features
 
-Phase 5.1 provides models, storage, scoring, timeline normalization, and a
-versioned report schema. CLI integration, campaign clustering, and analyst
-views remain later Phase 5 work.
+All features operate offline over the local correlation database and are
+deterministic: re-running over the same inputs yields identical output,
+including identifiers.
+
+### Campaign clustering (`campaigns.py`)
+
+Builds the pairwise relationship graph over recorded analyses with the
+default scorer, keeps edges at or above `--campaign-min-score`
+(default 0.45), and reports connected components as campaigns
+(`campaign-clusters-v1.0`). Campaign IDs are stable digests of the sorted
+member set.
+
+### Timeline correlation (`timeline_correlation.py`)
+
+Links events from *different* analyses that fall within
+`--timeline-window-seconds` (default 300) of each other
+(`timeline-correlation-v1.0`). Events sharing observable metadata values
+(domain, IP, hash, host, user, …) form strong links; matching event kinds
+alone form weaker ones. `None` and nested values are never compared, so
+sparse events cannot false-match. Events come from DFIR evidence
+(`evidence.events`), which carries real wall-clock timestamps.
+
+### Infrastructure reuse (`infrastructure.py`)
+
+Flags network-infrastructure indicators (domains, URLs, public IPs,
+certificates, JA3/JA4, ASNs, nameservers, WHOIS emails) observed in more
+than one recorded analysis (`infrastructure-reuse-v1.0`). Private IP
+ranges are excluded by design: shared RFC 1918 addresses are noise, not
+reuse.
+
+### Shared payload detection (`payload_similarity.py`)
+
+Fingerprints each report from node content hashes and the decode chain,
+then scores pairs (`shared-payload-v1.0`). An exact content-hash match
+contributes 0.55; fuzzy/import/resource hashes (when present) and
+decode-chain overlap corroborate. Matches below
+`--shared-payload-min-score` (default 0.35) are dropped.
+
+### Attribution hints (`attribution.py`)
+
+Combines infrastructure reuse, shared payloads, and ATT&CK/tag overlap
+into per-pair hints (`attribution-hints-v1.0`). Hints are investigative
+leads: every hint carries an explicit statement and the report carries a
+disclaimer that hints are never actor identity claims.
+
+### Analyst views (`views.py`)
+
+`analyst_summary` condenses the full result into one view
+(`analyst-correlation-view-v1.0`), rendered as JSON, Markdown, or a
+self-contained HTML page with the machine-readable view embedded.
+
+## CLI usage
+
+```bash
+titan-decoder --file sample.bin \
+  --correlation-db cases.sqlite3 \
+  --correlation-out correlation.json \
+  --campaign-out campaigns.json \
+  --attribution-hints-out hints.json \
+  --analyst-correlation-out view.md --analyst-correlation-format markdown
+```
+
+Passing any Phase 5 flag runs the whole suite and embeds the sections in
+the main report. `--correlation-no-record` correlates without persisting
+the current analysis. The combined output contract is versioned as
+`milestone-5-report-v1.0` (`schemas/milestone-5-report-v1.0.schema.json`).
+
+The service entry point is
+`titan_decoder.correlation.service.analyze_milestone5(report, db_path, ...)`;
+report adapters live in `titan_decoder/correlation/adapters.py`.

--- a/schemas/milestone-5-report-v1.0.schema.json
+++ b/schemas/milestone-5-report-v1.0.schema.json
@@ -1,0 +1,373 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pragmaconflux/titan1/schemas/milestone-5-report-v1.0.schema.json",
+  "title": "Titan Milestone 5 Correlation Report v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "correlation",
+    "campaigns",
+    "timeline_correlation",
+    "infrastructure_reuse",
+    "shared_payloads",
+    "attribution_hints",
+    "analyst_view"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "milestone-5-report-v1.0"
+    },
+    "correlation": {
+      "$ref": "https://github.com/pragmaconflux/titan1/schemas/correlation-report-v1.0.schema.json"
+    },
+    "campaigns": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "minimum_score",
+        "campaign_count",
+        "campaigns"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "campaign-clusters-v1.0"
+        },
+        "minimum_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "campaign_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "campaigns": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "campaign_id",
+              "member_analysis_ids",
+              "relationship_ids",
+              "relationship_count",
+              "confidence",
+              "maximum_relationship_score"
+            ],
+            "properties": {
+              "campaign_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "member_analysis_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 2
+              },
+              "relationship_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "relationship_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "confidence": {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "maximum_relationship_score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "timeline_correlation": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "event_count",
+        "link_count",
+        "links"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "timeline-correlation-v1.0"
+        },
+        "event_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "link_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "link_id",
+              "left_event_id",
+              "right_event_id",
+              "delta_seconds",
+              "reason",
+              "score"
+            ],
+            "properties": {
+              "link_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "left_event_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "right_event_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "delta_seconds": {
+                "type": "number",
+                "minimum": 0
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1
+              },
+              "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "infrastructure_reuse": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "reuse_count",
+        "reused_infrastructure"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "infrastructure-reuse-v1.0"
+        },
+        "reuse_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "reused_infrastructure": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "reuse_id",
+              "indicator_type",
+              "normalized_value",
+              "analysis_ids",
+              "reuse_count",
+              "references"
+            ],
+            "properties": {
+              "reuse_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "indicator_type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "normalized_value": {
+                "type": "string",
+                "minLength": 1
+              },
+              "analysis_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 2
+              },
+              "reuse_count": {
+                "type": "integer",
+                "minimum": 2
+              },
+              "references": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "shared_payloads": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "match_count",
+        "matches"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "shared-payload-v1.0"
+        },
+        "match_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "match_id",
+              "left_analysis_id",
+              "right_analysis_id",
+              "score",
+              "reasons"
+            ],
+            "properties": {
+              "match_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "left_analysis_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "right_analysis_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "reasons": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "attribution_hints": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "hint_count",
+        "hints",
+        "disclaimer"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "attribution-hints-v1.0"
+        },
+        "hint_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "hint_id",
+              "left_analysis_id",
+              "right_analysis_id",
+              "confidence",
+              "score",
+              "evidence",
+              "statement"
+            ],
+            "properties": {
+              "hint_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "left_analysis_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "right_analysis_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "confidence": {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "score": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "evidence": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "statement": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "disclaimer": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "analyst_view": {
+      "type": "object",
+      "required": [
+        "schema_version",
+        "subject_analysis_id",
+        "relationship_count",
+        "top_relationships"
+      ],
+      "properties": {
+        "schema_version": {
+          "const": "analyst-correlation-view-v1.0"
+        },
+        "relationship_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "top_relationships": {
+          "type": "array",
+          "maxItems": 10
+        }
+      }
+    }
+  }
+}

--- a/tests/test_correlation_milestone5.py
+++ b/tests/test_correlation_milestone5.py
@@ -1,0 +1,202 @@
+"""Tests for the Phase 5 milestone features: timeline correlation,
+infrastructure reuse, shared payloads, attribution hints, campaign
+clustering, and analyst views."""
+
+import pytest
+
+from titan_decoder.correlation.attribution import build_attribution_hints
+from titan_decoder.correlation.campaigns import cluster_campaigns
+from titan_decoder.correlation.infrastructure import detect_infrastructure_reuse
+from titan_decoder.correlation.models import AnalysisRecord, IndicatorRecord
+from titan_decoder.correlation.payload_similarity import (
+    PayloadFingerprint,
+    detect_shared_payloads,
+)
+from titan_decoder.correlation.timeline import TimelineEvent
+from titan_decoder.correlation.timeline_correlation import correlate_timelines
+from titan_decoder.correlation.views import analyst_summary, to_html, to_markdown
+
+
+def _record(case_id: str, domain: str, attack_ids=("T1027",)) -> AnalysisRecord:
+    return AnalysisRecord(
+        analysis_id=case_id,
+        root_hash=f"hash-{case_id}",
+        indicators=(IndicatorRecord(case_id, "domains", domain),),
+        attack_ids=attack_ids,
+    )
+
+
+def test_infrastructure_reuse_detects_shared_domain():
+    analyses = (_record("a", "c2.test"), _record("b", "c2.test"))
+    report = detect_infrastructure_reuse(analyses)
+    assert report["reuse_count"] == 1
+    reuse = report["reused_infrastructure"][0]
+    assert reuse["indicator_type"] == "domains"
+    assert reuse["normalized_value"] == "c2.test"
+    assert reuse["analysis_ids"] == ["a", "b"]
+    assert reuse["reuse_count"] == 2
+
+
+def test_infrastructure_reuse_ignores_non_infra_and_unique_indicators():
+    analyses = (
+        AnalysisRecord(
+            "a",
+            "hash-a",
+            indicators=(
+                IndicatorRecord("a", "hashes", "deadbeef"),
+                IndicatorRecord("a", "ipv4_private", "10.0.0.1"),
+                IndicatorRecord("a", "domains", "only-here.test"),
+            ),
+        ),
+        AnalysisRecord(
+            "b",
+            "hash-b",
+            indicators=(
+                IndicatorRecord("b", "hashes", "deadbeef"),
+                IndicatorRecord("b", "ipv4_private", "10.0.0.1"),
+            ),
+        ),
+    )
+    report = detect_infrastructure_reuse(analyses)
+    assert report["reuse_count"] == 0
+
+
+def test_shared_payload_exact_hash_match():
+    report = detect_shared_payloads(
+        (
+            PayloadFingerprint("a", "x", payload_hashes=("same",)),
+            PayloadFingerprint("b", "y", payload_hashes=("same",)),
+        )
+    )
+    assert report["match_count"] == 1
+    match = report["matches"][0]
+    assert match["score"] >= 0.55
+    assert "exact_payload_hash" in match["reasons"]
+
+
+def test_shared_payload_below_floor_excluded():
+    report = detect_shared_payloads(
+        (
+            PayloadFingerprint("a", "x", decode_chain=("base64",)),
+            PayloadFingerprint("b", "y", decode_chain=("base64",)),
+        ),
+        minimum_score=0.35,
+    )
+    assert report["match_count"] == 0
+
+
+def test_shared_payload_rejects_bad_floor():
+    with pytest.raises(ValueError):
+        detect_shared_payloads((), minimum_score=1.5)
+
+
+def test_timeline_correlation_links_shared_metadata():
+    events = (
+        TimelineEvent("a", "2026-01-01T00:00:00Z", "dns_query", "query", metadata={"domain": "c2.test"}),
+        TimelineEvent("b", "2026-01-01T00:01:00Z", "proxy_request", "connect", metadata={"domain": "c2.test"}),
+    )
+    report = correlate_timelines(events, window_seconds=300)
+    assert report["event_count"] == 2
+    assert report["link_count"] == 1
+    link = report["links"][0]
+    assert link["reason"] == "shared_metadata:c2.test"
+    assert 0.0 < link["score"] <= 1.0
+
+
+def test_timeline_correlation_respects_window():
+    events = (
+        TimelineEvent("a", "2026-01-01T00:00:00Z", "dns_query", "query", metadata={"domain": "c2.test"}),
+        TimelineEvent("b", "2026-01-01T01:00:00Z", "dns_query", "query", metadata={"domain": "c2.test"}),
+    )
+    assert correlate_timelines(events, window_seconds=300)["link_count"] == 0
+
+
+def test_timeline_correlation_never_links_same_analysis():
+    events = (
+        TimelineEvent("a", "2026-01-01T00:00:00Z", "dns_query", "query", metadata={"domain": "c2.test"}),
+        TimelineEvent("a", "2026-01-01T00:00:30Z", "dns_query", "query", metadata={"domain": "c2.test"}),
+    )
+    assert correlate_timelines(events, window_seconds=300)["link_count"] == 0
+
+
+def test_timeline_correlation_rejects_negative_window():
+    with pytest.raises(ValueError):
+        correlate_timelines((), window_seconds=-1)
+
+
+def test_attribution_hints_combine_evidence():
+    analyses = (_record("a", "c2.test"), _record("b", "c2.test"))
+    infra = detect_infrastructure_reuse(analyses)
+    payloads = detect_shared_payloads(
+        (
+            PayloadFingerprint("a", "x", payload_hashes=("same",)),
+            PayloadFingerprint("b", "y", payload_hashes=("same",)),
+        )
+    )
+    hints = build_attribution_hints(analyses, infra, payloads)
+    assert hints["hint_count"] == 1
+    hint = hints["hints"][0]
+    assert hint["confidence"] in {"medium", "high"}
+    assert "infrastructure:domains" in hint["evidence"]
+    assert "exact_payload_hash" in hint["evidence"]
+    assert "shared_attack" in hint["evidence"]
+    assert "lead" in hint["statement"]
+    assert "not actor identity claims" in hints["disclaimer"]
+
+
+def test_attribution_hints_empty_without_shared_evidence():
+    analyses = (_record("a", "one.test"), _record("b", "two.test"))
+    infra = detect_infrastructure_reuse(analyses)
+    payloads = detect_shared_payloads(())
+    hints = build_attribution_hints(analyses, infra, payloads)
+    assert hints["hint_count"] == 0
+
+
+def test_campaign_clustering_groups_connected_analyses():
+    analyses = (
+        _record("a", "c2.test"),
+        _record("b", "c2.test"),
+        _record("c", "unrelated.test", attack_ids=()),
+    )
+    report = cluster_campaigns(analyses, minimum_score=0.45)
+    assert report["campaign_count"] == 1
+    campaign = report["campaigns"][0]
+    assert campaign["member_analysis_ids"] == ["a", "b"]
+    assert campaign["relationship_count"] == 1
+    assert campaign["confidence"] in {"medium", "high"}
+
+
+def test_campaign_clustering_is_deterministic():
+    analyses = (_record("a", "c2.test"), _record("b", "c2.test"))
+    first = cluster_campaigns(analyses)
+    second = cluster_campaigns(tuple(reversed(analyses)))
+    assert first == second
+
+
+def test_campaign_clustering_rejects_bad_floor():
+    with pytest.raises(ValueError):
+        cluster_campaigns((), minimum_score=2.0)
+
+
+def test_analyst_views_render_all_sections():
+    analyses = (_record("a", "c2.test"), _record("b", "c2.test"))
+    infra = detect_infrastructure_reuse(analyses)
+    result = {
+        "correlation": {"subject_analysis_id": "b", "relationships": []},
+        "campaigns": cluster_campaigns(analyses),
+        "timeline_correlation": correlate_timelines(()),
+        "infrastructure_reuse": infra,
+        "shared_payloads": detect_shared_payloads(()),
+        "attribution_hints": build_attribution_hints(analyses, infra, {"matches": []}),
+    }
+    view = analyst_summary(result)
+    assert view["schema_version"] == "analyst-correlation-view-v1.0"
+    assert view["subject_analysis_id"] == "b"
+
+    markdown = to_markdown(view)
+    assert "# Titan Phase 5 Correlation" in markdown
+    assert "Infrastructure reuse: **1**" in markdown
+
+    html = to_html(view)
+    assert html.startswith("<!doctype html>")
+    assert "application/json" in html

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -1,0 +1,236 @@
+"""End-to-end tests for the Phase 5 service, report adapters, and CLI stage."""
+
+import json
+
+import pytest
+
+from titan_decoder import cli
+from titan_decoder.correlation.adapters import (
+    analysis_record_from_report,
+    timeline_events_from_report,
+)
+from titan_decoder.correlation.payload_similarity import fingerprint_from_report
+from titan_decoder.correlation.service import analyze_milestone5, correlate_report
+
+
+def _engine_style_report(analysis_id: str, domain: str, timestamp: str, sha256: str = "same"):
+    """Report shaped like TitanEngine.run_analysis output plus evidence events."""
+
+    return {
+        "meta": {
+            "tool": "Titan Decoder Engine",
+            "analysis_id": analysis_id,
+            "started_at": "2026-01-01T00:00:00+00:00",
+        },
+        "node_count": 2,
+        "nodes": [
+            {"id": 0, "parent": None, "depth": 0, "method": "SOURCE", "sha256": f"root-{analysis_id}"},
+            {"id": 1, "parent": 0, "depth": 1, "method": "Base64", "decoder_used": "Base64", "sha256": sha256},
+        ],
+        "iocs": {"domains": [domain], "urls": [], "ipv4_private": ["10.0.0.1"]},
+        "detections": [{"rule": "obfuscation", "attack_ids": ["T1027"]}],
+        "threat_intelligence": {
+            "techniques": [{"technique_id": "T1027"}],
+            "malware_tags": ["obfuscated"],
+        },
+        "evidence": {
+            "events": [
+                {
+                    "event_id": f"ev-{analysis_id}",
+                    "event_type": "dns_query",
+                    "timestamp": timestamp,
+                    "source": "dns.log",
+                    "extracted_by": "dns_parser",
+                    "domain": domain,
+                    "host": None,
+                    "raw": {"nested": True},
+                }
+            ]
+        },
+    }
+
+
+def test_analysis_record_from_engine_style_report():
+    record = analysis_record_from_report(
+        _engine_style_report("case-1", "c2.test", "2026-01-01T00:00:00Z")
+    )
+    assert record.analysis_id == "case-1"
+    assert record.root_hash == "root-case-1"
+    assert record.created_at == "2026-01-01T00:00:00+00:00"
+    assert ("domains", "c2.test") in {
+        (item.indicator_type, item.normalized_value) for item in record.indicators
+    }
+    assert record.attack_ids == ("T1027",)
+    assert record.threat_tags == ("obfuscated",)
+    assert record.decode_chain == ("SOURCE", "Base64")
+
+
+def test_analysis_record_requires_identifier_and_root_hash():
+    with pytest.raises(ValueError):
+        analysis_record_from_report({"nodes": [{"parent": None, "sha256": "x"}]})
+    with pytest.raises(ValueError):
+        analysis_record_from_report({"meta": {"analysis_id": "a"}, "nodes": []})
+
+
+def test_timeline_events_skip_none_metadata_and_bad_timestamps():
+    report = _engine_style_report("case-1", "c2.test", "2026-01-01T00:00:00Z")
+    report["evidence"]["events"].append(
+        {"event_type": "dns_query", "timestamp": "not-a-time", "domain": "x.test"}
+    )
+    events = timeline_events_from_report(report)
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == "dns_query"
+    # None-valued fields and nested raw data must not leak into metadata,
+    # otherwise cross-case matching would link events on shared "None".
+    assert "host" not in event.metadata
+    assert "raw" not in event.metadata
+    assert event.metadata["domain"] == "c2.test"
+
+
+def test_fingerprint_from_engine_style_report():
+    fingerprint = fingerprint_from_report(
+        _engine_style_report("case-1", "c2.test", "2026-01-01T00:00:00Z")
+    )
+    assert fingerprint.analysis_id == "case-1"
+    assert fingerprint.root_hash == "root-case-1"
+    assert "same" in fingerprint.payload_hashes
+    assert fingerprint.decode_chain == ("SOURCE", "Base64")
+
+
+def test_analyze_milestone5_end_to_end(tmp_path):
+    db = tmp_path / "correlation.sqlite3"
+    first = _engine_style_report("case-a", "c2.test", "2026-01-01T00:00:00Z")
+    second = _engine_style_report("case-b", "c2.test", "2026-01-01T00:01:00Z")
+
+    analyze_milestone5(first, db)
+    result = analyze_milestone5(second, db, prior_reports=(first,))
+
+    assert result["schema_version"] == "milestone-5-report-v1.0"
+    assert len(result["correlation"]["relationships"]) == 1
+    assert result["campaigns"]["campaign_count"] == 1
+    assert result["timeline_correlation"]["link_count"] == 1
+    assert result["infrastructure_reuse"]["reuse_count"] == 1
+    assert result["shared_payloads"]["match_count"] == 1
+    assert result["attribution_hints"]["hint_count"] == 1
+    assert result["analyst_view"]["subject_analysis_id"] == "case-b"
+
+
+def test_analyze_milestone5_is_deterministic(tmp_path):
+    first = _engine_style_report("case-a", "c2.test", "2026-01-01T00:00:00Z")
+    second = _engine_style_report("case-b", "c2.test", "2026-01-01T00:01:00Z")
+    results = []
+    for name in ("one.sqlite3", "two.sqlite3"):
+        db = tmp_path / name
+        analyze_milestone5(first, db)
+        results.append(analyze_milestone5(second, db, prior_reports=(first,)))
+    assert results[0] == results[1]
+
+
+def test_analyze_milestone5_matches_json_schema(tmp_path):
+    jsonschema = pytest.importorskip("jsonschema")
+    referencing = pytest.importorskip("referencing")
+    from pathlib import Path
+
+    schemas_dir = Path(__file__).resolve().parents[1] / "schemas"
+    milestone = json.loads(
+        (schemas_dir / "milestone-5-report-v1.0.schema.json").read_text()
+    )
+    correlation = json.loads(
+        (schemas_dir / "correlation-report-v1.0.schema.json").read_text()
+    )
+    registry = referencing.Registry().with_resources(
+        [
+            (milestone["$id"], referencing.Resource.from_contents(milestone)),
+            (correlation["$id"], referencing.Resource.from_contents(correlation)),
+        ]
+    )
+    validator = jsonschema.Draft202012Validator(milestone, registry=registry)
+
+    db = tmp_path / "correlation.sqlite3"
+    first = _engine_style_report("case-a", "c2.test", "2026-01-01T00:00:00Z")
+    analyze_milestone5(first, db)
+    result = analyze_milestone5(
+        _engine_style_report("case-b", "c2.test", "2026-01-01T00:01:00Z"),
+        db,
+        prior_reports=(first,),
+    )
+    validator.validate(result)
+
+
+def test_correlate_report_no_record_leaves_database_unchanged(tmp_path):
+    db = tmp_path / "correlation.sqlite3"
+    first = _engine_style_report("case-a", "c2.test", "2026-01-01T00:00:00Z")
+    second = _engine_style_report("case-b", "c2.test", "2026-01-01T00:01:00Z")
+
+    analyze_milestone5(first, db)
+    correlation = correlate_report(second, db, record_subject=False)
+    assert len(correlation["relationships"]) == 1
+
+    # The subject was not recorded, so correlating it again still sees only
+    # the first analysis.
+    again = correlate_report(second, db, record_subject=False)
+    assert len(again["relationships"]) == 1
+
+
+def _cli_args(**over):
+    args = cli.build_parser().parse_args([])
+    for key, value in over.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_cli_parser_phase5_defaults():
+    args = cli.build_parser().parse_args(["--file", "x.bin"])
+    assert args.correlation_db is None
+    assert args.correlation_min_score == 0.0
+    assert args.campaign_min_score == 0.45
+    assert args.shared_payload_min_score == 0.35
+    assert args.timeline_window_seconds == 300.0
+    assert args.analyst_correlation_format == "json"
+
+
+def test_cli_phase5_stage_noop_without_flags():
+    report = {"meta": {"analysis_id": "case-a"}}
+    assert cli.run_phase5_correlation_stage(_cli_args(), report) == 0
+    assert "correlation" not in report
+
+
+def test_cli_phase5_stage_writes_outputs(tmp_path, capsys):
+    db = tmp_path / "correlation.sqlite3"
+    first = _engine_style_report("case-a", "c2.test", "2026-01-01T00:00:00Z")
+    analyze_milestone5(first, db)
+
+    report = _engine_style_report("case-b", "c2.test", "2026-01-01T00:01:00Z")
+    args = _cli_args(
+        correlation_db=db,
+        correlation_out=tmp_path / "correlation.json",
+        campaign_out=tmp_path / "campaigns.json",
+        infrastructure_reuse_out=tmp_path / "infra.json",
+        shared_payload_out=tmp_path / "payloads.json",
+        attribution_hints_out=tmp_path / "hints.json",
+        analyst_correlation_out=tmp_path / "view.md",
+        analyst_correlation_format="markdown",
+        quiet=True,
+    )
+    assert cli.run_phase5_correlation_stage(args, report) == 0
+
+    # Sections are embedded in the report for downstream output stages.
+    assert len(report["correlation"]["relationships"]) == 1
+    assert report["campaigns"]["campaign_count"] == 1
+
+    correlation = json.loads((tmp_path / "correlation.json").read_text())
+    assert correlation["subject_analysis_id"] == "case-b"
+    assert json.loads((tmp_path / "campaigns.json").read_text())["campaign_count"] == 1
+    assert json.loads((tmp_path / "infra.json").read_text())["reuse_count"] == 1
+    assert json.loads((tmp_path / "payloads.json").read_text())["match_count"] == 0
+    hints = json.loads((tmp_path / "hints.json").read_text())
+    assert hints["hint_count"] == 1
+    assert "# Titan Phase 5 Correlation" in (tmp_path / "view.md").read_text()
+
+
+def test_cli_phase5_stage_reports_failure(tmp_path, capsys):
+    args = _cli_args(correlation_db=tmp_path / "correlation.sqlite3", quiet=True)
+    # Report without an analysis identifier cannot be correlated.
+    assert cli.run_phase5_correlation_stage(args, {"nodes": []}) == 1
+    assert "Phase 5 correlation failed" in capsys.readouterr().err

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -282,6 +282,84 @@ def build_parser() -> argparse.ArgumentParser:
         help="Validate a rule pack file and exit (can be repeated)",
     )
     parser.add_argument(
+        "--correlation-db",
+        type=Path,
+        help=(
+            "Local SQLite database for Phase 5 cross-case correlation "
+            "(default: ~/.titan_decoder/correlation.sqlite3)"
+        ),
+    )
+    parser.add_argument(
+        "--correlation-out",
+        type=Path,
+        help="Write the cross-case correlation report (relationships) to a JSON file",
+    )
+    parser.add_argument(
+        "--correlation-min-score",
+        type=float,
+        default=0.0,
+        help="Minimum relationship score to include in the correlation report (0-1)",
+    )
+    parser.add_argument(
+        "--correlation-no-record",
+        action="store_true",
+        help="Correlate against prior analyses without recording this one",
+    )
+    parser.add_argument(
+        "--campaign-out",
+        type=Path,
+        help="Write campaign clusters over recorded analyses to a JSON file",
+    )
+    parser.add_argument(
+        "--campaign-min-score",
+        type=float,
+        default=0.45,
+        help="Minimum relationship score for campaign clustering edges (0-1)",
+    )
+    parser.add_argument(
+        "--timeline-correlation-out",
+        type=Path,
+        help="Write cross-case timeline correlation links to a JSON file",
+    )
+    parser.add_argument(
+        "--timeline-window-seconds",
+        type=float,
+        default=300.0,
+        help="Time window for cross-case timeline correlation (seconds)",
+    )
+    parser.add_argument(
+        "--infrastructure-reuse-out",
+        type=Path,
+        help="Write infrastructure reuse detections to a JSON file",
+    )
+    parser.add_argument(
+        "--shared-payload-out",
+        type=Path,
+        help="Write shared payload detections to a JSON file",
+    )
+    parser.add_argument(
+        "--shared-payload-min-score",
+        type=float,
+        default=0.35,
+        help="Minimum similarity score for shared payload matches (0-1)",
+    )
+    parser.add_argument(
+        "--attribution-hints-out",
+        type=Path,
+        help="Write evidence-backed attribution hints to a JSON file",
+    )
+    parser.add_argument(
+        "--analyst-correlation-out",
+        type=Path,
+        help="Write the analyst correlation view to a file",
+    )
+    parser.add_argument(
+        "--analyst-correlation-format",
+        choices=["json", "markdown", "html"],
+        default="json",
+        help="Format for --analyst-correlation-out (default: json)",
+    )
+    parser.add_argument(
         "--fail-on-risk-level",
         choices=["MEDIUM", "HIGH", "CRITICAL"],
         help="Exit non-zero if risk_assessment risk_level is at/above this level",
@@ -806,6 +884,90 @@ def run_enrichment_stage(args, config, report, evidence_result) -> None:
                 file=sys.stderr,
             )
 
+def run_phase5_correlation_stage(args, report) -> int:
+    """Run Phase 5 cross-case correlation when any of its outputs were requested.
+
+    Embeds the correlation sections into the report and writes any requested
+    per-section JSON files plus the analyst view. Returns 0 on success (or
+    when Phase 5 was not requested) and 1 on failure.
+    """
+    requested = any(
+        (
+            args.correlation_db,
+            args.correlation_out,
+            args.campaign_out,
+            args.timeline_correlation_out,
+            args.infrastructure_reuse_out,
+            args.shared_payload_out,
+            args.attribution_hints_out,
+            args.analyst_correlation_out,
+        )
+    )
+    if not requested:
+        return 0
+
+    try:
+        from .correlation.service import analyze_milestone5
+        from .correlation.views import to_html as phase5_to_html
+        from .correlation.views import to_markdown as phase5_to_markdown
+
+        db_path = args.correlation_db or (
+            Path.home() / ".titan_decoder" / "correlation.sqlite3"
+        )
+        phase5 = analyze_milestone5(
+            report,
+            db_path,
+            minimum_relationship_score=float(args.correlation_min_score),
+            minimum_campaign_score=float(args.campaign_min_score),
+            minimum_payload_score=float(args.shared_payload_min_score),
+            timeline_window_seconds=float(args.timeline_window_seconds),
+            record_subject=not args.correlation_no_record,
+        )
+        for key in (
+            "correlation",
+            "campaigns",
+            "timeline_correlation",
+            "infrastructure_reuse",
+            "shared_payloads",
+            "attribution_hints",
+        ):
+            report[key] = phase5[key]
+
+        section_outputs = (
+            (args.correlation_out, phase5["correlation"]),
+            (args.campaign_out, phase5["campaigns"]),
+            (args.timeline_correlation_out, phase5["timeline_correlation"]),
+            (args.infrastructure_reuse_out, phase5["infrastructure_reuse"]),
+            (args.shared_payload_out, phase5["shared_payloads"]),
+            (args.attribution_hints_out, phase5["attribution_hints"]),
+        )
+        for path, payload in section_outputs:
+            if path:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+        if args.analyst_correlation_out:
+            view = phase5["analyst_view"]
+            if args.analyst_correlation_format == "html":
+                rendered = phase5_to_html(view)
+            elif args.analyst_correlation_format == "markdown":
+                rendered = phase5_to_markdown(view)
+            else:
+                rendered = json.dumps(view, indent=2)
+            args.analyst_correlation_out.parent.mkdir(parents=True, exist_ok=True)
+            args.analyst_correlation_out.write_text(rendered, encoding="utf-8")
+
+        if not args.quiet:
+            print(
+                f"Phase 5 correlation complete (database: {db_path})",
+                file=sys.stderr,
+            )
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"Error: Phase 5 correlation failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def write_outputs_stage(args, config, report, engine, detections, risk_assessment, evidence_result) -> int:
     """Run all exports, contract validation, output, and compute the exit code.
 
@@ -813,6 +975,12 @@ def write_outputs_stage(args, config, report, engine, detections, risk_assessmen
     vault, strict validation, the report-size guard, stdout/file output, and the
     ``--fail-on-risk-level`` exit code. Returns the process exit code.
     """
+    # Phase 5 cross-case correlation (runs first so its sections are embedded
+    # in the report before validation and stdout/file output).
+    phase5_exit = run_phase5_correlation_stage(args, report)
+    if phase5_exit != 0:
+        return phase5_exit
+
     # Optional forensic attribution summary
     forensics_summary = None
     if args.forensics_out or args.forensics_print:

--- a/titan_decoder/correlation/__init__.py
+++ b/titan_decoder/correlation/__init__.py
@@ -1,7 +1,11 @@
-"""Deterministic cross-case evidence correlation foundation."""
+"""Deterministic cross-case evidence correlation (Phase 5)."""
 
+from .adapters import analysis_record_from_report, timeline_events_from_report
+from .attribution import build_attribution_hints
+from .campaigns import cluster_campaigns
 from .database import CorrelationDatabase
 from .engine import CorrelationEngine
+from .infrastructure import detect_infrastructure_reuse
 from .models import (
     AnalysisRecord,
     CorrelationEvidence,
@@ -12,8 +16,17 @@ from .models import (
     SCHEMA_VERSION,
     stable_id,
 )
+from .payload_similarity import (
+    PayloadFingerprint,
+    SharedPayload,
+    detect_shared_payloads,
+    fingerprint_from_report,
+)
 from .relationships import RelationshipScorer, score_relationship
+from .service import analyze_milestone5, correlate_report
 from .timeline import TimelineEvent, normalize_timestamp, sort_timeline
+from .timeline_correlation import TimelineLink, correlate_timelines
+from .views import analyst_summary, to_html, to_markdown
 
 __all__ = [
     "AnalysisRecord",
@@ -23,12 +36,28 @@ __all__ = [
     "CorrelationReport",
     "EvidenceReference",
     "IndicatorRecord",
+    "PayloadFingerprint",
     "Relationship",
     "RelationshipScorer",
     "SCHEMA_VERSION",
+    "SharedPayload",
     "TimelineEvent",
+    "TimelineLink",
+    "analysis_record_from_report",
+    "analyze_milestone5",
+    "analyst_summary",
+    "build_attribution_hints",
+    "cluster_campaigns",
+    "correlate_report",
+    "correlate_timelines",
+    "detect_infrastructure_reuse",
+    "detect_shared_payloads",
+    "fingerprint_from_report",
     "normalize_timestamp",
     "score_relationship",
     "sort_timeline",
     "stable_id",
+    "timeline_events_from_report",
+    "to_html",
+    "to_markdown",
 ]

--- a/titan_decoder/correlation/adapters.py
+++ b/titan_decoder/correlation/adapters.py
@@ -1,0 +1,241 @@
+"""Adapters that build correlation inputs from Titan analysis reports.
+
+The correlation layer works with normalized :class:`AnalysisRecord` and
+:class:`TimelineEvent` values. These adapters translate the engine's report
+dictionary (``meta``, ``nodes``, ``iocs``, ``detections``,
+``threat_intelligence``, ``evidence``) into those records so the rest of
+Phase 5 never touches raw report shapes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from .models import AnalysisRecord, EvidenceReference, IndicatorRecord
+from .timeline import TimelineEvent
+
+# Evidence-event fields that identify what an event touched. Only these are
+# carried into TimelineEvent.metadata so cross-case matching compares real
+# observables instead of bookkeeping fields (event_id, extracted_by, raw).
+_EVENT_OBSERVABLE_FIELDS = (
+    "host",
+    "user",
+    "src_ip",
+    "dst_ip",
+    "domain",
+    "url",
+    "process",
+    "file_path",
+    "sha256",
+)
+
+
+def _string_values(value: Any) -> tuple[str, ...]:
+    """Coerce a report field into a sorted tuple of non-empty strings."""
+
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, Mapping):
+        value = value.keys()
+    if not isinstance(value, Iterable):
+        return (str(value),)
+    return tuple(sorted({str(item) for item in value if str(item)}))
+
+
+def _analysis_id(report: Mapping[str, Any]) -> str:
+    meta = report.get("meta") or {}
+    return str(
+        meta.get("analysis_id")
+        or report.get("analysis_id")
+        or report.get("root_hash")
+        or ""
+    )
+
+
+def _root_hash(report: Mapping[str, Any]) -> str:
+    """Return the root artifact hash for a report.
+
+    Engine reports do not carry a top-level ``root_hash``; the canonical
+    value is the sha256 of the root node (the node without a parent).
+    """
+
+    meta = report.get("meta") or {}
+    explicit = report.get("root_hash") or meta.get("root_hash")
+    if explicit:
+        return str(explicit)
+    for node in report.get("nodes") or ():
+        if isinstance(node, Mapping) and node.get("parent") is None:
+            sha256 = node.get("sha256")
+            if sha256:
+                return str(sha256)
+    return ""
+
+
+def _decode_chain(report: Mapping[str, Any]) -> tuple[str, ...]:
+    chain: list[str] = []
+    for node in report.get("nodes") or ():
+        if not isinstance(node, Mapping):
+            continue
+        operation = node.get("decoder_used") or node.get("method")
+        if operation:
+            chain.append(str(operation))
+    return tuple(chain)
+
+
+def _indicators(report: Mapping[str, Any], analysis_id: str) -> tuple[IndicatorRecord, ...]:
+    indicators: list[IndicatorRecord] = []
+    iocs = report.get("iocs") or {}
+    if not isinstance(iocs, Mapping):
+        return ()
+    for kind in sorted(iocs):
+        items = iocs[kind]
+        if isinstance(items, (str, bytes, Mapping)):
+            items = (items,)
+        if not isinstance(items, Iterable):
+            continue
+        for item in items:
+            if isinstance(item, Mapping):
+                value = item.get("value") or item.get("normalized_value") or item.get("indicator")
+                node_id = item.get("node_id")
+                evidence_id = item.get("evidence_id") or item.get("id")
+            else:
+                value, node_id, evidence_id = item, None, None
+            if value is None or not str(value).strip():
+                continue
+            indicators.append(
+                IndicatorRecord(
+                    analysis_id=analysis_id,
+                    indicator_type=str(kind),
+                    value=str(value).strip(),
+                    references=(
+                        EvidenceReference(
+                            analysis_id=analysis_id,
+                            node_id=str(node_id) if node_id is not None else None,
+                            evidence_id=str(evidence_id) if evidence_id is not None else None,
+                            source="report.iocs",
+                        ),
+                    ),
+                )
+            )
+    return tuple(indicators)
+
+
+def _attack_ids_and_tags(report: Mapping[str, Any]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    attacks: set[str] = set()
+    tags: set[str] = set()
+
+    for detection in report.get("detections") or ():
+        if isinstance(detection, Mapping):
+            attacks.update(_string_values(detection.get("attack_ids")))
+            attacks.update(_string_values(detection.get("mitre_attack")))
+
+    threat = report.get("threat_intelligence") or {}
+    if isinstance(threat, Mapping):
+        for technique in threat.get("techniques") or ():
+            if isinstance(technique, Mapping) and technique.get("technique_id"):
+                attacks.add(str(technique["technique_id"]))
+        tags.update(_string_values(threat.get("malware_tags")))
+        for lolbin in threat.get("lolbins") or ():
+            if isinstance(lolbin, Mapping) and lolbin.get("name"):
+                tags.add(f"lolbin:{lolbin['name']}")
+            elif isinstance(lolbin, str) and lolbin:
+                tags.add(f"lolbin:{lolbin}")
+
+    return tuple(sorted(attacks)), tuple(sorted(tags))
+
+
+def analysis_record_from_report(report: Mapping[str, Any]) -> AnalysisRecord:
+    """Build the persistence-safe :class:`AnalysisRecord` for one report."""
+
+    analysis_id = _analysis_id(report)
+    if not analysis_id:
+        raise ValueError("report has no analysis identifier")
+    root_hash = _root_hash(report)
+    if not root_hash:
+        raise ValueError("report has no root hash (missing root node sha256)")
+
+    meta = report.get("meta") or {}
+    created_at = meta.get("started_at") or meta.get("created_at") or report.get("created_at")
+    attack_ids, threat_tags = _attack_ids_and_tags(report)
+
+    return AnalysisRecord(
+        analysis_id=analysis_id,
+        root_hash=root_hash,
+        created_at=str(created_at) if created_at else None,
+        indicators=_indicators(report, analysis_id),
+        attack_ids=attack_ids,
+        threat_tags=threat_tags,
+        decode_chain=_decode_chain(report),
+        metadata={"node_count": report.get("node_count")},
+    )
+
+
+def timeline_events_from_report(report: Mapping[str, Any]) -> tuple[TimelineEvent, ...]:
+    """Extract timestamped, normalized events from one report.
+
+    DFIR evidence events (``report["evidence"]["events"]``) are the primary
+    source because they carry real wall-clock timestamps. Generic
+    ``report["timeline"]`` / ``report["events"]`` entries are also accepted
+    for callers that assemble reports by hand.
+    """
+
+    analysis_id = _analysis_id(report) or "analysis"
+    events: list[TimelineEvent] = []
+
+    evidence = report.get("evidence") or {}
+    evidence_events = evidence.get("events") if isinstance(evidence, Mapping) else None
+    sources: tuple[Any, ...] = (
+        evidence_events,
+        report.get("timeline"),
+        report.get("events"),
+    )
+    for source in sources:
+        if not isinstance(source, Iterable) or isinstance(source, (str, bytes, Mapping)):
+            continue
+        for index, item in enumerate(source):
+            if not isinstance(item, Mapping):
+                continue
+            timestamp = item.get("timestamp") or item.get("time") or item.get("created_at")
+            if not timestamp:
+                continue
+            kind = str(item.get("event_type") or item.get("kind") or item.get("type") or "event")
+            summary = str(
+                item.get("summary")
+                or item.get("message")
+                or item.get("description")
+                or kind
+            )
+            # Keep only scalar observable values: comparing None or nested
+            # structures across cases would manufacture false matches.
+            metadata = {
+                key: item[key]
+                for key in _EVENT_OBSERVABLE_FIELDS
+                if isinstance(item.get(key), (str, int, float)) and item.get(key) != ""
+            }
+            for key, value in item.items():
+                if key in metadata or key in {
+                    "timestamp", "time", "created_at", "kind", "event_type",
+                    "type", "summary", "message", "description", "event_id",
+                    "id", "source", "extracted_by", "raw", "tags",
+                }:
+                    continue
+                if isinstance(value, (str, int, float)) and value != "":
+                    metadata[key] = value
+            try:
+                events.append(
+                    TimelineEvent(
+                        analysis_id=analysis_id,
+                        timestamp=str(timestamp),
+                        kind=kind,
+                        summary=summary,
+                        source_id=str(item.get("event_id") or item.get("id") or f"{analysis_id}:{index}"),
+                        metadata=metadata,
+                    )
+                )
+            except ValueError:
+                # Unparseable timestamps are skipped rather than failing the
+                # whole correlation run.
+                continue
+    return tuple(events)

--- a/titan_decoder/correlation/attribution.py
+++ b/titan_decoder/correlation/attribution.py
@@ -1,0 +1,91 @@
+"""Evidence-backed attribution hints.
+
+Combines infrastructure reuse, shared payloads, and ATT&CK/tag overlap into
+per-pair hints. A hint is an investigative lead — the output deliberately
+carries a disclaimer and never names an actor.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from .models import AnalysisRecord, stable_id
+
+SCHEMA_VERSION = "attribution-hints-v1.0"
+
+DISCLAIMER = (
+    "Attribution hints are evidence-backed investigative leads, "
+    "not actor identity claims."
+)
+
+
+def _confidence(score: float) -> str:
+    if score >= 0.75:
+        return "high"
+    if score >= 0.45:
+        return "medium"
+    return "low"
+
+
+def build_attribution_hints(
+    analyses: Iterable[AnalysisRecord],
+    infrastructure_report: Mapping[str, Any],
+    payload_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build ranked attribution hints for analysis pairs with shared evidence."""
+
+    records = {record.analysis_id: record for record in analyses}
+    pairs: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for item in infrastructure_report.get("reused_infrastructure") or ():
+        ids = sorted(item.get("analysis_ids") or ())
+        for index, left in enumerate(ids):
+            for right in ids[index + 1:]:
+                pair = pairs.setdefault((left, right), {"evidence": [], "score": 0.0})
+                pair["evidence"].append("infrastructure:" + str(item.get("indicator_type")))
+                pair["score"] += 0.35
+
+    for item in payload_report.get("matches") or ():
+        key = tuple(sorted((item["left_analysis_id"], item["right_analysis_id"])))
+        pair = pairs.setdefault(key, {"evidence": [], "score": 0.0})
+        pair["evidence"].extend(item.get("reasons") or ())
+        pair["score"] += 0.40 * float(item.get("score", 0.0))
+
+    hints: list[dict[str, Any]] = []
+    for (left, right), data in pairs.items():
+        if left in records and right in records:
+            attack_overlap = set(records[left].attack_ids) & set(records[right].attack_ids)
+            tag_overlap = set(records[left].threat_tags) & set(records[right].threat_tags)
+            if attack_overlap:
+                data["score"] += min(0.15, 0.05 * len(attack_overlap))
+                data["evidence"].append("shared_attack")
+            if tag_overlap:
+                data["score"] += min(0.10, 0.025 * len(tag_overlap))
+                data["evidence"].append("shared_threat_tag")
+        score = min(1.0, data["score"])
+        evidence = tuple(sorted(set(data["evidence"])))
+        hints.append(
+            {
+                "hint_id": stable_id(
+                    "attribution-hint",
+                    {"left": left, "right": right, "evidence": list(evidence)},
+                ),
+                "left_analysis_id": left,
+                "right_analysis_id": right,
+                "confidence": _confidence(score),
+                "score": round(score, 6),
+                "evidence": list(evidence),
+                "statement": (
+                    "Analyses share forensic characteristics; this is a lead, "
+                    "not definitive attribution."
+                ),
+            }
+        )
+
+    hints.sort(key=lambda hint: (-hint["score"], hint["hint_id"]))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "hint_count": len(hints),
+        "hints": hints,
+        "disclaimer": DISCLAIMER,
+    }

--- a/titan_decoder/correlation/campaigns.py
+++ b/titan_decoder/correlation/campaigns.py
@@ -1,0 +1,89 @@
+"""Campaign clustering over recorded analyses.
+
+Builds the pairwise relationship graph with the deterministic
+:class:`RelationshipScorer`, keeps edges at or above a score floor, and
+returns the connected components as campaigns. Campaign identifiers are
+stable digests of the sorted member set, so re-running over the same
+database yields identical output.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from .models import AnalysisRecord, Relationship, stable_id
+from .relationships import RelationshipScorer
+
+SCHEMA_VERSION = "campaign-clusters-v1.0"
+
+
+def _confidence(strongest_score: float) -> str:
+    if strongest_score >= 0.75:
+        return "high"
+    if strongest_score >= 0.45:
+        return "medium"
+    return "low"
+
+
+def cluster_campaigns(
+    analyses: Iterable[AnalysisRecord],
+    *,
+    minimum_score: float = 0.45,
+    scorer: RelationshipScorer | None = None,
+) -> dict[str, Any]:
+    """Cluster analyses into campaigns via connected relationship components."""
+
+    if not 0.0 <= minimum_score <= 1.0:
+        raise ValueError("minimum_score must be between 0 and 1")
+
+    records = tuple(sorted(analyses, key=lambda record: record.analysis_id))
+    scorer = scorer or RelationshipScorer()
+
+    graph: dict[str, set[str]] = {record.analysis_id: set() for record in records}
+    edges: list[Relationship] = []
+    for index, left in enumerate(records):
+        for right in records[index + 1:]:
+            relationship = scorer.score(left, right)
+            if relationship.score > 0.0 and relationship.score >= minimum_score:
+                graph[left.analysis_id].add(right.analysis_id)
+                graph[right.analysis_id].add(left.analysis_id)
+                edges.append(relationship)
+
+    seen: set[str] = set()
+    campaigns: list[dict[str, Any]] = []
+    for start in sorted(graph):
+        if start in seen or not graph[start]:
+            continue
+        stack, members = [start], set()
+        while stack:
+            current = stack.pop()
+            if current in seen:
+                continue
+            seen.add(current)
+            members.add(current)
+            stack.extend(sorted(graph[current] - seen, reverse=True))
+        member_ids = tuple(sorted(members))
+        relationships = [
+            edge
+            for edge in edges
+            if edge.left_analysis_id in members and edge.right_analysis_id in members
+        ]
+        strongest = max((edge.score for edge in relationships), default=0.0)
+        campaigns.append(
+            {
+                "campaign_id": stable_id("campaign", {"members": list(member_ids)}),
+                "member_analysis_ids": list(member_ids),
+                "relationship_ids": sorted(edge.relationship_id for edge in relationships),
+                "relationship_count": len(relationships),
+                "confidence": _confidence(strongest),
+                "maximum_relationship_score": round(strongest, 6),
+            }
+        )
+
+    campaigns.sort(key=lambda campaign: campaign["campaign_id"])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "minimum_score": round(minimum_score, 6),
+        "campaign_count": len(campaigns),
+        "campaigns": campaigns,
+    }

--- a/titan_decoder/correlation/infrastructure.py
+++ b/titan_decoder/correlation/infrastructure.py
@@ -1,0 +1,97 @@
+"""Infrastructure reuse detection across analyses.
+
+Flags network-infrastructure indicators (domains, URLs, public IPs,
+certificates, …) that appear in more than one recorded analysis. Private
+IP ranges are intentionally excluded: shared RFC 1918 addresses across
+unrelated cases are noise, not reuse.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from .models import AnalysisRecord, EvidenceReference, stable_id
+
+SCHEMA_VERSION = "infrastructure-reuse-v1.0"
+
+# Indicator types that describe attacker infrastructure. Both singular and
+# plural forms are accepted because report IOC keys are plural ("domains")
+# while hand-built records often use singular ("domain").
+INFRA_TYPES = frozenset(
+    {
+        "domain",
+        "domains",
+        "url",
+        "urls",
+        "ipv4_public",
+        "ipv6",
+        "ip",
+        "ips",
+        "certificate",
+        "certificates",
+        "ja3",
+        "ja4",
+        "asn",
+        "nameserver",
+        "whois_email",
+    }
+)
+
+
+@dataclass(frozen=True)
+class InfrastructureReuse:
+    """One indicator observed in two or more analyses."""
+
+    indicator_type: str
+    normalized_value: str
+    analysis_ids: tuple[str, ...]
+
+    @property
+    def reuse_id(self) -> str:
+        return stable_id(
+            "infrastructure-reuse",
+            {
+                "type": self.indicator_type,
+                "value": self.normalized_value,
+                "analyses": list(self.analysis_ids),
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "reuse_id": self.reuse_id,
+            "indicator_type": self.indicator_type,
+            "normalized_value": self.normalized_value,
+            "analysis_ids": list(self.analysis_ids),
+            "reuse_count": len(self.analysis_ids),
+            "references": [
+                EvidenceReference(analysis_id, source="infrastructure").to_dict()
+                for analysis_id in self.analysis_ids
+            ],
+        }
+
+
+def detect_infrastructure_reuse(analyses: Iterable[AnalysisRecord]) -> dict[str, Any]:
+    """Return every infrastructure indicator shared by two or more analyses."""
+
+    index: dict[tuple[str, str], set[str]] = {}
+    for analysis in analyses:
+        for indicator in analysis.indicators:
+            kind = indicator.indicator_type.lower()
+            if kind not in INFRA_TYPES:
+                continue
+            key = (kind, indicator.normalized_value or indicator.value)
+            index.setdefault(key, set()).add(analysis.analysis_id)
+
+    results = [
+        InfrastructureReuse(kind, value, tuple(sorted(ids)))
+        for (kind, value), ids in index.items()
+        if len(ids) > 1
+    ]
+    results.sort(key=lambda item: (-len(item.analysis_ids), item.indicator_type, item.normalized_value))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "reuse_count": len(results),
+        "reused_infrastructure": [item.to_dict() for item in results],
+    }

--- a/titan_decoder/correlation/payload_similarity.py
+++ b/titan_decoder/correlation/payload_similarity.py
@@ -1,0 +1,167 @@
+"""Shared payload detection across analyses.
+
+Builds a deterministic fingerprint per report from node content hashes and
+the decode chain, then scores pairwise similarity. An exact content-hash
+match dominates the score; fuzzy/import/resource hashes (when a report
+carries them) and decode-chain overlap corroborate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from .models import stable_id
+
+SCHEMA_VERSION = "shared-payload-v1.0"
+
+
+@dataclass(frozen=True)
+class PayloadFingerprint:
+    """Hash-level summary of the payloads inside one analysis."""
+
+    analysis_id: str
+    root_hash: str
+    payload_hashes: tuple[str, ...] = ()
+    fuzzy_hashes: tuple[str, ...] = ()
+    import_hashes: tuple[str, ...] = ()
+    resource_hashes: tuple[str, ...] = ()
+    decode_chain: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SharedPayload:
+    """One payload-similarity match between two analyses."""
+
+    left_analysis_id: str
+    right_analysis_id: str
+    score: float
+    reasons: tuple[str, ...]
+
+    @property
+    def match_id(self) -> str:
+        return stable_id(
+            "shared-payload",
+            {
+                "left": self.left_analysis_id,
+                "right": self.right_analysis_id,
+                "reasons": list(self.reasons),
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "match_id": self.match_id,
+            "left_analysis_id": self.left_analysis_id,
+            "right_analysis_id": self.right_analysis_id,
+            "score": round(self.score, 6),
+            "reasons": list(self.reasons),
+        }
+
+
+def _jaccard(left: Iterable[str], right: Iterable[str]) -> float:
+    left_set, right_set = set(left), set(right)
+    union = left_set | right_set
+    if not union:
+        return 0.0
+    return len(left_set & right_set) / len(union)
+
+
+def fingerprint_from_report(report: Mapping[str, Any]) -> PayloadFingerprint:
+    """Build a payload fingerprint from an analysis report."""
+
+    meta = report.get("meta") or {}
+    analysis_id = str(
+        meta.get("analysis_id") or report.get("analysis_id") or report.get("root_hash") or ""
+    )
+    root_hash = str(report.get("root_hash") or meta.get("root_hash") or "")
+
+    hashes: set[str] = set()
+    fuzzy: set[str] = set()
+    imports: set[str] = set()
+    resources: set[str] = set()
+    chain: list[str] = []
+    for node in report.get("nodes") or ():
+        if not isinstance(node, Mapping):
+            continue
+        for key in ("sha256", "content_hash", "payload_hash", "hash"):
+            if node.get(key):
+                hashes.add(str(node[key]))
+        if node.get("parent") is None and node.get("sha256") and not root_hash:
+            root_hash = str(node["sha256"])
+        if node.get("ssdeep"):
+            fuzzy.add("ssdeep:" + str(node["ssdeep"]))
+        if node.get("tlsh"):
+            fuzzy.add("tlsh:" + str(node["tlsh"]))
+        if node.get("imphash"):
+            imports.add(str(node["imphash"]))
+        for value in node.get("resource_hashes") or ():
+            resources.add(str(value))
+        operation = node.get("decoder_used") or node.get("method")
+        if operation:
+            chain.append(str(operation))
+    if root_hash:
+        hashes.add(root_hash)
+
+    return PayloadFingerprint(
+        analysis_id=analysis_id,
+        root_hash=root_hash,
+        payload_hashes=tuple(sorted(hashes)),
+        fuzzy_hashes=tuple(sorted(fuzzy)),
+        import_hashes=tuple(sorted(imports)),
+        resource_hashes=tuple(sorted(resources)),
+        decode_chain=tuple(chain),
+    )
+
+
+def detect_shared_payloads(
+    fingerprints: Iterable[PayloadFingerprint],
+    *,
+    minimum_score: float = 0.35,
+) -> dict[str, Any]:
+    """Score every fingerprint pair and keep matches at or above the floor."""
+
+    if not 0.0 <= minimum_score <= 1.0:
+        raise ValueError("minimum_score must be between 0 and 1")
+
+    items = sorted(fingerprints, key=lambda item: item.analysis_id)
+    matches: list[SharedPayload] = []
+    for index, left in enumerate(items):
+        for right in items[index + 1:]:
+            if left.analysis_id == right.analysis_id:
+                continue
+            exact = bool(set(left.payload_hashes) & set(right.payload_hashes))
+            fuzzy = _jaccard(left.fuzzy_hashes, right.fuzzy_hashes)
+            imports = _jaccard(left.import_hashes, right.import_hashes)
+            resources = _jaccard(left.resource_hashes, right.resource_hashes)
+            chain = _jaccard(left.decode_chain, right.decode_chain)
+            score = min(
+                1.0,
+                (0.55 if exact else 0.0)
+                + 0.15 * fuzzy
+                + 0.15 * imports
+                + 0.10 * resources
+                + 0.05 * chain,
+            )
+            reasons: list[str] = []
+            if exact:
+                reasons.append("exact_payload_hash")
+            if fuzzy:
+                reasons.append("shared_fuzzy_hash")
+            if imports:
+                reasons.append("shared_import_hash")
+            if resources:
+                reasons.append("shared_resource_hash")
+            if chain:
+                reasons.append("decode_chain_similarity")
+            if score >= minimum_score and reasons:
+                matches.append(
+                    SharedPayload(left.analysis_id, right.analysis_id, score, tuple(reasons))
+                )
+
+    matches.sort(key=lambda match: (-match.score, match.match_id))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "match_count": len(matches),
+        "matches": [match.to_dict() for match in matches],
+    }

--- a/titan_decoder/correlation/service.py
+++ b/titan_decoder/correlation/service.py
@@ -1,0 +1,98 @@
+"""End-to-end Phase 5 orchestration for one analysis report.
+
+``analyze_milestone5`` is the single entry point used by the CLI: it
+normalizes the subject report, correlates it against the local database,
+clusters campaigns, correlates timelines, detects infrastructure reuse and
+shared payloads, and derives attribution hints plus the analyst view.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .adapters import analysis_record_from_report, timeline_events_from_report
+from .attribution import build_attribution_hints
+from .campaigns import cluster_campaigns
+from .database import CorrelationDatabase
+from .engine import CorrelationEngine
+from .infrastructure import detect_infrastructure_reuse
+from .payload_similarity import detect_shared_payloads, fingerprint_from_report
+from .timeline_correlation import correlate_timelines
+from .views import analyst_summary
+
+SCHEMA_VERSION = "milestone-5-report-v1.0"
+
+
+def analyze_milestone5(
+    report: Mapping[str, Any],
+    database_path: str | Path,
+    *,
+    prior_reports: Iterable[Mapping[str, Any]] = (),
+    minimum_relationship_score: float = 0.0,
+    minimum_campaign_score: float = 0.45,
+    minimum_payload_score: float = 0.35,
+    timeline_window_seconds: float = 300.0,
+    record_subject: bool = True,
+) -> dict[str, Any]:
+    """Run the full Phase 5 correlation suite for one report.
+
+    Relationship scoring, campaign clustering, infrastructure reuse, and
+    attribution hints operate on the persisted analysis records (including
+    the subject). Payload fingerprints and timeline events need node- and
+    event-level detail that is not persisted, so they come from the subject
+    report plus any ``prior_reports`` supplied by the caller.
+    """
+
+    subject = analysis_record_from_report(report)
+    prior_reports = tuple(prior_reports)
+
+    with CorrelationDatabase(database_path) as database:
+        correlation = CorrelationEngine(
+            database, minimum_score=minimum_relationship_score
+        ).correlate(subject, record_subject=record_subject)
+        analyses = list(database.iter_analyses())
+        if not record_subject:
+            analyses.append(subject)
+
+    reports = prior_reports + (report,)
+    infrastructure = detect_infrastructure_reuse(analyses)
+    shared_payloads = detect_shared_payloads(
+        (fingerprint_from_report(item) for item in reports),
+        minimum_score=minimum_payload_score,
+    )
+    events = [
+        event for item in reports for event in timeline_events_from_report(item)
+    ]
+    timeline = correlate_timelines(events, window_seconds=timeline_window_seconds)
+
+    result: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "correlation": correlation.to_dict(),
+        "campaigns": cluster_campaigns(analyses, minimum_score=minimum_campaign_score),
+        "timeline_correlation": timeline,
+        "infrastructure_reuse": infrastructure,
+        "shared_payloads": shared_payloads,
+        "attribution_hints": build_attribution_hints(
+            analyses, infrastructure, shared_payloads
+        ),
+    }
+    result["analyst_view"] = analyst_summary(result)
+    return result
+
+
+def correlate_report(
+    report: Mapping[str, Any],
+    database_path: str | Path,
+    *,
+    minimum_score: float = 0.0,
+    record_subject: bool = True,
+) -> dict[str, Any]:
+    """Convenience wrapper returning only the relationship correlation."""
+
+    return analyze_milestone5(
+        report,
+        database_path,
+        minimum_relationship_score=minimum_score,
+        record_subject=record_subject,
+    )["correlation"]

--- a/titan_decoder/correlation/timeline_correlation.py
+++ b/titan_decoder/correlation/timeline_correlation.py
@@ -1,0 +1,121 @@
+"""Cross-case timeline correlation.
+
+Links events from *different* analyses that fall within a configurable time
+window and either share observable metadata values (domain, IP, hash, …) or
+are the same kind of event. Scores are deterministic: a fixed semantic
+component plus temporal proximity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Iterable
+
+from .models import stable_id
+from .timeline import TimelineEvent, sort_timeline
+
+SCHEMA_VERSION = "timeline-correlation-v1.0"
+
+
+@dataclass(frozen=True)
+class TimelineLink:
+    """One deterministic link between events from two analyses."""
+
+    left_event_id: str
+    right_event_id: str
+    delta_seconds: float
+    reason: str
+    score: float
+
+    @property
+    def link_id(self) -> str:
+        return stable_id(
+            "timeline-link",
+            {
+                "left": self.left_event_id,
+                "right": self.right_event_id,
+                "reason": self.reason,
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "link_id": self.link_id,
+            "left_event_id": self.left_event_id,
+            "right_event_id": self.right_event_id,
+            "delta_seconds": round(self.delta_seconds, 6),
+            "reason": self.reason,
+            "score": round(self.score, 6),
+        }
+
+
+def _comparable_values(event: TimelineEvent) -> set[str]:
+    """Metadata values that are safe to compare across analyses."""
+
+    return {
+        str(value)
+        for value in event.metadata.values()
+        if isinstance(value, (str, int, float)) and str(value)
+    }
+
+
+def _parse(timestamp: str) -> datetime:
+    return datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+
+def correlate_timelines(
+    events: Iterable[TimelineEvent],
+    *,
+    window_seconds: float = 300.0,
+) -> dict[str, Any]:
+    """Correlate normalized events across analyses.
+
+    Only pairs from different analyses within ``window_seconds`` of each
+    other are considered. Shared observable metadata is required for a
+    strong link; matching event kinds alone produce a weaker one.
+    """
+
+    if window_seconds < 0:
+        raise ValueError("window_seconds must be non-negative")
+
+    ordered = sort_timeline(events)
+    links: list[TimelineLink] = []
+    for index, left in enumerate(ordered):
+        left_time = _parse(left.timestamp)
+        left_values = _comparable_values(left)
+        for right in ordered[index + 1:]:
+            if left.analysis_id == right.analysis_id:
+                continue
+            delta = abs((_parse(right.timestamp) - left_time).total_seconds())
+            if delta > window_seconds:
+                # Events are sorted chronologically, so once one falls
+                # outside the window every later one does too.
+                break
+            shared = sorted(left_values & _comparable_values(right))
+            if not shared and left.kind != right.kind:
+                continue
+            reason = (
+                "shared_metadata:" + ",".join(shared[:5])
+                if shared
+                else "same_event_kind"
+            )
+            proximity = 1.0 if window_seconds == 0 else max(0.0, 1.0 - delta / window_seconds)
+            semantic = 1.0 if shared else 0.5
+            links.append(
+                TimelineLink(
+                    left_event_id=left.event_id,
+                    right_event_id=right.event_id,
+                    delta_seconds=delta,
+                    reason=reason,
+                    score=min(1.0, 0.65 * semantic + 0.35 * proximity),
+                )
+            )
+
+    links.sort(key=lambda link: (-link.score, link.delta_seconds, link.link_id))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "event_count": len(ordered),
+        "link_count": len(links),
+        "links": [link.to_dict() for link in links],
+    }

--- a/titan_decoder/correlation/views.py
+++ b/titan_decoder/correlation/views.py
@@ -1,0 +1,70 @@
+"""Analyst-facing views over Phase 5 correlation results."""
+
+from __future__ import annotations
+
+from html import escape
+import json
+from typing import Any, Mapping
+
+SCHEMA_VERSION = "analyst-correlation-view-v1.0"
+
+
+def analyst_summary(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Condense a full Phase 5 result into one analyst-oriented view."""
+
+    correlation = result.get("correlation") or {}
+    relationships = sorted(
+        correlation.get("relationships") or [],
+        key=lambda item: (-float(item.get("score", 0.0)), item.get("relationship_id", "")),
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "subject_analysis_id": correlation.get("subject_analysis_id"),
+        "relationship_count": len(relationships),
+        "top_relationships": relationships[:10],
+        "campaigns": result.get("campaigns") or {},
+        "timeline_correlation": result.get("timeline_correlation") or {},
+        "infrastructure_reuse": result.get("infrastructure_reuse") or {},
+        "shared_payloads": result.get("shared_payloads") or {},
+        "attribution_hints": result.get("attribution_hints") or {},
+    }
+
+
+def to_markdown(view: Mapping[str, Any]) -> str:
+    """Render the analyst view as a short Markdown summary."""
+
+    def count(section: str, key: str) -> Any:
+        return (view.get(section) or {}).get(key, 0)
+
+    lines = [
+        "# Titan Phase 5 Correlation",
+        "",
+        f"- Subject: `{view.get('subject_analysis_id') or 'unknown'}`",
+        f"- Relationships: **{view.get('relationship_count', 0)}**",
+        f"- Campaigns: **{count('campaigns', 'campaign_count')}**",
+        f"- Timeline links: **{count('timeline_correlation', 'link_count')}**",
+        f"- Infrastructure reuse: **{count('infrastructure_reuse', 'reuse_count')}**",
+        f"- Shared payloads: **{count('shared_payloads', 'match_count')}**",
+        f"- Attribution hints: **{count('attribution_hints', 'hint_count')}**",
+    ]
+    disclaimer = (view.get("attribution_hints") or {}).get("disclaimer")
+    if disclaimer:
+        lines += ["", f"> {disclaimer}"]
+    return "\n".join(lines) + "\n"
+
+
+def to_html(view: Mapping[str, Any]) -> str:
+    """Render the analyst view as a self-contained HTML page.
+
+    The full view is embedded as an escaped JSON block so downstream tooling
+    can recover the machine-readable data from the HTML artifact.
+    """
+
+    return (
+        "<!doctype html><html><head><meta charset=\"utf-8\">"
+        "<title>Titan Phase 5 Correlation</title></head><body><pre>"
+        + escape(to_markdown(view))
+        + "</pre><script type=\"application/json\" id=\"correlation-view\">"
+        + escape(json.dumps(view, sort_keys=True))
+        + "</script></body></html>"
+    )


### PR DESCRIPTION
## Summary

Completes the Phase 5 evidence-correlation milestone on top of the Phase 5.1 foundation (#111), adding the remaining capabilities:

- **Campaign clustering** (`titan_decoder/correlation/campaigns.py`): connected components over the deterministic relationship graph, with stable campaign IDs derived from the sorted member set and per-campaign confidence (`campaign-clusters-v1.0`).
- **Cross-case timeline correlation** (`timeline_correlation.py`): links events from *different* analyses within a configurable window (default 300s). Shared observable metadata (domain, IP, hash, host, user) forms strong links; matching event kinds alone form weaker ones. `None` and nested metadata values are never compared, so sparse events cannot false-match (`timeline-correlation-v1.0`).
- **Infrastructure reuse detection** (`infrastructure.py`): domains, URLs, public IPs, certificates, JA3/JA4, ASNs, nameservers, and WHOIS emails observed in more than one recorded analysis. Private IP ranges are excluded by design — shared RFC 1918 addresses are noise, not reuse (`infrastructure-reuse-v1.0`).
- **Shared payload detection** (`payload_similarity.py`): per-report fingerprints from node content hashes and decode chains, pairwise scoring with exact-hash-dominant weighting (0.55), corroborated by fuzzy/import/resource hashes when present (`shared-payload-v1.0`).
- **Attribution hints** (`attribution.py`): per-pair hints combining infrastructure reuse, shared payloads, and ATT&CK/tag overlap. Hints are explicitly investigative leads — every hint carries a statement and the report carries a disclaimer that hints are never actor identity claims (`attribution-hints-v1.0`).
- **Report adapters** (`adapters.py`): translate engine reports into correlation records — root hash from the root node's `sha256`, decode chain from `decoder_used`/`method`, ATT&CK IDs from detections plus threat-intelligence techniques, threat tags from `malware_tags`/LOLBins, timeline events from DFIR evidence events (`evidence.events`).
- **Service orchestration** (`service.py::analyze_milestone5`): runs the full suite against the local SQLite database and returns the versioned `milestone-5-report-v1.0` result, including the analyst view (`views.py`: JSON/Markdown/self-contained HTML).
- **CLI integration**: `--correlation-db`, `--correlation-out`, `--correlation-min-score`, `--correlation-no-record`, `--campaign-out`, `--campaign-min-score`, `--timeline-correlation-out`, `--timeline-window-seconds`, `--infrastructure-reuse-out`, `--shared-payload-out`, `--shared-payload-min-score`, `--attribution-hints-out`, `--analyst-correlation-out`, `--analyst-correlation-format`. Requesting any of them runs the suite and embeds the sections in the main JSON report.
- **Schema + docs**: `schemas/milestone-5-report-v1.0.schema.json`, expanded `docs/EVIDENCE_CORRELATION.md`, new CLI section in `docs/CLI_REFERENCE.md`, changelog entry.

Everything is offline-first and deterministic: re-running over the same inputs yields identical output, including all identifiers (covered by a determinism test).

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q                 # 520 passed
ruff check .              # all checks passed
mypy titan_decoder/       # no issues in 63 source files
```

- Notes: 27 new tests cover every new module (unit), end-to-end `analyze_milestone5` runs, determinism across databases, JSON-schema validation of the combined result (with local `$ref` resolution to the correlation schema), and the CLI stage (no-op without flags, output files, embedded report sections, failure exit code). Also verified end-to-end by running the real CLI on two related base64 samples through a shared correlation DB: relationship score 0.85, one campaign, two reused infrastructure indicators (domain + URL), one attribution hint.

## Screenshots / Output (optional)

Analyst view (`--analyst-correlation-out view.md --analyst-correlation-format markdown`) from the end-to-end run, redacted to test data:

```markdown
# Titan Phase 5 Correlation

- Subject: `5fa30118-...`
- Relationships: **1**
- Campaigns: **1**
- Timeline links: **0**
- Infrastructure reuse: **2**
- Shared payloads: **0**
- Attribution hints: **1**

> Attribution hints are evidence-backed investigative leads, not actor identity claims.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q

---
_Generated by [Claude Code](https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q)_