### PR TITLE
Complete Milestone 5: cross-case persistence and correlation search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+Evidence correlation (Milestone 5 completion):
+
+- Cross-case persistence (correlation database schema v2): payload
+  fingerprints and timeline events are stored alongside indicator records,
+  so shared-payload and timeline correlation now operate across every
+  recorded case without needing in-process `prior_reports`. Timeline
+  events are capped at a deterministic 2,000 per analysis; v1 databases
+  upgrade in place on open.
+- Cross-case search: `--correlation-search [TYPE:]VALUE` (repeatable,
+  standalone mode — no input file) queries the correlation IOC database
+  and returns matching analyses with stored evidence references
+  (`correlation-search-v1.0`). Also available as
+  `titan_decoder.correlation.service.search_cases`.
+- Deprecated the legacy `core/correlation.py` `CorrelationStore`
+  (config key `enable_correlation`) in favor of the Phase 5 correlation
+  database; using it now prints a deprecation warning.
+- Roadmap updated: evidence correlation moved to Shipped; Plugin SDK v1
+  and Analyst Workbench listed as next work.
+
 Evidence correlation (Phase 5 milestone complete):
 
 - Campaign clustering (`titan_decoder/correlation/campaigns.py`): connected

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -112,6 +112,14 @@ without persisting the current analysis). The analyst view renders as
 `json`, `markdown`, or `html`. See
 [EVIDENCE_CORRELATION.md](EVIDENCE_CORRELATION.md).
 
+Cross-case search runs standalone (no input file) and exits:
+
+```bash
+titan-decoder --correlation-db cases.sqlite3 --correlation-search c2.example
+titan-decoder --correlation-db cases.sqlite3 --correlation-search domains:c2.example \
+  --correlation-search urls:https://c2.example/gate.php
+```
+
 ## Graph formats
 
 ```bash

--- a/docs/EVIDENCE_CORRELATION.md
+++ b/docs/EVIDENCE_CORRELATION.md
@@ -75,6 +75,22 @@ contributes 0.55; fuzzy/import/resource hashes (when present) and
 decode-chain overlap corroborate. Matches below
 `--shared-payload-min-score` (default 0.35) are dropped.
 
+### Cross-case persistence and search
+
+Payload fingerprints and timeline events are persisted in the correlation
+database (schema v2) alongside indicator records, so shared-payload and
+timeline correlation operate across every recorded case — no in-process
+report set is required. Timeline events are capped at a deterministic
+2,000 per analysis. v1 databases upgrade in place on open; analyses
+recorded before v2 lack stored fingerprints/events until re-analyzed.
+
+`--correlation-search [TYPE:]VALUE` (repeatable) searches recorded
+indicators across cases and exits without running an analysis. Matching is
+exact on the normalized value and case-insensitive; results include each
+match's evidence references (`correlation-search-v1.0`). The same query
+API is available as
+`titan_decoder.correlation.service.search_cases(db_path, queries)`.
+
 ### Attribution hints (`attribution.py`)
 
 Combines infrastructure reuse, shared payloads, and ATT&CK/tag overlap

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,10 +21,12 @@ This roadmap separates shipped features from planned work.
 - Catalog/producer parity: every ATT&CK catalog entry has a built-in producer or an explicit rule-pack-only designation
 - Repeatable performance benchmarks with a committed baseline and CI regression gate
 - Rule-pack hardening: enforced validation, duplicate-ID checks (including built-in impersonation), per-pack limits, fixtures, and a strict `--rules-validate` gate
+- Evidence correlation platform (Milestone 5): cross-case IOC database, relationship scoring, campaign clustering, timeline correlation, infrastructure reuse detection, shared payload detection, attribution hints, analyst views, persisted cross-case fingerprints/events, and `--correlation-search`
 
 ## Highest-value next work
 
-1. Improve cross-source evidence correlation while preserving provenance.
+1. Plugin SDK v1: stable public decoder/analyzer/detection/report APIs, plugin manifest and validation, semantic version compatibility, example plugins, and developer documentation.
+2. Analyst Workbench: interactive exploration of reports (timeline explorer, graph viewer, IOC/evidence browsers, decode-tree navigation, search/filter/export, investigation workspace).
 
 ## Optional local AI assistant
 

--- a/tests/test_correlation_cross_case.py
+++ b/tests/test_correlation_cross_case.py
@@ -1,0 +1,205 @@
+"""Tests for cross-case persistence (schema v2) and correlation search.
+
+Covers the Milestone 5 completion work: payload fingerprints and timeline
+events persisted in the correlation database (making shared-payload and
+timeline correlation fully cross-case, with no ``prior_reports`` needed),
+plus indicator search across recorded cases.
+"""
+
+import json
+import sqlite3
+
+from titan_decoder import cli
+from titan_decoder.correlation.database import (
+    DATABASE_SCHEMA_VERSION,
+    MAX_TIMELINE_EVENTS_PER_ANALYSIS,
+    CorrelationDatabase,
+)
+from titan_decoder.correlation.models import AnalysisRecord
+from titan_decoder.correlation.payload_similarity import PayloadFingerprint
+from titan_decoder.correlation.service import analyze_milestone5, search_cases
+from titan_decoder.correlation.timeline import TimelineEvent
+
+
+def _report(analysis_id: str, domain: str, timestamp: str):
+    return {
+        "meta": {"analysis_id": analysis_id, "started_at": "2026-01-01T00:00:00+00:00"},
+        "node_count": 2,
+        "nodes": [
+            {"id": 0, "parent": None, "method": "SOURCE", "sha256": f"root-{analysis_id}"},
+            {"id": 1, "parent": 0, "method": "Base64", "decoder_used": "Base64", "sha256": "same"},
+        ],
+        "iocs": {"domains": [domain]},
+        "evidence": {
+            "events": [
+                {
+                    "event_id": f"ev-{analysis_id}",
+                    "event_type": "dns_query",
+                    "timestamp": timestamp,
+                    "domain": domain,
+                }
+            ]
+        },
+    }
+
+
+def test_fingerprint_round_trip(tmp_path):
+    fingerprint = PayloadFingerprint(
+        "case-a", "root", payload_hashes=("h1", "h2"), decode_chain=("SOURCE", "Base64")
+    )
+    with CorrelationDatabase(tmp_path / "c.sqlite3") as database:
+        database.record_analysis(AnalysisRecord("case-a", "root"))
+        database.record_fingerprint(fingerprint)
+        stored = database.iter_fingerprints()
+    assert stored == (fingerprint,)
+    assert PayloadFingerprint.from_dict(fingerprint.to_dict()) == fingerprint
+
+
+def test_timeline_event_round_trip_and_cap(tmp_path):
+    events = tuple(
+        TimelineEvent(
+            "case-a",
+            f"2026-01-01T00:{index // 60:02d}:{index % 60:02d}Z",
+            "dns_query",
+            "query",
+            source_id=f"src-{index}",
+        )
+        for index in range(MAX_TIMELINE_EVENTS_PER_ANALYSIS + 5)
+    )
+    with CorrelationDatabase(tmp_path / "c.sqlite3") as database:
+        database.record_analysis(AnalysisRecord("case-a", "root"))
+        database.record_timeline_events("case-a", events)
+        stored = database.iter_timeline_events()
+    assert len(stored) == MAX_TIMELINE_EVENTS_PER_ANALYSIS
+    # Recomputed event ids must match the originals after a round trip.
+    assert stored[0].event_id == events[0].event_id
+    assert TimelineEvent.from_dict(events[0].to_dict()) == events[0]
+
+
+def test_v1_database_upgrades_on_open(tmp_path):
+    path = tmp_path / "old.sqlite3"
+    # Minimal v1 layout: analyses/indicators only, no v2 tables.
+    connection = sqlite3.connect(str(path))
+    connection.executescript(
+        """
+        CREATE TABLE correlation_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE analyses (
+            analysis_id TEXT PRIMARY KEY, root_hash TEXT NOT NULL,
+            created_at TEXT, payload_json TEXT NOT NULL
+        );
+        CREATE TABLE indicators (
+            indicator_id TEXT NOT NULL, analysis_id TEXT NOT NULL,
+            indicator_type TEXT NOT NULL, normalized_value TEXT NOT NULL,
+            payload_json TEXT NOT NULL, PRIMARY KEY (analysis_id, indicator_id)
+        );
+        INSERT INTO correlation_meta VALUES ('schema_version', '1');
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    with CorrelationDatabase(path) as database:
+        assert database.schema_version() == DATABASE_SCHEMA_VERSION
+        assert database.iter_fingerprints() == ()
+        assert database.iter_timeline_events() == ()
+
+
+def test_shared_payloads_and_timeline_are_cross_case_without_prior_reports(tmp_path):
+    """The core Milestone 5 completion: no prior_reports needed."""
+
+    db = tmp_path / "correlation.sqlite3"
+    analyze_milestone5(_report("case-a", "c2.test", "2026-01-01T00:00:00Z"), db)
+    result = analyze_milestone5(
+        _report("case-b", "c2.test", "2026-01-01T00:01:00Z"), db
+    )
+
+    assert result["shared_payloads"]["match_count"] == 1
+    match = result["shared_payloads"]["matches"][0]
+    assert {match["left_analysis_id"], match["right_analysis_id"]} == {"case-a", "case-b"}
+
+    assert result["timeline_correlation"]["event_count"] == 2
+    assert result["timeline_correlation"]["link_count"] == 1
+
+
+def test_prior_reports_still_supported_and_not_double_counted(tmp_path):
+    db = tmp_path / "correlation.sqlite3"
+    first = _report("case-a", "c2.test", "2026-01-01T00:00:00Z")
+    analyze_milestone5(first, db)
+    # Passing the recorded report again as prior_reports must not duplicate
+    # its fingerprint or events.
+    result = analyze_milestone5(
+        _report("case-b", "c2.test", "2026-01-01T00:01:00Z"),
+        db,
+        prior_reports=(first,),
+    )
+    assert result["shared_payloads"]["match_count"] == 1
+    assert result["timeline_correlation"]["event_count"] == 2
+
+
+def test_search_cases_by_value_and_type(tmp_path):
+    db = tmp_path / "correlation.sqlite3"
+    analyze_milestone5(_report("case-a", "c2.test", "2026-01-01T00:00:00Z"), db)
+    analyze_milestone5(_report("case-b", "c2.test", "2026-01-01T00:01:00Z"), db)
+    analyze_milestone5(_report("case-c", "other.test", "2026-01-01T00:02:00Z"), db)
+
+    result = search_cases(db, ["c2.test"])
+    assert result["schema_version"] == "correlation-search-v1.0"
+    entry = result["results"][0]
+    assert entry["analysis_ids"] == ["case-a", "case-b"]
+    assert entry["match_count"] == 2
+    # Stored indicator payloads carry evidence references.
+    assert entry["matches"][0]["indicator"]["references"]
+
+    typed = search_cases(db, ["domains:c2.test", "hashes:c2.test"])
+    assert typed["results"][0]["indicator_type"] == "domains"
+    assert typed["results"][0]["analysis_ids"] == ["case-a", "case-b"]
+    assert typed["results"][1]["analysis_ids"] == []
+
+
+def test_search_cases_is_case_insensitive_and_handles_urls(tmp_path):
+    db = tmp_path / "correlation.sqlite3"
+    report = _report("case-a", "c2.test", "2026-01-01T00:00:00Z")
+    report["iocs"]["urls"] = ["https://c2.test/gate.php"]
+    analyze_milestone5(report, db)
+
+    upper = search_cases(db, ["C2.TEST"])
+    assert upper["results"][0]["analysis_ids"] == ["case-a"]
+
+    # A URL query contains colons but must not be parsed as a type filter.
+    url = search_cases(db, ["https://c2.test/gate.php"])
+    assert url["results"][0]["indicator_type"] is None
+    assert url["results"][0]["analysis_ids"] == ["case-a"]
+
+
+def _cli_args(**over):
+    args = cli.build_parser().parse_args([])
+    for key, value in over.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_cli_correlation_search_mode(tmp_path, capsys):
+    from titan_decoder.config import Config
+
+    db = tmp_path / "correlation.sqlite3"
+    analyze_milestone5(_report("case-a", "c2.test", "2026-01-01T00:00:00Z"), db)
+
+    args = _cli_args(correlation_search=["c2.test"], correlation_db=db)
+    exit_code = cli.handle_info_commands(args, Config())
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["results"][0]["analysis_ids"] == ["case-a"]
+
+
+def test_cli_correlation_search_runs_without_input_file(tmp_path, capsys):
+    """Search is an early-exit mode: an empty database is a valid query target."""
+
+    from titan_decoder.config import Config
+
+    args = _cli_args(
+        correlation_search=["nothing.test"],
+        correlation_db=tmp_path / "fresh.sqlite3",
+    )
+    assert cli.handle_info_commands(args, Config()) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["results"][0]["match_count"] == 0

--- a/tests/test_correlation_database.py
+++ b/tests/test_correlation_database.py
@@ -1,4 +1,7 @@
-from titan_decoder.correlation.database import CorrelationDatabase
+from titan_decoder.correlation.database import (
+    DATABASE_SCHEMA_VERSION,
+    CorrelationDatabase,
+)
 from titan_decoder.correlation.models import AnalysisRecord, IndicatorRecord
 
 
@@ -18,7 +21,7 @@ def test_database_upsert_and_lookup(tmp_path):
         loaded = database.get_analysis("case-a")
         assert loaded is not None
         assert loaded.indicators[0].value == "changed.test"
-        assert database.schema_version() == 1
+        assert database.schema_version() == DATABASE_SCHEMA_VERSION
 
 
 def test_database_indicator_query_is_deterministic(tmp_path):

--- a/tests/test_correlation_service.py
+++ b/tests/test_correlation_service.py
@@ -223,7 +223,9 @@ def test_cli_phase5_stage_writes_outputs(tmp_path, capsys):
     assert correlation["subject_analysis_id"] == "case-b"
     assert json.loads((tmp_path / "campaigns.json").read_text())["campaign_count"] == 1
     assert json.loads((tmp_path / "infra.json").read_text())["reuse_count"] == 1
-    assert json.loads((tmp_path / "payloads.json").read_text())["match_count"] == 0
+    # Fingerprints persist in the database (schema v2), so the shared payload
+    # with recorded case-a is found without passing prior reports in-process.
+    assert json.loads((tmp_path / "payloads.json").read_text())["match_count"] == 1
     hints = json.loads((tmp_path / "hints.json").read_text())
     assert hints["hint_count"] == 1
     assert "# Titan Phase 5 Correlation" in (tmp_path / "view.md").read_text()

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -295,6 +295,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Write the cross-case correlation report (relationships) to a JSON file",
     )
     parser.add_argument(
+        "--correlation-search",
+        action="append",
+        metavar="[TYPE:]VALUE",
+        help=(
+            "Search the correlation database for an indicator across recorded "
+            "cases and exit (repeatable). Prefix with an indicator type to "
+            "restrict, e.g. domains:c2.example"
+        ),
+    )
+    parser.add_argument(
         "--correlation-min-score",
         type=float,
         default=0.0,
@@ -479,6 +489,22 @@ def handle_info_commands(args, config) -> "int | None":
     if args.vault_list_recent is not None:
         recent = _vault_list_recent(config, int(args.vault_list_recent))
         print(json.dumps({"recent": recent}, indent=2))
+        return 0
+
+    # Correlation search mode: query the Phase 5 cross-case IOC database and
+    # exit (no input file required).
+    if args.correlation_search:
+        from .correlation.service import search_cases
+
+        db_path = args.correlation_db or (
+            Path.home() / ".titan_decoder" / "correlation.sqlite3"
+        )
+        try:
+            result = search_cases(db_path, args.correlation_search)
+        except (OSError, RuntimeError, ValueError) as exc:
+            print(f"Error: correlation search failed: {exc}", file=sys.stderr)
+            return 1
+        print(json.dumps(result, indent=2))
         return 0
 
     # Vault search mode: query prior runs and exit (no input file required).
@@ -995,8 +1021,16 @@ def write_outputs_stage(args, config, report, engine, detections, risk_assessmen
         iocs = build_ioc_summary(report, forensics_summary)
         _merge_evidence_iocs(iocs, evidence_result)
 
-        # Correlation (optional, config-driven)
+        # Correlation (optional, config-driven). Deprecated: the Phase 5
+        # correlation database (--correlation-db and friends) supersedes this
+        # store with evidence-backed relationships and cross-case search.
         if config.get("enable_correlation", False):
+            if not args.quiet:
+                print(
+                    "Warning: enable_correlation/CorrelationStore is deprecated; "
+                    "use --correlation-db and --correlation-search instead.",
+                    file=sys.stderr,
+                )
             try:
                 from .core.correlation import CorrelationStore
 

--- a/titan_decoder/core/correlation.py
+++ b/titan_decoder/core/correlation.py
@@ -1,5 +1,11 @@
 """Simple SQLite-based correlation cache for IOCs.
 
+Deprecated: superseded by the Phase 5 correlation package
+(``titan_decoder.correlation``), which persists full indicator records with
+evidence references and supports relationship scoring, campaign clustering,
+and cross-case search (``--correlation-db`` / ``--correlation-search``).
+This store remains only for existing ``enable_correlation`` configs.
+
 Stores seen indicators and links new analyses to prior ones. Optional and
 lightweight—if disabled or DB unavailable, it safely no-ops.
 """

--- a/titan_decoder/correlation/__init__.py
+++ b/titan_decoder/correlation/__init__.py
@@ -23,7 +23,7 @@ from .payload_similarity import (
     fingerprint_from_report,
 )
 from .relationships import RelationshipScorer, score_relationship
-from .service import analyze_milestone5, correlate_report
+from .service import analyze_milestone5, correlate_report, search_cases
 from .timeline import TimelineEvent, normalize_timestamp, sort_timeline
 from .timeline_correlation import TimelineLink, correlate_timelines
 from .views import analyst_summary, to_html, to_markdown
@@ -55,6 +55,7 @@ __all__ = [
     "fingerprint_from_report",
     "normalize_timestamp",
     "score_relationship",
+    "search_cases",
     "sort_timeline",
     "stable_id",
     "timeline_events_from_report",

--- a/titan_decoder/correlation/database.py
+++ b/titan_decoder/correlation/database.py
@@ -6,11 +6,21 @@ from contextlib import AbstractContextManager
 import json
 from pathlib import Path
 import sqlite3
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from .models import AnalysisRecord
 
-DATABASE_SCHEMA_VERSION = 1
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard for annotations
+    from .payload_similarity import PayloadFingerprint
+    from .timeline import TimelineEvent
+
+DATABASE_SCHEMA_VERSION = 2
+
+# Deterministic cap on persisted timeline events per analysis. Evidence files
+# can carry very large event sets; storing them unbounded would make the
+# correlation database a decompression-bomb amplifier. Events are sorted
+# before truncation so the retained subset is stable across runs.
+MAX_TIMELINE_EVENTS_PER_ANALYSIS = 2000
 
 _SCHEMA = """
 PRAGMA foreign_keys = ON;
@@ -37,11 +47,29 @@ CREATE TABLE IF NOT EXISTS indicators (
     FOREIGN KEY (analysis_id) REFERENCES analyses(analysis_id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS payload_fingerprints (
+    analysis_id TEXT PRIMARY KEY,
+    payload_json TEXT NOT NULL,
+    FOREIGN KEY (analysis_id) REFERENCES analyses(analysis_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS timeline_events (
+    analysis_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    timestamp TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    PRIMARY KEY (analysis_id, event_id),
+    FOREIGN KEY (analysis_id) REFERENCES analyses(analysis_id) ON DELETE CASCADE
+);
+
 CREATE INDEX IF NOT EXISTS idx_correlation_indicator_lookup
 ON indicators(indicator_type, normalized_value);
 
 CREATE INDEX IF NOT EXISTS idx_correlation_root_hash
 ON analyses(root_hash);
+
+CREATE INDEX IF NOT EXISTS idx_correlation_timeline_timestamp
+ON timeline_events(timestamp);
 """
 
 
@@ -151,6 +179,117 @@ class CorrelationDatabase(AbstractContextManager["CorrelationDatabase"]):
             ).fetchall()
         return tuple(
             AnalysisRecord.from_dict(json.loads(str(row["payload_json"])))
+            for row in rows
+        )
+
+    def record_fingerprint(self, fingerprint: "PayloadFingerprint") -> None:
+        """Persist one analysis' payload fingerprint (upsert)."""
+
+        conn = self._conn()
+        with conn:
+            conn.execute(
+                """
+                INSERT INTO payload_fingerprints(analysis_id, payload_json)
+                VALUES (?, ?)
+                ON CONFLICT(analysis_id) DO UPDATE SET
+                    payload_json=excluded.payload_json
+                """,
+                (
+                    fingerprint.analysis_id,
+                    json.dumps(
+                        fingerprint.to_dict(), sort_keys=True, separators=(",", ":")
+                    ),
+                ),
+            )
+
+    def iter_fingerprints(self) -> tuple["PayloadFingerprint", ...]:
+        from .payload_similarity import PayloadFingerprint
+
+        rows = self._conn().execute(
+            "SELECT payload_json FROM payload_fingerprints ORDER BY analysis_id"
+        ).fetchall()
+        return tuple(
+            PayloadFingerprint.from_dict(json.loads(str(row["payload_json"])))
+            for row in rows
+        )
+
+    def record_timeline_events(
+        self, analysis_id: str, events: Iterable["TimelineEvent"]
+    ) -> None:
+        """Replace the persisted timeline events for one analysis.
+
+        Events are sorted before the deterministic per-analysis cap is
+        applied, so re-recording the same analysis always retains the same
+        subset.
+        """
+
+        from .timeline import sort_timeline
+
+        ordered = sort_timeline(
+            event for event in events if event.analysis_id == analysis_id
+        )[:MAX_TIMELINE_EVENTS_PER_ANALYSIS]
+        conn = self._conn()
+        with conn:
+            conn.execute(
+                "DELETE FROM timeline_events WHERE analysis_id = ?", (analysis_id,)
+            )
+            conn.executemany(
+                """
+                INSERT OR REPLACE INTO timeline_events(
+                    analysis_id, event_id, timestamp, payload_json
+                ) VALUES (?, ?, ?, ?)
+                """,
+                [
+                    (
+                        analysis_id,
+                        event.event_id,
+                        event.timestamp,
+                        json.dumps(
+                            event.to_dict(), sort_keys=True, separators=(",", ":")
+                        ),
+                    )
+                    for event in ordered
+                ],
+            )
+
+    def iter_timeline_events(self) -> tuple["TimelineEvent", ...]:
+        from .timeline import TimelineEvent
+
+        rows = self._conn().execute(
+            "SELECT payload_json FROM timeline_events ORDER BY timestamp, event_id"
+        ).fetchall()
+        return tuple(
+            TimelineEvent.from_dict(json.loads(str(row["payload_json"])))
+            for row in rows
+        )
+
+    def search_indicators(
+        self, value: str, indicator_type: str | None = None
+    ) -> tuple[dict, ...]:
+        """Search recorded indicators by exact normalized value.
+
+        Returns one entry per (analysis, indicator) match, each carrying the
+        stored indicator payload with its evidence references. Matching is
+        case-insensitive on the value; ``indicator_type`` (when given)
+        restricts the search to one indicator type.
+        """
+
+        query = """
+            SELECT analysis_id, indicator_type, payload_json FROM indicators
+            WHERE normalized_value = ? COLLATE NOCASE
+        """
+        params: list[str] = [value]
+        if indicator_type is not None:
+            query += " AND indicator_type = ?"
+            params.append(indicator_type.strip().lower())
+        query += " ORDER BY analysis_id, indicator_type, indicator_id"
+        rows = self._conn().execute(query, params).fetchall()
+        return tuple(
+            {
+                "analysis_id": str(row["analysis_id"]),
+                "indicator_type": str(row["indicator_type"]),
+                "indicator": json.loads(str(row["payload_json"])),
+            }
             for row in rows
         )
 

--- a/titan_decoder/correlation/payload_similarity.py
+++ b/titan_decoder/correlation/payload_similarity.py
@@ -28,6 +28,29 @@ class PayloadFingerprint:
     resource_hashes: tuple[str, ...] = ()
     decode_chain: tuple[str, ...] = ()
 
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "analysis_id": self.analysis_id,
+            "root_hash": self.root_hash,
+            "payload_hashes": list(self.payload_hashes),
+            "fuzzy_hashes": list(self.fuzzy_hashes),
+            "import_hashes": list(self.import_hashes),
+            "resource_hashes": list(self.resource_hashes),
+            "decode_chain": list(self.decode_chain),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "PayloadFingerprint":
+        return cls(
+            analysis_id=str(data["analysis_id"]),
+            root_hash=str(data.get("root_hash") or ""),
+            payload_hashes=tuple(data.get("payload_hashes") or ()),
+            fuzzy_hashes=tuple(data.get("fuzzy_hashes") or ()),
+            import_hashes=tuple(data.get("import_hashes") or ()),
+            resource_hashes=tuple(data.get("resource_hashes") or ()),
+            decode_chain=tuple(data.get("decode_chain") or ()),
+        )
+
 
 @dataclass(frozen=True)
 class SharedPayload:

--- a/titan_decoder/correlation/service.py
+++ b/titan_decoder/correlation/service.py
@@ -37,34 +37,55 @@ def analyze_milestone5(
 ) -> dict[str, Any]:
     """Run the full Phase 5 correlation suite for one report.
 
-    Relationship scoring, campaign clustering, infrastructure reuse, and
-    attribution hints operate on the persisted analysis records (including
-    the subject). Payload fingerprints and timeline events need node- and
-    event-level detail that is not persisted, so they come from the subject
-    report plus any ``prior_reports`` supplied by the caller.
+    Every feature operates cross-case against the correlation database:
+    analysis records power relationship scoring, campaign clustering,
+    infrastructure reuse, and attribution hints, while persisted payload
+    fingerprints and timeline events power shared-payload and timeline
+    correlation. ``prior_reports`` remains supported for callers that
+    correlate reports without recording them.
     """
 
     subject = analysis_record_from_report(report)
+    subject_fingerprint = fingerprint_from_report(report)
+    subject_events = timeline_events_from_report(report)
     prior_reports = tuple(prior_reports)
 
     with CorrelationDatabase(database_path) as database:
         correlation = CorrelationEngine(
             database, minimum_score=minimum_relationship_score
         ).correlate(subject, record_subject=record_subject)
+        if record_subject:
+            database.record_fingerprint(subject_fingerprint)
+            database.record_timeline_events(subject.analysis_id, subject_events)
         analyses = list(database.iter_analyses())
+        stored_fingerprints = database.iter_fingerprints()
+        stored_events = database.iter_timeline_events()
         if not record_subject:
             analyses.append(subject)
 
-    reports = prior_reports + (report,)
+    # Merge persisted state with in-process reports, deduplicating so a
+    # report that was also recorded is not counted twice. Later sources win
+    # for fingerprints (the in-process report is the freshest view).
+    fingerprints = {item.analysis_id: item for item in stored_fingerprints}
+    for item in prior_reports:
+        fingerprint = fingerprint_from_report(item)
+        fingerprints[fingerprint.analysis_id] = fingerprint
+    fingerprints[subject_fingerprint.analysis_id] = subject_fingerprint
+
+    events = {event.event_id: event for event in stored_events}
+    for item in prior_reports:
+        for event in timeline_events_from_report(item):
+            events[event.event_id] = event
+    for event in subject_events:
+        events[event.event_id] = event
+
     infrastructure = detect_infrastructure_reuse(analyses)
     shared_payloads = detect_shared_payloads(
-        (fingerprint_from_report(item) for item in reports),
-        minimum_score=minimum_payload_score,
+        fingerprints.values(), minimum_score=minimum_payload_score
     )
-    events = [
-        event for item in reports for event in timeline_events_from_report(item)
-    ]
-    timeline = correlate_timelines(events, window_seconds=timeline_window_seconds)
+    timeline = correlate_timelines(
+        events.values(), window_seconds=timeline_window_seconds
+    )
 
     result: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
@@ -79,6 +100,55 @@ def analyze_milestone5(
     }
     result["analyst_view"] = analyst_summary(result)
     return result
+
+
+def search_cases(
+    database_path: str | Path,
+    queries: Iterable[str],
+) -> dict[str, Any]:
+    """Search the correlation database for indicators across recorded cases.
+
+    Each query is either a bare value (searched across every indicator type)
+    or ``type:value`` (restricted to one type, e.g. ``domains:c2.test``).
+    Matching is exact on the normalized value and case-insensitive. Results
+    include the stored indicator payloads with their evidence references.
+    """
+
+    results = []
+    with CorrelationDatabase(database_path) as database:
+        for query in queries:
+            text = str(query).strip()
+            if not text:
+                continue
+            indicator_type: str | None = None
+            value = text
+            head, separator, tail = text.partition(":")
+            # "type:value" splits on the first colon; URL queries like
+            # "https://x" must not be treated as a type filter.
+            if (
+                separator
+                and tail
+                and head.replace("_", "").isalnum()
+                and not tail.startswith("//")
+            ):
+                indicator_type, value = head, tail
+            matches = database.search_indicators(value, indicator_type)
+            analysis_ids = sorted({item["analysis_id"] for item in matches})
+            results.append(
+                {
+                    "query": text,
+                    "indicator_type": indicator_type,
+                    "value": value,
+                    "match_count": len(matches),
+                    "analysis_ids": analysis_ids,
+                    "matches": list(matches),
+                }
+            )
+    return {
+        "schema_version": "correlation-search-v1.0",
+        "database": str(database_path),
+        "results": results,
+    }
 
 
 def correlate_report(

--- a/titan_decoder/correlation/timeline.py
+++ b/titan_decoder/correlation/timeline.py
@@ -67,6 +67,18 @@ class TimelineEvent:
             "metadata": dict(self.metadata),
         }
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "TimelineEvent":
+        # event_id is a derived property; it is recomputed, not stored state.
+        return cls(
+            analysis_id=str(data["analysis_id"]),
+            timestamp=str(data["timestamp"]),
+            kind=str(data["kind"]),
+            summary=str(data["summary"]),
+            source_id=data.get("source_id"),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
 
 def sort_timeline(events: Iterable[TimelineEvent]) -> tuple[TimelineEvent, ...]:
     """Return events in deterministic chronological order."""


### PR DESCRIPTION
## Summary

Audited Milestones 4 and 5 against the milestone plan and closed the gaps found.

**Milestone 4 (Threat Intelligence): audited complete, no changes.** ATT&CK technique mapping with tactics, LOLBin detection, the behavioral malware tagging framework (deliberately never asserting family attribution without evidence), and confidence scoring are all present, and ATT&CK data renders in JSON reports, Markdown case reports, HTML case reports, and all three graph export formats.

**Milestone 5 (Evidence Correlation): two gaps found and fixed.**

1. **Cross-case persistence (correlation database schema v2).** Shared-payload and timeline correlation previously only compared reports passed in the same invocation, because node hashes and events weren't persisted. The database now stores payload fingerprints and timeline events alongside indicator records, so both features operate across every recorded case with no `prior_reports` needed. Timeline events are capped at a deterministic 2,000 per analysis (sorted before truncation, so the retained subset is stable). v1 databases upgrade in place on open; `prior_reports` remains supported and deduplicated.
2. **Cross-case searching.** New `--correlation-search [TYPE:]VALUE` (repeatable) runs standalone like `--vault-search` — no input file — and queries the correlation IOC database, returning matching analyses with each indicator's stored evidence references (`correlation-search-v1.0`). Matching is exact on the normalized value and case-insensitive; a `type:` prefix restricts the search, and URL values containing colons are handled correctly. Also exposed as `correlation.service.search_cases`.

Also: deprecated the legacy `core/correlation.py` `CorrelationStore` (`enable_correlation` config) in favor of the Phase 5 database — it still works but prints a deprecation warning — and updated the roadmap to move evidence correlation to Shipped, listing Plugin SDK v1 and Analyst Workbench as next work.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q                 # 529 passed
ruff check .              # all checks passed
mypy titan_decoder/       # no issues in 63 source files
```

- Notes: 9 new tests cover fingerprint/timeline round-trips, the per-analysis event cap, v1→v2 upgrade, cross-case shared payloads and timeline links without `prior_reports`, prior-report deduplication, search (bare/typed/case-insensitive/URL queries), and both CLI search modes. Two existing tests were updated because they asserted the old behavior (schema version pinned to 1; shared-payload count of 0 without in-process prior reports — now correctly 1 from the persisted fingerprint). Verified end-to-end with the real CLI: two separate invocations against one database detect the shared payload (`exact_payload_hash`, `decode_chain_similarity`), and `--correlation-search` finds both analyses by domain and by typed URL query.

## Screenshots / Output (optional)

```
$ titan-decoder --correlation-db corr.sqlite3 --correlation-search c2-example.test
{
  "schema_version": "correlation-search-v1.0",
  "results": [
    {
      "query": "c2-example.test",
      "match_count": 2,
      "analysis_ids": ["0530f4db-...", "d9154941-..."],
      ...
    }
  ]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q

---
_Generated by [Claude Code](https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q)_