### PR TITLE
Milestone 6: Plugin SDK v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 ## Unreleased
 
+Plugin SDK v1 (Milestone 6):
+
+- Four plugin SDKs behind the stable `titan_decoder.plugins.api` surface:
+  `DecoderPlugin`, `AnalyzerPlugin`, `DetectionPlugin`, and `ReportPlugin`,
+  with typed results (`DecodeResult`, `AnalysisArtifact`,
+  `DetectionFinding`, `ReportSection`) and an optional `PluginContext`
+  carrying the offline stance and resource bounds. Typed decode/analyze
+  results unpack like the legacy tuples, so the engine consumes both plugin
+  styles identically.
+- Manifest plugins: a directory with `titan-plugin.json` (JSON Schema in
+  `schemas/titan-plugin-manifest-v1.0.schema.json`) declaring identity,
+  SemVer versions, entry point, capabilities, permissions (policy metadata,
+  not a sandbox), and dependencies. Single-file plugins (API 1.0) keep
+  loading exactly as before; `PLUGIN_API_VERSION` bumps to `1.1`
+  (additive).
+- Semantic version engine with correct SemVer 2.0.0 pre-release precedence
+  (`1.0.0-alpha < 1.0.0`) and dependency requirements (`*`, `^`, `~`,
+  comparator lists, exact). Manifest plugins load in deterministic
+  dependency order.
+- Pipeline integration: detection plugins run in the detection stage after
+  rule engines and before risk scoring (findings carry
+  `source: {"type": "plugin"}` and feed the risk assessment); report
+  plugins contribute JSON-serializable sections embedded under
+  `plugin_report_sections` and rendered into Markdown/HTML case reports.
+  Bounded output: 200 findings / 20 sections per plugin; a failing plugin
+  is skipped with a warning and can never abort an analysis.
+- Guardrails: the `TITAN-` rule prefix is reserved (plugins cannot
+  impersonate built-in detections), rule IDs must be declared and unique
+  across plugins, undeclared findings are dropped, and duplicate plugin IDs
+  are rejected.
+- Deep validation (`--plugin-validate`): manifest contract, API
+  compatibility, entry point, capability match, constructor, plus a bounded
+  runtime probe checking return types, output limits, artifact names,
+  declared rule IDs, and execution time. `--plugin-list` prints discovered
+  plugins including per-plugin load errors; `--plugin-dir` adds search
+  directories (repeatable).
+- Example plugins (one per capability) in `examples/plugins/`, a complete
+  developer guide in `docs/PLUGIN_API.md`, and SDK unit plus
+  engine/CLI integration tests.
+
 Evidence correlation (Milestone 5 completion):
 
 - Cross-case persistence (correlation database schema v2): payload

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -130,6 +130,21 @@ titan-decoder --file sample.bin --graph graph.mmd --graph-format mermaid
 
 When Intelligence is present, all formats include graph-level assessment metadata and ranked-artifact annotations. See [GRAPH_EXPORTS.md](GRAPH_EXPORTS.md).
 
+## Plugins
+
+```bash
+titan-decoder --plugin-validate path/to/plugin
+titan-decoder --plugin-list --plugin-dir examples/plugins
+titan-decoder --file sample.bin --plugin-dir ~/my-plugins --enable-detections
+```
+
+`--plugin-validate` deep-validates a manifest plugin (manifest contract, API
+compatibility, entry point, capabilities, and a bounded runtime probe) and
+exits non-zero on failure; the probe executes plugin code in-process.
+`--plugin-list` prints every discovered plugin, including load errors.
+`--plugin-dir` adds plugin search directories (repeatable) for both
+standalone modes and analysis runs. See [PLUGIN_API.md](PLUGIN_API.md).
+
 ## Diagnostics and discovery
 
 ```bash

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,42 +1,255 @@
-# Plugin API
+# Plugin SDK v1
 
-Titan discovers plugin decoders and analyzers through configured directories, the user plugin directory, and built-in plugin paths.
+Titan can be extended without modifying the core through four plugin SDKs:
+**decoders**, **analyzers**, **detections**, and **report sections**. All
+public types live in `titan_decoder.plugins.api` — third-party plugins import
+only from that module; it is the compatibility surface covered by the
+versioned API contract.
 
-## Decoder plugin expectations
+## Plugin styles
 
-- implement the decoder base interface;
-- expose a stable `name`;
-- reject non-matching input cheaply;
-- return bytes and deterministic metadata;
-- cap output growth;
-- avoid network access;
-- handle malformed content without crashing.
+Two styles are supported side by side:
 
-## Analyzer plugin expectations
+| Style | API | Layout | Capabilities |
+|---|---|---|---|
+| Single-file | 1.0 | one `.py` file in a plugin directory | decoder, analyzer |
+| Manifest | 1.1 | a directory with `titan-plugin.json` + entry-point module | decoder, analyzer, detection, report |
 
-- implement the analyzer base interface;
-- emit structured metadata or bounded child artifacts;
-- preserve meaningful artifact names;
-- sanitize paths;
-- cap member count, total size, and per-member size.
+Plugin directories are searched in this order: `plugin_dirs` from
+configuration, `--plugin-dir` CLI arguments, `~/.titan_decoder/plugins`, and
+the built-in plugin path. Every directory is scanned for both styles.
+
+## API versioning
+
+The engine provides `PLUGIN_API_VERSION` (currently `1.1`, MAJOR.MINOR):
+
+- **MAJOR** bump = breaking change to base-class signatures or semantics.
+- **MINOR** bump = additive, backward-compatible extension. (`1.1` added the
+  manifest SDK; every API `1.0` plugin still loads and runs unchanged.)
+
+Single-file plugins may declare a module-level `PLUGIN_API_VERSION`; they are
+skipped on a MAJOR mismatch. Manifest plugins must declare `api_version` and
+are loadable when the MAJOR matches and their declared MINOR is not newer
+than the engine's.
+
+Plugin `version` and dependency requirements use Semantic Versioning 2.0.0,
+including correct pre-release precedence (`1.0.0-alpha < 1.0.0`). Dependency
+requirements accept `*`, `^X.Y.Z`, `~X.Y.Z`, comparator lists
+(`>=1.0.0,<2.0.0`), and exact versions.
+
+## The manifest
+
+Each manifest plugin directory contains `titan-plugin.json`
+(schema: `schemas/titan-plugin-manifest-v1.0.schema.json`):
+
+```json
+{
+  "schema_version": "1.0",
+  "id": "example.rot47",
+  "name": "ROT47 Decoder",
+  "version": "1.0.0",
+  "api_version": "1.1.0",
+  "entry_point": "plugin:Rot47Decoder",
+  "capabilities": ["decoder"],
+  "description": "Reverses ROT47-obfuscated printable ASCII.",
+  "author": "You",
+  "license": "MIT",
+  "permissions": [],
+  "dependencies": {}
+}
+```
+
+- `id`: lowercase segments separated by `.`, `_`, or `-`; unique across
+  loaded plugins.
+- `entry_point`: `module:ClassName`, resolved relative to the plugin
+  directory.
+- `capabilities`: which SDK base classes the entry-point class implements.
+- `permissions`: policy metadata (`filesystem.read`, `filesystem.write`,
+  `network`, `configuration`). **Not a sandbox** — see the trust model.
+- `dependencies`: other plugin IDs mapped to version requirements. Loading
+  is dependency-ordered; unresolved or unsatisfied dependencies fail the
+  plugin, never the run.
+
+## Decoder SDK
+
+```python
+from titan_decoder.plugins.api import DecoderPlugin, DecodeResult
+
+class Rot47Decoder(DecoderPlugin):
+    priority = 10  # higher = tried first
+
+    @property
+    def name(self):
+        return "ROT47"
+
+    def can_decode(self, data, context=None):
+        return bool(data) and all(b in b"\t\r\n" or 32 <= b <= 126 for b in data)
+
+    def decode(self, data, context=None):
+        out = bytes(((b - 33 + 47) % 94) + 33 if 33 <= b <= 126 else b for b in data)
+        return DecodeResult(out, out != data, {"algorithm": "ROT47"})
+```
+
+`decode` may return a `DecodeResult` or a legacy `(bytes, bool)` tuple —
+`DecodeResult` unpacks like the tuple, so both integrate identically.
+Decoded candidates compete on the engine's deterministic decode score; the
+best-scoring decoder wins the node.
+
+## Analyzer SDK
+
+```python
+from titan_decoder.plugins.api import AnalyzerPlugin, AnalysisArtifact
+
+class StringsAnalyzer(AnalyzerPlugin):
+    @property
+    def name(self):
+        return "PrintableStrings"
+
+    def can_analyze(self, data, context=None):
+        ...
+
+    def analyze(self, data, context=None):
+        return [AnalysisArtifact("strings.txt", content, {"count": 3})]
+```
+
+Artifact names must be plain basenames (no path separators); artifacts
+unpack like the legacy `(name, bytes)` tuples. Respect
+`context.max_output_bytes` and `context.max_children`.
+
+## Detection SDK
+
+```python
+from titan_decoder.plugins.api import DetectionPlugin, DetectionFinding
+
+class MarkerDetection(DetectionPlugin):
+    @property
+    def name(self):
+        return "Example Marker"
+
+    @property
+    def rule_ids(self):
+        return ("EXAMPLE-001",)
+
+    def detect(self, report, iocs, context=None):
+        ...
+        return [DetectionFinding(
+            rule_id="EXAMPLE-001",
+            name="Example Marker",
+            description="Synthetic marker found",
+            severity="medium",              # low | medium | high | critical
+            attack_ids=("T1027",),          # optional ATT&CK techniques
+            evidence=({"node_id": 2},),     # optional evidence references
+        )]
+```
+
+Detection plugins run during `--enable-detections`, after the built-in rules
+and rule packs and **before risk scoring**, so plugin findings contribute to
+the risk assessment exactly like rule matches. Findings appear in
+`report["detections"]` with `source: {"type": "plugin", ...}`.
+
+Rules of the road (enforced at load and validation time):
+
+- `rule_ids` must declare every rule the plugin can emit; undeclared
+  findings are dropped.
+- The `TITAN-` prefix is reserved for built-in rules — plugins cannot
+  impersonate them.
+- Rule IDs must be unique across all loaded plugins.
+- At most 200 findings per plugin per run are accepted.
+
+## Report SDK
+
+```python
+from titan_decoder.plugins.api import ReportPlugin, ReportSection
+
+class SummaryReport(ReportPlugin):
+    @property
+    def name(self):
+        return "Example Summary"
+
+    def build_sections(self, report, context=None):
+        return [ReportSection(
+            section_id="example_summary",
+            title="Example Plugin Summary",
+            content={"node_count": report.get("node_count", 0)},
+            order=900,                       # lower renders first
+            formats=("json", "markdown", "html"),
+        )]
+```
+
+Sections must be JSON-serializable. They are embedded in the JSON report
+under `plugin_report_sections` and rendered into Markdown/HTML case reports
+(`--report-out`) for the formats each section declares. At most 20 sections
+per plugin per run are accepted.
+
+## PluginContext
+
+SDK methods receive an optional `PluginContext` describing the run:
+`config` (a read-only snapshot), `offline` (honor it — perform no network
+access when set), `max_input_bytes`, `max_output_bytes`, `max_children`, and
+`working_directory`. Plugins must also work when `context` is `None`.
+
+## Validation
+
+```bash
+titan-decoder --plugin-validate path/to/plugin        # repeatable; exits non-zero on failure
+titan-decoder --plugin-list --plugin-dir examples/plugins
+```
+
+`--plugin-validate` checks the manifest contract, API compatibility, the
+entry point, declared capabilities, and the constructor, then runs a bounded
+runtime probe verifying return types, output limits, artifact naming,
+declared rule IDs, and execution time. The probe executes plugin code
+in-process — only validate plugins you would be willing to run.
+`--plugin-list` prints everything discovered, including per-plugin load
+errors.
+
+## Contract every plugin must uphold
+
+Enforced by the fuzz invariants and the validation probe:
+`can_decode`/`can_analyze`, `decode`, `analyze`, `detect`, and
+`build_sections` must **never raise**, must return the declared types, must
+bound their output, and must terminate quickly on any input, including
+hostile bytes. A plugin that violates the contract at runtime is skipped
+with a warning; plugins can extend an analysis but never abort one.
 
 ## Loading model
 
 ```mermaid
 flowchart LR
     Config[plugin_dirs] --> Manager[PluginManager]
+    CLI[--plugin-dir] --> Manager
     User[~/.titan_decoder/plugins] --> Manager
     Builtin[Built-in plugins] --> Manager
     Manager --> Decoders[Decoder registry]
     Manager --> Analyzers[Analyzer registry]
+    Manager --> Detections[Detection registry]
+    Manager --> Reports[Report registry]
     Decoders --> Engine[TitanEngine]
     Analyzers --> Engine
+    Detections --> Stage[Detection stage]
+    Reports --> Case[Case reports]
 ```
+
+Manifest plugins load in dependency order (deterministic topological order
+over declared dependencies). A plugin that fails to load is recorded in the
+manager's error list — visible via `--plugin-list` — and never aborts
+discovery.
 
 ## Trust model
 
-Plugins execute in the Titan process and can access local resources. Only install reviewed plugins. A future out-of-process plugin boundary would require a separate protocol and is not implied by the current API.
+Plugins execute in the Titan process and can access local resources.
+Manifest permissions are declarations for operators and reviewers, not an
+enforcement boundary. Only install reviewed plugins. A future out-of-process
+plugin boundary would require a separate protocol and is not implied by the
+current API.
 
-## Testing
+## Examples and testing
 
-Every plugin should include applicability, success, malformed-input, determinism, and resource-bound tests.
+Complete working examples — one per capability — live in
+`examples/plugins/`: `rot47_decoder`, `string_analyzer`, `marker_detection`,
+and `summary_report`. All four pass `--plugin-validate` and are exercised by
+the test suite (`tests/test_plugin_sdk.py`,
+`tests/test_plugin_sdk_integration.py`).
+
+Every plugin should include applicability, success, malformed-input,
+determinism, and resource-bound tests.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,10 +23,11 @@ This roadmap separates shipped features from planned work.
 - Rule-pack hardening: enforced validation, duplicate-ID checks (including built-in impersonation), per-pack limits, fixtures, and a strict `--rules-validate` gate
 - Evidence correlation platform (Milestone 5): cross-case IOC database, relationship scoring, campaign clustering, timeline correlation, infrastructure reuse detection, shared payload detection, attribution hints, analyst views, persisted cross-case fingerprints/events, and `--correlation-search`
 
+- Plugin SDK v1 (Milestone 6): stable public decoder/analyzer/detection/report APIs behind `titan_decoder.plugins.api`, plugin manifest with JSON Schema, semantic version compatibility and dependency constraints, deep validation (`--plugin-validate`), example plugins, and a complete developer guide
+
 ## Highest-value next work
 
-1. Plugin SDK v1: stable public decoder/analyzer/detection/report APIs, plugin manifest and validation, semantic version compatibility, example plugins, and developer documentation.
-2. Analyst Workbench: interactive exploration of reports (timeline explorer, graph viewer, IOC/evidence browsers, decode-tree navigation, search/filter/export, investigation workspace).
+1. Analyst Workbench: interactive exploration of reports (timeline explorer, graph viewer, IOC/evidence browsers, decode-tree navigation, search/filter/export, investigation workspace).
 
 ## Optional local AI assistant
 

--- a/examples/plugins/marker_detection/plugin.py
+++ b/examples/plugins/marker_detection/plugin.py
@@ -1,0 +1,38 @@
+"""Example detection plugin.
+
+Demonstrates the Detection SDK: declared ``rule_ids`` (never using the
+reserved ``TITAN-`` prefix), evidence-carrying :class:`DetectionFinding`
+results, and the report/IOC inputs.
+"""
+
+from titan_decoder.plugins.api import DetectionFinding, DetectionPlugin
+
+MARKER = "malware-marker"
+
+
+class MarkerDetection(DetectionPlugin):
+    @property
+    def name(self):
+        return "Example Marker"
+
+    @property
+    def rule_ids(self):
+        return ("EXAMPLE-001",)
+
+    def detect(self, report, iocs, context=None):
+        matched_nodes = [
+            node.get("id")
+            for node in report.get("nodes") or []
+            if MARKER in str(node.get("content_preview") or "").lower()
+        ]
+        if not matched_nodes:
+            return []
+        return [
+            DetectionFinding(
+                rule_id="EXAMPLE-001",
+                name="Example Marker",
+                description="Synthetic example marker found in decoded content",
+                severity="medium",
+                evidence=tuple({"node_id": node_id} for node_id in matched_nodes),
+            )
+        ]

--- a/examples/plugins/marker_detection/titan-plugin.json
+++ b/examples/plugins/marker_detection/titan-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0",
+  "id": "example.marker",
+  "name": "Marker Detection",
+  "version": "1.0.0",
+  "api_version": "1.1.0",
+  "entry_point": "plugin:MarkerDetection",
+  "capabilities": ["detection"],
+  "description": "Example detection plugin: flags a synthetic marker string in decoded nodes.",
+  "author": "Titan examples",
+  "license": "MIT",
+  "permissions": [],
+  "dependencies": {}
+}

--- a/examples/plugins/rot47_decoder/plugin.py
+++ b/examples/plugins/rot47_decoder/plugin.py
@@ -1,0 +1,23 @@
+"""Example decoder plugin: ROT47.
+
+Demonstrates the Decoder SDK: typed :class:`DecodeResult`, an optional
+context argument, and priority ordering. ``can_decode``/``decode`` never
+raise and always bound their output (same size as input).
+"""
+
+from titan_decoder.plugins.api import DecodeResult, DecoderPlugin
+
+
+class Rot47Decoder(DecoderPlugin):
+    priority = 10
+
+    @property
+    def name(self):
+        return "ROT47"
+
+    def can_decode(self, data, context=None):
+        return bool(data) and all(b in b"\t\r\n" or 32 <= b <= 126 for b in data)
+
+    def decode(self, data, context=None):
+        out = bytes(((b - 33 + 47) % 94) + 33 if 33 <= b <= 126 else b for b in data)
+        return DecodeResult(out, out != data, {"algorithm": "ROT47"})

--- a/examples/plugins/rot47_decoder/titan-plugin.json
+++ b/examples/plugins/rot47_decoder/titan-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0",
+  "id": "example.rot47",
+  "name": "ROT47 Decoder",
+  "version": "1.0.0",
+  "api_version": "1.1.0",
+  "entry_point": "plugin:Rot47Decoder",
+  "capabilities": ["decoder"],
+  "description": "Example decoder plugin: reverses ROT47-obfuscated printable ASCII.",
+  "author": "Titan examples",
+  "license": "MIT",
+  "permissions": [],
+  "dependencies": {}
+}

--- a/examples/plugins/string_analyzer/plugin.py
+++ b/examples/plugins/string_analyzer/plugin.py
@@ -1,0 +1,32 @@
+"""Example analyzer plugin: printable-string extraction.
+
+Demonstrates the Analyzer SDK: typed :class:`AnalysisArtifact` results and
+honoring the context's output bound.
+"""
+
+import re
+
+from titan_decoder.plugins.api import AnalysisArtifact, AnalyzerPlugin
+
+
+class StringsAnalyzer(AnalyzerPlugin):
+    @property
+    def name(self):
+        return "PrintableStrings"
+
+    def can_analyze(self, data, context=None):
+        # Only binary data with embedded strings: extracting "strings" from
+        # already-printable text would just duplicate the node and shadow
+        # decoders that could act on it.
+        if len(data) < 4:
+            return False
+        has_binary = any(b < 9 or (13 < b < 32) or b > 126 for b in data)
+        return has_binary and re.search(rb"[ -~]{4,}", data) is not None
+
+    def analyze(self, data, context=None):
+        limit = context.max_output_bytes if context else 1024 * 1024
+        parts = re.findall(rb"[ -~]{4,}", data)
+        content = b"\n".join(parts)[:limit]
+        if not content:
+            return []
+        return [AnalysisArtifact("strings.txt", content, {"count": len(parts)})]

--- a/examples/plugins/string_analyzer/titan-plugin.json
+++ b/examples/plugins/string_analyzer/titan-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0",
+  "id": "example.strings",
+  "name": "Strings Analyzer",
+  "version": "1.0.0",
+  "api_version": "1.1.0",
+  "entry_point": "plugin:StringsAnalyzer",
+  "capabilities": ["analyzer"],
+  "description": "Example analyzer plugin: extracts printable ASCII strings as an artifact.",
+  "author": "Titan examples",
+  "license": "MIT",
+  "permissions": [],
+  "dependencies": {}
+}

--- a/examples/plugins/summary_report/plugin.py
+++ b/examples/plugins/summary_report/plugin.py
@@ -1,0 +1,27 @@
+"""Example report plugin.
+
+Demonstrates the Report SDK: a JSON-serializable :class:`ReportSection`
+rendered into the JSON report and Markdown/HTML case reports.
+"""
+
+from titan_decoder.plugins.api import ReportPlugin, ReportSection
+
+
+class SummaryReport(ReportPlugin):
+    @property
+    def name(self):
+        return "Example Summary"
+
+    def build_sections(self, report, context=None):
+        return [
+            ReportSection(
+                section_id="example_summary",
+                title="Example Plugin Summary",
+                content={
+                    "node_count": report.get("node_count", 0),
+                    "detection_count": len(report.get("detections") or []),
+                },
+                order=900,
+                formats=("json", "markdown", "html"),
+            )
+        ]

--- a/examples/plugins/summary_report/titan-plugin.json
+++ b/examples/plugins/summary_report/titan-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0",
+  "id": "example.summary",
+  "name": "Summary Report",
+  "version": "1.0.0",
+  "api_version": "1.1.0",
+  "entry_point": "plugin:SummaryReport",
+  "capabilities": ["report"],
+  "description": "Example report plugin: contributes a summary section to case reports.",
+  "author": "Titan examples",
+  "license": "MIT",
+  "permissions": [],
+  "dependencies": {}
+}

--- a/schemas/titan-plugin-manifest-v1.0.schema.json
+++ b/schemas/titan-plugin-manifest-v1.0.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/pragmaconflux/titan1/schemas/titan-plugin-manifest-v1.0.schema.json",
+  "title": "Titan Plugin Manifest v1.0",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "name",
+    "version",
+    "api_version",
+    "entry_point",
+    "capabilities"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "1.0"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+      "maxLength": 128
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "api_version": {
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:\\.(0|[1-9]\\d*))?$"
+    },
+    "entry_point": {
+      "type": "string",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "decoder",
+          "analyzer",
+          "detection",
+          "report"
+        ]
+      }
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 2048
+    },
+    "author": {
+      "type": "string",
+      "maxLength": 256
+    },
+    "license": {
+      "type": "string",
+      "maxLength": 128
+    },
+    "homepage": {
+      "type": "string",
+      "maxLength": 512
+    },
+    "permissions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "filesystem.read",
+          "filesystem.write",
+          "network",
+          "configuration"
+        ]
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "maxLength": 128
+      }
+    }
+  }
+}

--- a/tests/golden/expected/cfb_macro.doc.json
+++ b/tests/golden/expected/cfb_macro.doc.json
@@ -98,9 +98,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/golden/expected/gzip_text.bin.json
+++ b/tests/golden/expected/gzip_text.bin.json
@@ -119,9 +119,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/golden/expected/high_entropy.bin.json
+++ b/tests/golden/expected/high_entropy.bin.json
@@ -71,9 +71,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/golden/expected/multi_ioc.txt.json
+++ b/tests/golden/expected/multi_ioc.txt.json
@@ -81,9 +81,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/golden/expected/nested_base64.txt.json
+++ b/tests/golden/expected/nested_base64.txt.json
@@ -98,9 +98,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/golden/expected/pdf_js.pdf.json
+++ b/tests/golden/expected/pdf_js.pdf.json
@@ -99,9 +99,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/golden/expected/plain_iocs.txt.json
+++ b/tests/golden/expected/plain_iocs.txt.json
@@ -80,9 +80,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/golden/expected/xor_url.bin.json
+++ b/tests/golden/expected/xor_url.bin.json
@@ -98,9 +98,13 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.0",
+        "api_version": "1.1",
         "decoders": [],
-        "loaded_plugins": []
+        "detections": [],
+        "errors": [],
+        "loaded_plugins": [],
+        "manifest_plugins": [],
+        "reports": []
       }
     },
     "effective_config": {

--- a/tests/test_plugin_sdk.py
+++ b/tests/test_plugin_sdk.py
@@ -1,0 +1,388 @@
+"""Unit tests for the Plugin SDK v1: semver, manifest, registry, validation."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from titan_decoder.plugins import (
+    AnalysisArtifact,
+    DecodeResult,
+    DetectionFinding,
+    PluginManager,
+    PluginManifest,
+    ReportSection,
+    Version,
+    is_manifest_api_compatible,
+    satisfies,
+    validate_manifest,
+    validate_plugin,
+)
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples" / "plugins"
+
+
+# --- semver -----------------------------------------------------------------
+
+
+def test_version_parse_and_shorthand():
+    assert Version.parse("1.2.3") == Version(1, 2, 3)
+    assert Version.parse("1.1") == Version(1, 1, 0)
+    with pytest.raises(ValueError):
+        Version.parse("not-a-version")
+    with pytest.raises(ValueError):
+        Version.parse("1.2.3.4")
+
+
+def test_prerelease_precedence_follows_semver_spec():
+    # SemVer 2.0.0 §11: pre-releases sort before the release, numeric
+    # identifiers before alphanumeric.
+    ordered = [
+        Version.parse("1.0.0-alpha"),
+        Version.parse("1.0.0-alpha.1"),
+        Version.parse("1.0.0-alpha.beta"),
+        Version.parse("1.0.0-beta"),
+        Version.parse("1.0.0-beta.2"),
+        Version.parse("1.0.0-beta.11"),
+        Version.parse("1.0.0-rc.1"),
+        Version.parse("1.0.0"),
+    ]
+    assert ordered == sorted(ordered)
+
+
+def test_satisfies_requirement_forms():
+    assert satisfies("1.5.0", "*")
+    assert satisfies("1.5.0", "^1.0.0")
+    assert not satisfies("2.0.0", "^1.0.0")
+    assert satisfies("1.0.5", "~1.0.0")
+    assert not satisfies("1.1.0", "~1.0.0")
+    assert satisfies("1.5.0", ">=1.0.0,<2.0.0")
+    assert not satisfies("2.5.0", ">=1.0.0,<2.0.0")
+    assert satisfies("1.0.0", "1.0.0")
+    with pytest.raises(ValueError):
+        satisfies("1.0.0", "!!nonsense")
+
+
+def test_manifest_api_compatibility():
+    assert is_manifest_api_compatible("1.0.0", "1.1")
+    assert is_manifest_api_compatible("1.1.0", "1.1")
+    assert not is_manifest_api_compatible("1.2.0", "1.1")  # needs newer minor
+    assert not is_manifest_api_compatible("2.0.0", "1.1")
+
+
+# --- typed results ------------------------------------------------------------
+
+
+def test_decode_result_unpacks_like_legacy_tuple():
+    decoded, success = DecodeResult(b"data", True, {"k": "v"})
+    assert decoded == b"data" and success is True
+    with pytest.raises(TypeError):
+        DecodeResult("not-bytes", True)
+
+
+def test_analysis_artifact_unpacks_and_requires_basename():
+    name, content = AnalysisArtifact("strings.txt", b"abc")
+    assert name == "strings.txt" and content == b"abc"
+    with pytest.raises(ValueError):
+        AnalysisArtifact("../escape.txt", b"abc")
+
+
+def test_detection_finding_validation():
+    finding = DetectionFinding("X-1", "n", "d", "high", attack_ids=("T2", "T1", "T1"))
+    assert finding.attack_ids == ("T1", "T2")
+    with pytest.raises(ValueError):
+        DetectionFinding("X-1", "n", "d", "catastrophic")
+
+
+def test_report_section_validation():
+    section = ReportSection("s", "t", {"a": 1}, formats=("markdown", "json"))
+    assert section.formats == ("json", "markdown")
+    with pytest.raises(ValueError):
+        ReportSection("s", "t", {}, formats=("pdf",))
+
+
+# --- manifest -----------------------------------------------------------------
+
+
+def _manifest(**over):
+    data = {
+        "schema_version": "1.0",
+        "id": "example.test",
+        "name": "Example",
+        "version": "1.0.0",
+        "api_version": "1.0.0",
+        "entry_point": "plugin:Example",
+        "capabilities": ["decoder"],
+    }
+    data.update(over)
+    return PluginManifest.from_dict(data)
+
+
+def test_manifest_valid():
+    assert validate_manifest(_manifest()) == ()
+
+
+@pytest.mark.parametrize(
+    "override,fragment",
+    [
+        ({"id": "Bad ID"}, "invalid plugin id"),
+        ({"name": "  "}, "name must not be empty"),
+        ({"version": "one"}, "invalid version"),
+        ({"api_version": "9.0.0"}, "incompatible API version"),
+        ({"entry_point": "no-colon"}, "entry_point"),
+        ({"capabilities": []}, "capabilities must not be empty"),
+        ({"capabilities": ["wizard"]}, "unsupported capabilities"),
+        ({"permissions": ["root"]}, "unsupported permissions"),
+        ({"dependencies": {"ok.dep": "!!bad"}}, "invalid dependency requirement"),
+        ({"schema_version": "2.0"}, "unsupported schema_version"),
+    ],
+)
+def test_manifest_invalid_fields(override, fragment):
+    errors = validate_manifest(_manifest(**override))
+    assert any(fragment in error for error in errors), errors
+
+
+# --- registry -----------------------------------------------------------------
+
+
+def _write_plugin(root, plugin_id, capability="detection", rule_ids=("EX-1",),
+                  version="1.0.0", dependencies=None, dirname=None):
+    plugin_dir = root / (dirname or plugin_id.replace(".", "_"))
+    plugin_dir.mkdir()
+    body = {
+        "detection": (
+            "from titan_decoder.plugins.api import DetectionFinding, DetectionPlugin\n"
+            "class Example(DetectionPlugin):\n"
+            "    name = 'Example'\n"
+            f"    rule_ids = {tuple(rule_ids)!r}\n"
+            "    def detect(self, report, iocs, context=None):\n"
+            "        return []\n"
+        ),
+        "decoder": (
+            "from titan_decoder.plugins.api import DecoderPlugin\n"
+            "class Example(DecoderPlugin):\n"
+            "    name = 'ExampleDecoder'\n"
+            "    def can_decode(self, data, context=None):\n"
+            "        return False\n"
+            "    def decode(self, data, context=None):\n"
+            "        return data, False\n"
+        ),
+    }[capability]
+    (plugin_dir / "plugin.py").write_text(body)
+    (plugin_dir / "titan-plugin.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": plugin_id,
+                "name": plugin_id,
+                "version": version,
+                "api_version": "1.1.0",
+                "entry_point": "plugin:Example",
+                "capabilities": [capability],
+                "dependencies": dependencies or {},
+            }
+        )
+    )
+    return plugin_dir
+
+
+def test_registry_loads_all_example_plugins():
+    manager = PluginManager([EXAMPLES])
+    manager.load_plugins()
+    assert len(manager.manifest_plugins) == 4
+    assert [d.name for d in manager.decoders] == ["ROT47"]
+    assert [a.name for a in manager.analyzers] == ["PrintableStrings"]
+    assert [d.name for d in manager.detections] == ["Example Marker"]
+    assert [r.name for r in manager.reports] == ["Example Summary"]
+    assert manager.errors == []
+
+
+def test_registry_mixes_single_file_and_manifest_plugins(tmp_path):
+    (tmp_path / "legacy.py").write_text(
+        "from titan_decoder.plugins.api import PluginDecoder\n"
+        "class Legacy(PluginDecoder):\n"
+        "    name = 'LegacyDecoder'\n"
+        "    def can_decode(self, data):\n"
+        "        return False\n"
+        "    def decode(self, data):\n"
+        "        return data, False\n"
+    )
+    _write_plugin(tmp_path, "example.modern", capability="decoder")
+    manager = PluginManager([tmp_path])
+    manager.load_plugins()
+    names = [d.name for d in manager.decoders]
+    assert "LegacyDecoder" in names and "ExampleDecoder" in names
+
+
+def test_registry_resolves_dependencies_regardless_of_directory_order(tmp_path):
+    # "aaa_consumer" sorts before "zzz_base": naive name-order loading would
+    # fail the dependency check.
+    _write_plugin(tmp_path, "example.base", capability="decoder", dirname="zzz_base")
+    _write_plugin(
+        tmp_path,
+        "example.consumer",
+        rule_ids=("EX-CONSUMER-1",),
+        dependencies={"example.base": "^1.0.0"},
+        dirname="aaa_consumer",
+    )
+    manager = PluginManager([tmp_path])
+    manager.load_plugins()
+    assert set(manager.manifest_plugins) == {"example.base", "example.consumer"}
+    assert manager.errors == []
+
+
+def test_registry_rejects_unsatisfied_dependency(tmp_path):
+    _write_plugin(tmp_path, "example.base", capability="decoder", version="0.9.0")
+    _write_plugin(
+        tmp_path,
+        "example.consumer",
+        dependencies={"example.base": "^1.0.0"},
+    )
+    manager = PluginManager([tmp_path])
+    manager.load_plugins()
+    assert "example.consumer" not in manager.manifest_plugins
+    assert any("does not satisfy" in error["error"] for error in manager.errors)
+
+
+def test_registry_rejects_reserved_and_duplicate_rule_ids(tmp_path):
+    _write_plugin(tmp_path, "example.reserved", rule_ids=("TITAN-999",))
+    _write_plugin(tmp_path, "example.first", rule_ids=("SHARED-1",), dirname="m_first")
+    _write_plugin(tmp_path, "example.second", rule_ids=("SHARED-1",), dirname="n_second")
+    manager = PluginManager([tmp_path])
+    manager.load_plugins()
+    assert "example.reserved" not in manager.manifest_plugins
+    assert "example.first" in manager.manifest_plugins
+    assert "example.second" not in manager.manifest_plugins
+    errors = " ".join(error["error"] for error in manager.errors)
+    assert "reserved" in errors and "duplicate detection rule ids" in errors
+
+
+def test_registry_rejects_duplicate_plugin_ids(tmp_path):
+    _write_plugin(tmp_path, "example.dup", capability="decoder", dirname="one")
+    _write_plugin(tmp_path, "example.dup", capability="decoder", dirname="two")
+    manager = PluginManager([tmp_path])
+    manager.load_plugins()
+    assert len(manager.manifest_plugins) == 1
+    assert any("duplicate plugin id" in error["error"] for error in manager.errors)
+
+
+# --- validation ----------------------------------------------------------------
+
+
+def test_validate_all_example_plugins():
+    for path in sorted(EXAMPLES.iterdir()):
+        report = validate_plugin(path)
+        assert report.ok, (path, [issue.to_dict() for issue in report.issues])
+
+
+def test_validate_missing_and_malformed_manifest(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert not validate_plugin(empty).ok
+
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "titan-plugin.json").write_text("{not json")
+    assert not validate_plugin(bad).ok
+
+    invalid = tmp_path / "invalid"
+    invalid.mkdir()
+    (invalid / "titan-plugin.json").write_text(
+        json.dumps(
+            {
+                "id": "Bad ID",
+                "name": "",
+                "version": "1.0.0",
+                "api_version": "9.0.0",
+                "entry_point": "bad",
+                "capabilities": [],
+            }
+        )
+    )
+    report = validate_plugin(invalid)
+    assert not report.ok
+    assert all(issue.code.startswith("manifest.") for issue in report.issues)
+
+
+def test_validate_capability_mismatch(tmp_path):
+    plugin_dir = _write_plugin(tmp_path, "example.mismatch", capability="decoder")
+    manifest = json.loads((plugin_dir / "titan-plugin.json").read_text())
+    manifest["capabilities"] = ["report"]
+    (plugin_dir / "titan-plugin.json").write_text(json.dumps(manifest))
+    report = validate_plugin(plugin_dir)
+    assert not report.ok
+    assert any(issue.code == "entry_point.capability_mismatch" for issue in report.issues)
+
+
+def test_validate_runtime_type_errors(tmp_path):
+    plugin_dir = tmp_path / "badtypes"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        "from titan_decoder.plugins.api import DecoderPlugin\n"
+        "class Bad(DecoderPlugin):\n"
+        "    name = 'Bad'\n"
+        "    def can_decode(self, data, context=None):\n"
+        "        return 'yes'\n"
+        "    def decode(self, data, context=None):\n"
+        "        return 'not-bytes'\n"
+    )
+    (plugin_dir / "titan-plugin.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "example.badtypes",
+                "name": "Bad Types",
+                "version": "1.0.0",
+                "api_version": "1.1.0",
+                "entry_point": "plugin:Bad",
+                "capabilities": ["decoder"],
+            }
+        )
+    )
+    report = validate_plugin(plugin_dir)
+    assert not report.ok
+    codes = {issue.code for issue in report.issues}
+    assert "decoder.can_decode_type" in codes and "decoder.result_type" in codes
+
+
+def test_validate_undeclared_detection_rule(tmp_path):
+    plugin_dir = tmp_path / "undeclared"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        "from titan_decoder.plugins.api import DetectionFinding, DetectionPlugin\n"
+        "class Sneaky(DetectionPlugin):\n"
+        "    name = 'Sneaky'\n"
+        "    rule_ids = ('DECLARED-1',)\n"
+        "    def detect(self, report, iocs, context=None):\n"
+        "        return [DetectionFinding('OTHER-1', 'n', 'd', 'low')]\n"
+    )
+    (plugin_dir / "titan-plugin.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "example.sneaky",
+                "name": "Sneaky",
+                "version": "1.0.0",
+                "api_version": "1.1.0",
+                "entry_point": "plugin:Sneaky",
+                "capabilities": ["detection"],
+            }
+        )
+    )
+    report = validate_plugin(plugin_dir)
+    assert not report.ok
+    assert any(issue.code == "detection.undeclared_rule" for issue in report.issues)
+
+
+def test_manifest_matches_json_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "schemas"
+            / "titan-plugin-manifest-v1.0.schema.json"
+        ).read_text()
+    )
+    for path in sorted(EXAMPLES.iterdir()):
+        manifest = json.loads((path / "titan-plugin.json").read_text())
+        jsonschema.validate(manifest, schema)

--- a/tests/test_plugin_sdk_integration.py
+++ b/tests/test_plugin_sdk_integration.py
@@ -1,0 +1,161 @@
+"""Integration tests: SDK plugins running through the engine and CLI stages."""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from titan_decoder import cli
+from titan_decoder.config import Config
+from titan_decoder.core.case_report import build_case_report, to_html, to_markdown
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.plugins import PluginManager
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples" / "plugins"
+
+
+def _args(**over):
+    args = cli.build_parser().parse_args([])
+    for key, value in over.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_engine_loads_manifest_plugins_from_config_dir():
+    config = Config()
+    config.set("plugin_dirs", [str(EXAMPLES)])
+    engine = TitanEngine(config)
+    decoder_names = {getattr(d, "name", "") for d in engine.decoders}
+    analyzer_names = {getattr(a, "name", "") for a in engine.analyzers}
+    assert "ROT47" in decoder_names
+    assert "PrintableStrings" in analyzer_names
+    info = engine.plugin_manager.get_plugin_info()
+    assert {p["id"] for p in info["manifest_plugins"]} >= {
+        "example.rot47",
+        "example.strings",
+        "example.marker",
+        "example.summary",
+    }
+
+
+def test_engine_decodes_with_sdk_decoder_plugin():
+    """A DecodeResult-returning plugin decodes end to end inside the engine."""
+    config = Config()
+    config.set("plugin_dirs", [str(EXAMPLES / "rot47_decoder")])
+    engine = TitanEngine(config)
+    # ROT47-encoded text whose decode exposes a URL (clear structure gain):
+    rot47 = bytes(((b - 33 + 47) % 94) + 33 if 33 <= b <= 126 else b
+                  for b in b"fetch http://malware-marker.example/gate.php now")
+    report = engine.run_analysis(rot47)
+    methods = {node.get("decoder_used") for node in report["nodes"]}
+    assert "ROT47" in methods
+
+
+def _manager():
+    manager = PluginManager([EXAMPLES])
+    manager.load_plugins()
+    return manager
+
+
+def test_detection_plugins_run_in_detection_stage():
+    engine = SimpleNamespace(plugin_manager=_manager())
+    report = {
+        "meta": {"analysis_id": "t"},
+        "node_count": 1,
+        "nodes": [{"id": 0, "content_preview": "the MALWARE-MARKER is here"}],
+        "iocs": {},
+    }
+    args = _args(enable_detections=True, quiet=True)
+    detections, risk = cli.run_detections_stage(args, Config(), report, None, engine=engine)
+    plugin_hits = [d for d in detections if d.get("source", {}).get("type") == "plugin"]
+    assert len(plugin_hits) == 1
+    hit = plugin_hits[0]
+    assert hit["rule_id"] == "EXAMPLE-001"
+    assert hit["severity"] == "medium"
+    assert hit["source"]["plugin"] == "Example Marker"
+    # Plugin findings persist in the report and feed risk scoring.
+    assert hit in report["detections"]
+    assert risk is not None
+
+
+def test_detection_plugin_failure_never_aborts_stage(tmp_path, capsys):
+    plugin_dir = tmp_path / "crashy"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        "from titan_decoder.plugins.api import DetectionPlugin\n"
+        "class Crashy(DetectionPlugin):\n"
+        "    name = 'Crashy'\n"
+        "    rule_ids = ('CRASH-1',)\n"
+        "    def detect(self, report, iocs, context=None):\n"
+        "        raise RuntimeError('boom')\n"
+    )
+    (plugin_dir / "titan-plugin.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "id": "example.crashy",
+                "name": "Crashy",
+                "version": "1.0.0",
+                "api_version": "1.1.0",
+                "entry_point": "plugin:Crashy",
+                "capabilities": ["detection"],
+            }
+        )
+    )
+    manager = PluginManager([tmp_path])
+    manager.load_plugins()
+    engine = SimpleNamespace(plugin_manager=manager)
+    report = {"meta": {}, "node_count": 0, "nodes": [], "iocs": {}}
+    args = _args(enable_detections=True, quiet=False)
+    detections, _ = cli.run_detections_stage(args, Config(), report, None, engine=engine)
+    assert all(d.get("source", {}).get("type") != "plugin" for d in detections)
+    assert "Crashy failed" in capsys.readouterr().err
+
+
+def test_report_plugins_contribute_sections_to_case_reports():
+    engine = SimpleNamespace(plugin_manager=_manager())
+    report = {"meta": {}, "node_count": 3, "nodes": [], "iocs": {}, "detections": []}
+    cli._run_report_plugins(_args(quiet=True), Config(), report, engine)
+
+    sections = report["plugin_report_sections"]
+    assert len(sections) == 1
+    section = sections[0]
+    assert section["section_id"] == "example_summary"
+    assert section["plugin"] == "Example Summary"
+    assert section["content"]["node_count"] == 3
+
+    case = build_case_report(report, None, {})
+    markdown = to_markdown(case)
+    assert "Example Plugin Summary" in markdown
+    assert "Contributed by plugin: Example Summary" in markdown
+    html = to_html(case)
+    assert "Example Plugin Summary" in html
+
+
+def test_cli_plugin_list_mode(capsys):
+    args = _args(plugin_list=True, plugin_dir=[EXAMPLES])
+    assert cli.handle_info_commands(args, Config()) == 0
+    listing = json.loads(capsys.readouterr().out)
+    assert listing["api_version"] == "1.1"
+    assert {p["id"] for p in listing["manifest_plugins"]} >= {"example.rot47"}
+    assert "ROT47" in listing["decoders"]
+
+
+def test_cli_plugin_validate_mode(tmp_path, capsys):
+    args = _args(plugin_validate=[EXAMPLES / "rot47_decoder"])
+    assert cli.handle_info_commands(args, Config()) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["ok"] and output["results"][0]["ok"]
+
+    broken = tmp_path / "broken"
+    broken.mkdir()
+    args = _args(plugin_validate=[broken])
+    assert cli.handle_info_commands(args, Config()) == 1
+    output = json.loads(capsys.readouterr().out)
+    assert not output["ok"]
+
+
+def test_cli_parser_plugin_defaults():
+    args = cli.build_parser().parse_args(["--file", "x.bin"])
+    assert args.plugin_dir is None
+    assert args.plugin_validate is None
+    assert args.plugin_list is False

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -264,6 +264,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Write the intelligence summary to a separate JSON file",
     )
     parser.add_argument(
+        "--plugin-dir",
+        action="append",
+        type=Path,
+        help="Additional plugin directory to load (repeatable)",
+    )
+    parser.add_argument(
+        "--plugin-validate",
+        action="append",
+        type=Path,
+        help="Validate a manifest plugin directory and exit (repeatable)",
+    )
+    parser.add_argument(
+        "--plugin-list",
+        action="store_true",
+        help="List discovered plugins (including load errors) and exit",
+    )
+    parser.add_argument(
         "--rules-pack",
         action="append",
         type=Path,
@@ -445,6 +462,31 @@ def handle_info_commands(args, config) -> "int | None":
         print(json.dumps({"rule_packs": packs}, indent=2))
         return 0
 
+    # Validate manifest plugins and exit. Deep validation: manifest contract,
+    # API compatibility, entry point, capabilities, and a bounded runtime
+    # probe. Note the probe executes plugin code in-process.
+    if args.plugin_validate:
+        from .plugins.validation import validate_plugins
+
+        ok, results = validate_plugins(args.plugin_validate)
+        print(json.dumps({"ok": ok, "results": results}, indent=2))
+        return 0 if ok else 1
+
+    # List discovered plugins (same directory set the engine uses) and exit.
+    if args.plugin_list:
+        from .plugins import PluginManager
+
+        manager = PluginManager()
+        for plugin_dir in config.get("plugin_dirs", []) or []:
+            manager.add_plugin_dir(Path(plugin_dir))
+        for plugin_dir in args.plugin_dir or []:
+            manager.add_plugin_dir(Path(plugin_dir))
+        manager.add_plugin_dir(Path.home() / ".titan_decoder" / "plugins")
+        manager.add_plugin_dir(Path(__file__).parent / "plugins")
+        manager.load_plugins()
+        print(json.dumps(manager.get_plugin_info(), indent=2))
+        return 0
+
     # Validate rule packs and exit. Deep validation: structural load errors,
     # the per-pack rule limit, per-rule definition problems, and duplicate ids
     # all surface as errors and fail the command.
@@ -524,6 +566,13 @@ def apply_runtime_config(args, config) -> None:
         config.set("enable_geo_enrichment", False)
         config.set("enable_whois", False)
         config.set("enable_yara", False)
+
+    # Extra plugin directories: merged into config so the engine's plugin
+    # manager discovers them alongside the configured and default dirs.
+    if args.plugin_dir:
+        merged = list(config.get("plugin_dirs", []) or [])
+        merged.extend(str(p) for p in args.plugin_dir if str(p) not in merged)
+        config.set("plugin_dirs", merged)
 
     # Apply profile presets
     if args.analysis_profile == "safe":
@@ -776,10 +825,69 @@ def attach_evidence_stage(args, report, evidence_result) -> None:
             "top_links": top_links(links, limit=10),
         }
 
-def run_detections_stage(args, config, report, evidence_result):
-    """Run detection rules and risk scoring if requested.
+# Bounded plugin output: a plugin may contribute at most this many findings
+# or report sections per run, mirroring the per-pack rule limit.
+MAX_PLUGIN_FINDINGS = 200
+MAX_PLUGIN_SECTIONS = 20
 
-    Returns ``(detections, risk_assessment)`` and persists both into the report.
+
+def _plugin_context(config, args):
+    """Build the PluginContext SDK plugins receive from this run."""
+    from .plugins import PluginContext
+
+    return PluginContext(
+        config=dict(getattr(config, "_config", {}) or {}),
+        offline=bool(getattr(args, "offline", False)),
+    )
+
+
+def _run_detection_plugins(args, config, report, iocs, engine):
+    """Run loaded detection plugins; return their findings as detection dicts.
+
+    A failing plugin is skipped with a warning — plugins must never be able
+    to abort an analysis. Findings under undeclared rule IDs are dropped
+    (the declared set was validated at load time, including the reserved
+    ``TITAN-`` prefix and cross-plugin uniqueness).
+    """
+    manager = getattr(engine, "plugin_manager", None)
+    if manager is None or not getattr(manager, "detections", None):
+        return []
+
+    context = _plugin_context(config, args)
+    results = []
+    for plugin in manager.get_detections():
+        declared = {str(rule_id) for rule_id in plugin.rule_ids}
+        try:
+            findings = list(plugin.detect(report, iocs, context))
+        except Exception as exc:
+            if not args.quiet:
+                print(
+                    f"Warning: detection plugin {plugin.name} failed: {exc}",
+                    file=sys.stderr,
+                )
+            continue
+        for finding in findings[:MAX_PLUGIN_FINDINGS]:
+            data = finding.to_dict() if hasattr(finding, "to_dict") else None
+            if not isinstance(data, dict) or data.get("rule_id") not in declared:
+                if not args.quiet:
+                    print(
+                        f"Warning: detection plugin {plugin.name} emitted an "
+                        "invalid or undeclared finding; dropped",
+                        file=sys.stderr,
+                    )
+                continue
+            data["source"] = {"type": "plugin", "plugin": str(plugin.name)}
+            results.append(data)
+    return results
+
+
+def run_detections_stage(args, config, report, evidence_result, engine=None):
+    """Run detection rules, detection plugins, and risk scoring if requested.
+
+    Returns ``(detections, risk_assessment)`` and persists both into the
+    report. Detection plugins (loaded by the engine's plugin manager) run
+    after the rule engines and before risk scoring, so plugin findings feed
+    the risk assessment exactly like rule matches.
     """
     # Run detections and risk scoring if requested
     detections = []
@@ -810,6 +918,9 @@ def run_detections_stage(args, config, report, evidence_result):
         iocs = build_ioc_summary(report, None)
         _merge_evidence_iocs(iocs, evidence_result)
         detections = rules_engine.evaluate_all(report, iocs)
+        detections.extend(
+            _run_detection_plugins(args, config, report, iocs, engine)
+        )
 
         if getattr(rules_engine, "rule_packs", None) is not None:
             report.setdefault("meta", {})
@@ -994,6 +1105,52 @@ def run_phase5_correlation_stage(args, report) -> int:
     return 0
 
 
+def _run_report_plugins(args, config, report, engine) -> None:
+    """Collect sections from report plugins into ``report["plugin_report_sections"]``.
+
+    Sections must be JSON-serializable and are bounded per plugin. A failing
+    plugin is skipped with a warning; plugins can extend reports but never
+    break them.
+    """
+    manager = getattr(engine, "plugin_manager", None)
+    if manager is None or not getattr(manager, "reports", None):
+        return
+
+    from .plugins import ReportSection
+
+    context = _plugin_context(config, args)
+    sections = []
+    for plugin in manager.get_reports():
+        try:
+            built = list(plugin.build_sections(report, context))
+        except Exception as exc:
+            if not args.quiet:
+                print(
+                    f"Warning: report plugin {plugin.name} failed: {exc}",
+                    file=sys.stderr,
+                )
+            continue
+        for section in built[:MAX_PLUGIN_SECTIONS]:
+            if not isinstance(section, ReportSection):
+                continue
+            data = section.to_dict()
+            data["plugin"] = str(plugin.name)
+            try:
+                json.dumps(data)
+            except (TypeError, ValueError):
+                if not args.quiet:
+                    print(
+                        f"Warning: report plugin {plugin.name} section "
+                        f"{section.section_id} is not JSON-serializable; dropped",
+                        file=sys.stderr,
+                    )
+                continue
+            sections.append(data)
+    if sections:
+        sections.sort(key=lambda item: (item.get("order", 100), item.get("section_id", "")))
+        report["plugin_report_sections"] = sections
+
+
 def write_outputs_stage(args, config, report, engine, detections, risk_assessment, evidence_result) -> int:
     """Run all exports, contract validation, output, and compute the exit code.
 
@@ -1006,6 +1163,10 @@ def write_outputs_stage(args, config, report, engine, detections, risk_assessmen
     phase5_exit = run_phase5_correlation_stage(args, report)
     if phase5_exit != 0:
         return phase5_exit
+
+    # Report plugins contribute analyst sections; embedded in the JSON report
+    # and rendered into Markdown/HTML case reports.
+    _run_report_plugins(args, config, report, engine)
 
     # Optional forensic attribution summary
     forensics_summary = None
@@ -1332,7 +1493,7 @@ def main():
     report, engine = run_analysis_stage(args, config, data)
     attach_evidence_stage(args, report, evidence_result)
     detections, risk_assessment = run_detections_stage(
-        args, config, report, evidence_result
+        args, config, report, evidence_result, engine=engine
     )
     attach_intelligence_stage(
         args, report, detections, risk_assessment, evidence_result

--- a/titan_decoder/core/case_report.py
+++ b/titan_decoder/core/case_report.py
@@ -51,6 +51,7 @@ def build_case_report(
         }
         if evidence
         else {},
+        "plugin_sections": list(report.get("plugin_report_sections") or []),
         "recommendations": recommendations,
     }
 
@@ -142,6 +143,18 @@ def to_markdown(case: Dict[str, Any]) -> str:
     lines.append(json.dumps(case.get("forensics", {}) or {}, indent=2))
     lines.append("```")
     lines.append("")
+
+    for section in case.get("plugin_sections") or []:
+        if "markdown" not in (section.get("formats") or []):
+            continue
+        lines.append(f"## {_md_cell(section.get('title'))}")
+        lines.append("")
+        lines.append(f"_Contributed by plugin: {_md_cell(section.get('plugin'))}_")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(section.get("content"), indent=2, sort_keys=True))
+        lines.append("```")
+        lines.append("")
 
     lines.append("## Recommendations")
     lines.append("")
@@ -254,12 +267,28 @@ def to_html(case: Dict[str, Any]) -> str:
             f"  <pre>{esc(json.dumps(forensics, indent=2))}</pre>",
             "  <h2>Evidence (Normalized)</h2>",
             f"  {evidence_html}",
+            _plugin_sections_html(case, esc),
             "  <h2>Recommendations</h2>",
             f"  <ul>{rec_items}</ul>",
             "</body>",
             "</html>",
         ]
     )
+
+
+def _plugin_sections_html(case: Dict[str, Any], esc) -> str:
+    """Render plugin-contributed sections (html format) as HTML blocks."""
+    blocks: List[str] = []
+    for section in case.get("plugin_sections") or []:
+        if "html" not in (section.get("formats") or []):
+            continue
+        blocks.append(f"  <h2>{esc(section.get('title'))}</h2>")
+        blocks.append(
+            f"  <p><em>Contributed by plugin: {esc(section.get('plugin'))}</em></p>"
+        )
+        content = json.dumps(section.get("content"), indent=2, sort_keys=True)
+        blocks.append(f"  <pre>{esc(content)}</pre>")
+    return "\n".join(blocks)
 
 
 def _normalize_intelligence(value: Any) -> Dict[str, Any]:

--- a/titan_decoder/plugins/__init__.py
+++ b/titan_decoder/plugins/__init__.py
@@ -1,216 +1,84 @@
 """
 Plugin system for Titan Decoder Engine.
 
-This module provides the base classes and loading mechanisms for extending
-the decoder engine with custom decoders and analyzers.
+This package provides the base classes, manifest contract, validation, and
+loading mechanisms for extending the engine with custom decoders, analyzers,
+detections, and report sections. Third-party plugins should import only from
+``titan_decoder.plugins.api`` — the stable, versioned public surface.
+
+Two plugin styles are supported side by side:
+
+- Single-file plugins (API 1.0): a ``.py`` file in a plugin directory.
+- Manifest plugins (API 1.1): a directory with ``titan-plugin.json`` plus
+  its entry-point module, supporting all four SDK capabilities.
+
+See docs/PLUGIN_API.md for the full contract.
 """
 
-from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Tuple
-import importlib.util
-import sys
-from pathlib import Path
-import logging
+from .contracts import (
+    PLUGIN_API_VERSION,
+    AnalysisArtifact,
+    AnalyzerPlugin,
+    DecodeResult,
+    DecoderPlugin,
+    DetectionFinding,
+    DetectionPlugin,
+    PluginAnalyzer,
+    PluginCapability,
+    PluginContext,
+    PluginDecoder,
+    ReportPlugin,
+    ReportSection,
+    is_api_compatible,
+)
+from .manifest import (
+    PLUGIN_MANIFEST_FILENAME,
+    PLUGIN_MANIFEST_SCHEMA_VERSION,
+    PluginManifest,
+    validate_manifest,
+)
+from .registry import (
+    RESERVED_RULE_PREFIX,
+    LoadedPlugin,
+    PluginManager,
+    PluginRegistry,
+)
+from .semver import Version, is_manifest_api_compatible, satisfies
+from .validation import (
+    PluginValidationReport,
+    ValidationIssue,
+    validate_plugin,
+    validate_plugins,
+)
 
-logger = logging.getLogger(__name__)
-
-# Versioned plugin API contract (MAJOR.MINOR). A third party ships a decoder or
-# analyzer against this interface without reading engine internals. Plugins may
-# declare the API version they were built for via a module-level
-# ``PLUGIN_API_VERSION`` or a class attribute; the manager loads a plugin only
-# when its declared MAJOR matches. See docs/PLUGIN_API.md for the full contract.
-#
-# MAJOR bump = breaking change to the base-class method signatures / semantics.
-# MINOR bump = additive, backward-compatible extension.
-PLUGIN_API_VERSION = "1.0"
-
-
-def _api_major(version: str) -> int:
-    try:
-        return int(str(version).split(".", 1)[0])
-    except (ValueError, AttributeError):
-        return -1
-
-
-def is_api_compatible(declared: str) -> bool:
-    """Return True if a plugin declaring ``declared`` is loadable here.
-
-    Compatible when the MAJOR versions match: the engine may add MINOR features
-    without breaking older plugins, but a MAJOR change is breaking.
-    """
-    return _api_major(declared) == _api_major(PLUGIN_API_VERSION)
-
-
-class PluginDecoder(ABC):
-    """Base class for plugin decoders."""
-
-    @abstractmethod
-    def can_decode(self, data: bytes) -> bool:
-        """Check if this decoder can handle the data."""
-        pass
-
-    @abstractmethod
-    def decode(self, data: bytes) -> Tuple[bytes, bool]:
-        """Decode the data. Return (decoded_data, success)."""
-        pass
-
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Name of the decoder."""
-        pass
-
-    @property
-    def priority(self) -> int:
-        """Priority for decoder ordering (higher = tried first). Default 0."""
-        return 0
-
-
-class PluginAnalyzer(ABC):
-    """Base class for plugin analyzers."""
-
-    @abstractmethod
-    def can_analyze(self, data: bytes) -> bool:
-        """Check if this analyzer can handle the data."""
-        pass
-
-    @abstractmethod
-    def analyze(self, data: bytes) -> List[Tuple[str, bytes]]:
-        """Analyze the data and return list of (name, content) tuples."""
-        pass
-
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Name of the analyzer."""
-        pass
-
-    @property
-    def priority(self) -> int:
-        """Priority for analyzer ordering (higher = tried first). Default 0."""
-        return 0
-
-
-class PluginManager:
-    """Manages loading and registration of plugins."""
-
-    def __init__(self, plugin_dirs: List[Path] = None):
-        self.plugin_dirs = plugin_dirs or []
-        self.decoders: List[PluginDecoder] = []
-        self.analyzers: List[PluginAnalyzer] = []
-        self.loaded_plugins: Dict[str, Any] = {}
-
-    def add_plugin_dir(self, plugin_dir: Path):
-        """Add a directory to search for plugins."""
-        if plugin_dir not in self.plugin_dirs:
-            self.plugin_dirs.append(plugin_dir)
-
-    def load_plugins(self):
-        """Load all plugins from configured directories."""
-        for plugin_dir in self.plugin_dirs:
-            if plugin_dir.exists() and plugin_dir.is_dir():
-                self._load_plugins_from_dir(plugin_dir)
-
-        # Sort by priority (highest first)
-        self.decoders.sort(key=lambda d: d.priority, reverse=True)
-        self.analyzers.sort(key=lambda a: a.priority, reverse=True)
-
-    # Package-infrastructure modules in the built-in plugin dir that are not
-    # plugins and must not be discovered/loaded as such.
-    _RESERVED_MODULES = frozenset({"api.py"})
-
-    def _load_plugins_from_dir(self, plugin_dir: Path):
-        """Load plugins from a specific directory."""
-        for item in plugin_dir.iterdir():
-            if (
-                item.is_file()
-                and item.suffix == ".py"
-                and not item.name.startswith("_")
-                and item.name not in self._RESERVED_MODULES
-            ):
-                self._load_plugin_file(item)
-
-    def _load_plugin_file(self, plugin_file: Path):
-        """Load a single plugin file."""
-        try:
-            # Create module name
-            module_name = f"titan_decoder_plugins_{plugin_file.stem}"
-
-            # Load the module
-            spec = importlib.util.spec_from_file_location(module_name, plugin_file)
-            if spec and spec.loader:
-                module = importlib.util.module_from_spec(spec)
-                sys.modules[module_name] = module
-                spec.loader.exec_module(module)
-
-                # Enforce the versioned API contract: a plugin may declare the
-                # API version it targets; skip it on a breaking (MAJOR) mismatch
-                # rather than loading an incompatible extension.
-                declared = getattr(module, "PLUGIN_API_VERSION", None)
-                if declared is not None and not is_api_compatible(str(declared)):
-                    logger.warning(
-                        "Skipping plugin %s: declares API %s, engine provides %s "
-                        "(incompatible major version)",
-                        plugin_file.name,
-                        declared,
-                        PLUGIN_API_VERSION,
-                    )
-                    return
-
-                # Find plugin classes in the module
-                self._register_plugin_classes(module, plugin_file.stem)
-
-                self.loaded_plugins[plugin_file.stem] = module
-
-        except Exception as e:
-            logger.warning("Failed to load plugin %s: %s", plugin_file, e)
-
-    def _register_plugin_classes(self, module, plugin_name: str):
-        """Register plugin classes from a loaded module."""
-        for attr_name in dir(module):
-            attr = getattr(module, attr_name)
-            if isinstance(attr, type):
-                # Check if it's a plugin class
-                if issubclass(attr, PluginDecoder) and attr != PluginDecoder:
-                    try:
-                        instance = attr()
-                        self.decoders.append(instance)
-                        logger.info("Loaded decoder plugin: %s", instance.name)
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to instantiate decoder %s from plugin %s: %s",
-                            attr_name,
-                            plugin_name,
-                            e,
-                        )
-
-                elif issubclass(attr, PluginAnalyzer) and attr != PluginAnalyzer:
-                    try:
-                        instance = attr()
-                        self.analyzers.append(instance)
-                        logger.info("Loaded analyzer plugin: %s", instance.name)
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to instantiate analyzer %s from plugin %s: %s",
-                            attr_name,
-                            plugin_name,
-                            e,
-                        )
-
-    def get_decoders(self) -> List[PluginDecoder]:
-        """Get all loaded decoder plugins."""
-        return self.decoders.copy()
-
-    def get_analyzers(self) -> List[PluginAnalyzer]:
-        """Get all loaded analyzer plugins."""
-        return self.analyzers.copy()
-
-    def get_plugin_info(self) -> Dict[str, Any]:
-        """Get information about loaded plugins."""
-        return {
-            "api_version": PLUGIN_API_VERSION,
-            "plugin_dirs": [str(d) for d in self.plugin_dirs],
-            "loaded_plugins": list(self.loaded_plugins.keys()),
-            "decoders": [d.name for d in self.decoders],
-            "analyzers": [a.name for a in self.analyzers],
-        }
+__all__ = [
+    "AnalysisArtifact",
+    "AnalyzerPlugin",
+    "DecodeResult",
+    "DecoderPlugin",
+    "DetectionFinding",
+    "DetectionPlugin",
+    "LoadedPlugin",
+    "PLUGIN_API_VERSION",
+    "PLUGIN_MANIFEST_FILENAME",
+    "PLUGIN_MANIFEST_SCHEMA_VERSION",
+    "PluginAnalyzer",
+    "PluginCapability",
+    "PluginContext",
+    "PluginDecoder",
+    "PluginManager",
+    "PluginManifest",
+    "PluginRegistry",
+    "PluginValidationReport",
+    "RESERVED_RULE_PREFIX",
+    "ReportPlugin",
+    "ReportSection",
+    "ValidationIssue",
+    "Version",
+    "is_api_compatible",
+    "is_manifest_api_compatible",
+    "satisfies",
+    "validate_manifest",
+    "validate_plugin",
+    "validate_plugins",
+]

--- a/titan_decoder/plugins/api.py
+++ b/titan_decoder/plugins/api.py
@@ -1,12 +1,12 @@
 """Stable, versioned public plugin API for Titan.
 
-Third-party decoders and analyzers should import **only** from this module. It
-is the compatibility surface: everything here is covered by the
+Third-party plugins should import **only** from this module. It is the
+compatibility surface: everything here is covered by the
 ``PLUGIN_API_VERSION`` contract (see docs/PLUGIN_API.md), so a plugin written
 against it keeps working across engine releases with the same MAJOR version,
 without depending on engine internals.
 
-Example plugin (``myplugin.py`` dropped in a plugin dir)::
+Single-file plugin (``myplugin.py`` dropped in a plugin dir, API 1.0)::
 
     from titan_decoder.plugins.api import PluginDecoder, PLUGIN_API_VERSION
 
@@ -25,24 +25,75 @@ Example plugin (``myplugin.py`` dropped in a plugin dir)::
                         for b in data)
             return out, out != data
 
-Contract every plugin must uphold (enforced by the fuzz invariants):
-``can_decode``/``can_analyze`` and ``decode``/``analyze`` must never raise,
-must return the declared types, must bound their output, and must terminate
+Manifest plugin (a directory with ``titan-plugin.json``, API 1.1) may use any
+of the four SDK base classes — :class:`DecoderPlugin`,
+:class:`AnalyzerPlugin`, :class:`DetectionPlugin`, :class:`ReportPlugin` —
+with typed results and an optional :class:`PluginContext`. See
+``examples/plugins/`` for one complete plugin per capability.
+
+Contract every plugin must uphold (enforced by the fuzz invariants and
+``--plugin-validate``): ``can_decode``/``can_analyze`` and
+``decode``/``analyze``/``detect``/``build_sections`` must never raise, must
+return the declared types, must bound their output, and must terminate
 quickly on any input, including hostile bytes.
 """
 
 from __future__ import annotations
 
-from . import (
+from .contracts import (
     PLUGIN_API_VERSION,
+    AnalysisArtifact,
+    AnalyzerPlugin,
+    DecodeResult,
+    DecoderPlugin,
+    DetectionFinding,
+    DetectionPlugin,
     PluginAnalyzer,
+    PluginCapability,
+    PluginContext,
     PluginDecoder,
+    ReportPlugin,
+    ReportSection,
     is_api_compatible,
+)
+from .manifest import (
+    PLUGIN_MANIFEST_FILENAME,
+    PLUGIN_MANIFEST_SCHEMA_VERSION,
+    PluginManifest,
+    validate_manifest,
+)
+from .semver import Version, is_manifest_api_compatible, satisfies
+from .validation import (
+    PluginValidationReport,
+    ValidationIssue,
+    validate_plugin,
+    validate_plugins,
 )
 
 __all__ = [
     "PLUGIN_API_VERSION",
-    "PluginDecoder",
+    "PLUGIN_MANIFEST_FILENAME",
+    "PLUGIN_MANIFEST_SCHEMA_VERSION",
+    "AnalysisArtifact",
+    "AnalyzerPlugin",
+    "DecodeResult",
+    "DecoderPlugin",
+    "DetectionFinding",
+    "DetectionPlugin",
     "PluginAnalyzer",
+    "PluginCapability",
+    "PluginContext",
+    "PluginDecoder",
+    "PluginManifest",
+    "PluginValidationReport",
+    "ReportPlugin",
+    "ReportSection",
+    "ValidationIssue",
+    "Version",
     "is_api_compatible",
+    "is_manifest_api_compatible",
+    "satisfies",
+    "validate_manifest",
+    "validate_plugin",
+    "validate_plugins",
 ]

--- a/titan_decoder/plugins/contracts.py
+++ b/titan_decoder/plugins/contracts.py
@@ -1,0 +1,325 @@
+"""Plugin SDK v1 contracts: base classes and typed results.
+
+This module defines the four plugin SDKs (decoder, analyzer, detection,
+report) plus the typed values they exchange with the engine. Everything here
+is part of the versioned public API surface re-exported by
+``titan_decoder.plugins.api`` — third-party plugins import only from there.
+
+Compatibility: the original single-file plugin contract (``PluginDecoder`` /
+``PluginAnalyzer`` with ``(bytes, bool)`` and ``(name, bytes)`` results) is
+unchanged and remains fully supported. The SDK classes subclass those bases
+and add an optional :class:`PluginContext` argument and typed results;
+:class:`DecodeResult` and :class:`AnalysisArtifact` unpack like the legacy
+tuples, so the engine consumes both styles identically.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Sequence
+
+# Versioned plugin API contract (MAJOR.MINOR). A third party ships a plugin
+# against this interface without reading engine internals.
+#
+# MAJOR bump = breaking change to base-class method signatures / semantics.
+# MINOR bump = additive, backward-compatible extension.
+#
+# History: 1.0 = single-file PluginDecoder/PluginAnalyzer contract.
+#          1.1 = adds the manifest-based SDK (detection/report plugins,
+#                PluginContext, typed results) — purely additive.
+PLUGIN_API_VERSION = "1.1"
+
+
+def _api_major(version: str) -> int:
+    try:
+        return int(str(version).split(".", 1)[0])
+    except (ValueError, AttributeError):
+        return -1
+
+
+def is_api_compatible(declared: str) -> bool:
+    """Return True if a plugin declaring ``declared`` is loadable here.
+
+    Compatible when the MAJOR versions match: the engine may add MINOR
+    features without breaking older plugins, but a MAJOR change is breaking.
+    Malformed declarations are incompatible rather than an error.
+    """
+    return _api_major(declared) == _api_major(PLUGIN_API_VERSION)
+
+
+class PluginCapability(str, Enum):
+    """Capabilities a plugin may declare in its manifest."""
+
+    DECODER = "decoder"
+    ANALYZER = "analyzer"
+    DETECTION = "detection"
+    REPORT = "report"
+
+
+@dataclass(frozen=True)
+class PluginContext:
+    """Execution context handed to SDK plugins.
+
+    Communicates the engine's offline stance and resource bounds. Plugins
+    must honor these limits; validation probes them and the engine treats
+    violations as plugin failures.
+    """
+
+    config: Mapping[str, Any] = field(default_factory=dict)
+    offline: bool = True
+    max_input_bytes: int = 100 * 1024 * 1024
+    max_output_bytes: int = 100 * 1024 * 1024
+    max_children: int = 100
+    working_directory: Path | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "config", dict(self.config))
+
+
+@dataclass(frozen=True)
+class DecodeResult:
+    """Typed decoder result. Unpacks like the legacy ``(bytes, bool)``."""
+
+    data: bytes
+    success: bool
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.data, bytes):
+            raise TypeError("DecodeResult.data must be bytes")
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def __iter__(self) -> Iterator[Any]:
+        # Tuple-compatibility: `decoded, success = plugin.decode(data)` works
+        # whether the plugin returns a DecodeResult or a legacy tuple.
+        yield self.data
+        yield self.success
+
+
+@dataclass(frozen=True)
+class AnalysisArtifact:
+    """Typed analyzer artifact. Unpacks like the legacy ``(name, bytes)``."""
+
+    name: str
+    data: bytes
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.name or Path(self.name).name != self.name:
+            raise ValueError("artifact name must be a non-empty basename")
+        if not isinstance(self.data, bytes):
+            raise TypeError("AnalysisArtifact.data must be bytes")
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def __iter__(self) -> Iterator[Any]:
+        yield self.name
+        yield self.data
+
+
+@dataclass(frozen=True)
+class DetectionFinding:
+    """One detection produced by a detection plugin.
+
+    Mirrors the built-in detection dictionary shape so plugin findings merge
+    into ``report["detections"]`` and feed risk scoring like rule results.
+    """
+
+    rule_id: str
+    name: str
+    description: str
+    severity: str
+    attack_ids: tuple[str, ...] = ()
+    evidence: tuple[Mapping[str, Any], ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.rule_id or not self.name:
+            raise ValueError("rule_id and name are required")
+        if self.severity not in {"low", "medium", "high", "critical"}:
+            raise ValueError("severity must be low, medium, high, or critical")
+        object.__setattr__(self, "attack_ids", tuple(sorted(set(self.attack_ids))))
+        object.__setattr__(self, "evidence", tuple(dict(item) for item in self.evidence))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "name": self.name,
+            "description": self.description,
+            "severity": self.severity,
+            "attack_ids": list(self.attack_ids),
+            "evidence": [dict(item) for item in self.evidence],
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ReportSection:
+    """One analyst-facing section contributed by a report plugin."""
+
+    section_id: str
+    title: str
+    content: Any
+    order: int = 100
+    formats: tuple[str, ...] = ("json",)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.section_id or not self.title:
+            raise ValueError("section_id and title are required")
+        if not set(self.formats) <= {"json", "markdown", "html"}:
+            raise ValueError("formats must be a subset of json/markdown/html")
+        object.__setattr__(self, "formats", tuple(sorted(set(self.formats))))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "section_id": self.section_id,
+            "title": self.title,
+            "content": self.content,
+            "order": self.order,
+            "formats": list(self.formats),
+            "metadata": dict(self.metadata),
+        }
+
+
+class PluginDecoder(ABC):
+    """Base class for plugin decoders (single-file plugin contract, API 1.0).
+
+    Contract (enforced by the fuzz invariants): ``can_decode`` and ``decode``
+    must never raise, must return the declared types, must bound their
+    output, and must terminate quickly on any input, including hostile bytes.
+    """
+
+    @abstractmethod
+    def can_decode(self, data: bytes) -> bool:
+        """Check if this decoder can handle the data."""
+
+    @abstractmethod
+    def decode(self, data: bytes) -> "DecodeResult | tuple[bytes, bool]":
+        """Decode the data. Return (decoded_data, success).
+
+        A typed :class:`DecodeResult` is also accepted — it unpacks
+        identically, so the engine consumes both forms the same way.
+        """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name of the decoder."""
+
+    @property
+    def priority(self) -> int:
+        """Priority for decoder ordering (higher = tried first). Default 0."""
+        return 0
+
+
+class PluginAnalyzer(ABC):
+    """Base class for plugin analyzers (single-file plugin contract, API 1.0)."""
+
+    @abstractmethod
+    def can_analyze(self, data: bytes) -> bool:
+        """Check if this analyzer can handle the data."""
+
+    @abstractmethod
+    def analyze(
+        self, data: bytes
+    ) -> "Sequence[AnalysisArtifact] | Sequence[tuple[str, bytes]]":
+        """Analyze the data and return list of (name, content) tuples.
+
+        Typed :class:`AnalysisArtifact` items are also accepted — they
+        unpack identically to the tuples.
+        """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name of the analyzer."""
+
+    @property
+    def priority(self) -> int:
+        """Priority for analyzer ordering (higher = tried first). Default 0."""
+        return 0
+
+
+class DecoderPlugin(PluginDecoder):
+    """Decoder SDK base class (manifest plugins, API 1.1).
+
+    Same engine-facing contract as :class:`PluginDecoder`, with an optional
+    context argument and an optional typed result. Because
+    :class:`DecodeResult` unpacks like ``(bytes, bool)``, either return type
+    is valid.
+    """
+
+    api_version = PLUGIN_API_VERSION
+
+    @abstractmethod
+    def can_decode(self, data: bytes, context: PluginContext | None = None) -> bool: ...
+
+    @abstractmethod
+    def decode(
+        self, data: bytes, context: PluginContext | None = None
+    ) -> DecodeResult | tuple[bytes, bool]: ...
+
+
+class AnalyzerPlugin(PluginAnalyzer):
+    """Analyzer SDK base class (manifest plugins, API 1.1)."""
+
+    api_version = PLUGIN_API_VERSION
+
+    @abstractmethod
+    def can_analyze(self, data: bytes, context: PluginContext | None = None) -> bool: ...
+
+    @abstractmethod
+    def analyze(
+        self, data: bytes, context: PluginContext | None = None
+    ) -> Sequence[AnalysisArtifact] | Sequence[tuple[str, bytes]]: ...
+
+
+class DetectionPlugin(ABC):
+    """Detection SDK base class (manifest plugins, API 1.1).
+
+    ``rule_ids`` must declare every rule the plugin can emit. IDs are
+    validated at load time: the ``TITAN-`` prefix is reserved for built-in
+    rules, and IDs must not collide with other loaded plugins.
+    """
+
+    api_version = PLUGIN_API_VERSION
+    priority = 0
+
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def rule_ids(self) -> Sequence[str]: ...
+
+    @abstractmethod
+    def detect(
+        self,
+        report: Mapping[str, Any],
+        iocs: Mapping[str, Any],
+        context: PluginContext | None = None,
+    ) -> Sequence[DetectionFinding]: ...
+
+
+class ReportPlugin(ABC):
+    """Report SDK base class (manifest plugins, API 1.1)."""
+
+    api_version = PLUGIN_API_VERSION
+    priority = 0
+
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @abstractmethod
+    def build_sections(
+        self,
+        report: Mapping[str, Any],
+        context: PluginContext | None = None,
+    ) -> Sequence[ReportSection]: ...

--- a/titan_decoder/plugins/manifest.py
+++ b/titan_decoder/plugins/manifest.py
@@ -1,0 +1,164 @@
+"""Plugin manifest loading and validation.
+
+A manifest plugin is a directory containing ``titan-plugin.json`` plus its
+entry-point module. The manifest declares identity, versions, capabilities,
+permissions, and dependencies; the JSON Schema contract lives in
+``schemas/titan-plugin-manifest-v1.0.schema.json``.
+
+Permission declarations are policy metadata for operators and reviewers, not
+a sandbox: plugins execute in-process (see docs/PLUGIN_API.md).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import re
+from typing import Any, Mapping
+
+from .contracts import PLUGIN_API_VERSION, PluginCapability
+from .semver import Version, is_manifest_api_compatible
+
+PLUGIN_MANIFEST_FILENAME = "titan-plugin.json"
+PLUGIN_MANIFEST_SCHEMA_VERSION = "1.0"
+
+MAX_MANIFEST_BYTES = 64 * 1024
+
+SUPPORTED_PERMISSIONS = frozenset(
+    {"filesystem.read", "filesystem.write", "network", "configuration"}
+)
+
+_PLUGIN_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$")
+_ENTRY_POINT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*:[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Parsed ``titan-plugin.json`` contents."""
+
+    plugin_id: str
+    name: str
+    version: str
+    api_version: str
+    entry_point: str
+    capabilities: tuple[str, ...]
+    description: str = ""
+    author: str = ""
+    license: str = ""
+    homepage: str = ""
+    permissions: tuple[str, ...] = ()
+    dependencies: Mapping[str, str] = field(default_factory=dict)
+    schema_version: str = PLUGIN_MANIFEST_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "capabilities", tuple(sorted(set(self.capabilities))))
+        object.__setattr__(self, "permissions", tuple(sorted(set(self.permissions))))
+        object.__setattr__(self, "dependencies", dict(self.dependencies))
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "PluginManifest":
+        return cls(
+            plugin_id=str(data.get("id", "")),
+            name=str(data.get("name", "")),
+            version=str(data.get("version", "")),
+            api_version=str(data.get("api_version", "")),
+            entry_point=str(data.get("entry_point", "")),
+            capabilities=tuple(data.get("capabilities") or ()),
+            description=str(data.get("description", "")),
+            author=str(data.get("author", "")),
+            license=str(data.get("license", "")),
+            homepage=str(data.get("homepage", "")),
+            permissions=tuple(data.get("permissions") or ()),
+            dependencies=dict(data.get("dependencies") or {}),
+            schema_version=str(data.get("schema_version") or PLUGIN_MANIFEST_SCHEMA_VERSION),
+        )
+
+    @classmethod
+    def load(cls, path: str | Path) -> "PluginManifest":
+        manifest_path = Path(path)
+        if manifest_path.stat().st_size > MAX_MANIFEST_BYTES:
+            raise ValueError(f"manifest exceeds {MAX_MANIFEST_BYTES} bytes")
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("manifest root must be a JSON object")
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "id": self.plugin_id,
+            "name": self.name,
+            "version": self.version,
+            "api_version": self.api_version,
+            "entry_point": self.entry_point,
+            "capabilities": list(self.capabilities),
+            "description": self.description,
+            "author": self.author,
+            "license": self.license,
+            "homepage": self.homepage,
+            "permissions": list(self.permissions),
+            "dependencies": dict(self.dependencies),
+        }
+
+
+def validate_manifest(
+    manifest: PluginManifest,
+    provided_api_version: str = PLUGIN_API_VERSION,
+) -> tuple[str, ...]:
+    """Return every validation problem for *manifest* (empty when valid)."""
+
+    errors: list[str] = []
+    if manifest.schema_version != PLUGIN_MANIFEST_SCHEMA_VERSION:
+        errors.append(
+            f"unsupported schema_version: {manifest.schema_version!r} "
+            f"(expected {PLUGIN_MANIFEST_SCHEMA_VERSION!r})"
+        )
+    if not _PLUGIN_ID_RE.fullmatch(manifest.plugin_id):
+        errors.append(
+            "invalid plugin id (lowercase alphanumeric segments separated "
+            "by '.', '_', or '-')"
+        )
+    if not manifest.name.strip():
+        errors.append("name must not be empty")
+
+    for label, value in (("version", manifest.version), ("api_version", manifest.api_version)):
+        try:
+            Version.parse(value)
+        except ValueError:
+            errors.append(f"invalid {label}: {value!r}")
+
+    if not _ENTRY_POINT_RE.fullmatch(manifest.entry_point):
+        errors.append("entry_point must have the form module:ClassName")
+
+    supported = {capability.value for capability in PluginCapability}
+    if not manifest.capabilities:
+        errors.append("capabilities must not be empty")
+    unknown = sorted(set(manifest.capabilities) - supported)
+    if unknown:
+        errors.append(f"unsupported capabilities: {unknown}")
+
+    bad_permissions = sorted(set(manifest.permissions) - SUPPORTED_PERMISSIONS)
+    if bad_permissions:
+        errors.append(f"unsupported permissions: {bad_permissions}")
+
+    for dependency, requirement in sorted(manifest.dependencies.items()):
+        if not _PLUGIN_ID_RE.fullmatch(dependency):
+            errors.append(f"invalid dependency id: {dependency!r}")
+        try:
+            from .semver import satisfies
+
+            satisfies("0.0.0", requirement)
+        except ValueError:
+            errors.append(f"invalid dependency requirement for {dependency}: {requirement!r}")
+
+    try:
+        if not is_manifest_api_compatible(manifest.api_version, provided_api_version):
+            errors.append(
+                f"incompatible API version: plugin declares "
+                f"{manifest.api_version}, engine provides {provided_api_version}"
+            )
+    except ValueError:
+        pass  # already reported as invalid api_version
+
+    return tuple(errors)

--- a/titan_decoder/plugins/registry.py
+++ b/titan_decoder/plugins/registry.py
@@ -1,0 +1,369 @@
+"""Plugin discovery, loading, and registration.
+
+``PluginManager`` supports both plugin styles side by side:
+
+- **Single-file plugins** (API 1.0): a bare ``.py`` file dropped in a plugin
+  directory, discovered exactly as before the SDK existed.
+- **Manifest plugins** (API 1.1): a subdirectory containing
+  ``titan-plugin.json`` plus its entry-point module, validated against the
+  manifest contract, loaded in dependency order.
+
+Failures never abort discovery: a broken plugin is skipped with a logged
+warning and recorded in ``self.errors`` so ``--plugin-list`` can surface it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib.util
+import logging
+from pathlib import Path
+import sys
+from typing import Any
+
+from .contracts import (
+    PLUGIN_API_VERSION,
+    AnalyzerPlugin,
+    DecoderPlugin,
+    DetectionPlugin,
+    PluginAnalyzer,
+    PluginDecoder,
+    ReportPlugin,
+    is_api_compatible,
+)
+from .manifest import PLUGIN_MANIFEST_FILENAME, PluginManifest, validate_manifest
+from .semver import satisfies
+
+logger = logging.getLogger(__name__)
+
+# Rule-ID prefix reserved for built-in detection rules. Plugins may not emit
+# rules under it, so a plugin can never impersonate a built-in detection —
+# the same guarantee rule packs enforce.
+RESERVED_RULE_PREFIX = "TITAN-"
+
+
+@dataclass(frozen=True)
+class LoadedPlugin:
+    """One successfully loaded manifest plugin."""
+
+    manifest: PluginManifest
+    instance: Any
+    path: Path
+
+
+class PluginManager:
+    """Manages loading and registration of plugins."""
+
+    def __init__(self, plugin_dirs: list[Path] | None = None):
+        self.plugin_dirs = plugin_dirs or []
+        self.decoders: list[PluginDecoder] = []
+        self.analyzers: list[PluginAnalyzer] = []
+        self.detections: list[DetectionPlugin] = []
+        self.reports: list[ReportPlugin] = []
+        self.loaded_plugins: dict[str, Any] = {}
+        self.manifest_plugins: dict[str, LoadedPlugin] = {}
+        self.errors: list[dict[str, str]] = []
+
+    def add_plugin_dir(self, plugin_dir: Path):
+        """Add a directory to search for plugins."""
+        plugin_dir = Path(plugin_dir)
+        if plugin_dir not in self.plugin_dirs:
+            self.plugin_dirs.append(plugin_dir)
+
+    def load_plugins(self):
+        """Load all plugins from configured directories."""
+        for plugin_dir in self.plugin_dirs:
+            if plugin_dir.exists() and plugin_dir.is_dir():
+                self._load_plugins_from_dir(plugin_dir)
+        self._load_manifest_plugins()
+
+        # Sort by priority (highest first); name breaks ties so ordering is
+        # deterministic across runs and platforms.
+        def _key(plugin):
+            return (-int(getattr(plugin, "priority", 0)), str(plugin.name))
+
+        self.decoders.sort(key=_key)
+        self.analyzers.sort(key=_key)
+        self.detections.sort(key=_key)
+        self.reports.sort(key=_key)
+
+    # Package-infrastructure modules in the built-in plugin dir that are not
+    # plugins and must not be discovered/loaded as such.
+    _RESERVED_MODULES = frozenset(
+        {
+            "api.py",
+            "contracts.py",
+            "manifest.py",
+            "registry.py",
+            "semver.py",
+            "validation.py",
+        }
+    )
+
+    def _load_plugins_from_dir(self, plugin_dir: Path):
+        """Load single-file plugins from a specific directory."""
+        for item in plugin_dir.iterdir():
+            if (
+                item.is_file()
+                and item.suffix == ".py"
+                and not item.name.startswith("_")
+                and item.name not in self._RESERVED_MODULES
+            ):
+                self._load_plugin_file(item)
+
+    def _load_plugin_file(self, plugin_file: Path):
+        """Load a single-file plugin."""
+        try:
+            # Create module name
+            module_name = f"titan_decoder_plugins_{plugin_file.stem}"
+
+            # Load the module
+            spec = importlib.util.spec_from_file_location(module_name, plugin_file)
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = module
+                spec.loader.exec_module(module)
+
+                # Enforce the versioned API contract: a plugin may declare the
+                # API version it targets; skip it on a breaking (MAJOR) mismatch
+                # rather than loading an incompatible extension.
+                declared = getattr(module, "PLUGIN_API_VERSION", None)
+                if declared is not None and not is_api_compatible(str(declared)):
+                    logger.warning(
+                        "Skipping plugin %s: declares API %s, engine provides %s "
+                        "(incompatible major version)",
+                        plugin_file.name,
+                        declared,
+                        PLUGIN_API_VERSION,
+                    )
+                    return
+
+                # Find plugin classes in the module
+                self._register_plugin_classes(module, plugin_file.stem)
+
+                self.loaded_plugins[plugin_file.stem] = module
+
+        except Exception as e:
+            logger.warning("Failed to load plugin %s: %s", plugin_file, e)
+            self.errors.append({"path": str(plugin_file), "error": str(e)})
+
+    def _register_plugin_classes(self, module, plugin_name: str):
+        """Register plugin classes from a loaded single-file module."""
+        abstract = {
+            PluginDecoder,
+            PluginAnalyzer,
+            DecoderPlugin,
+            AnalyzerPlugin,
+            DetectionPlugin,
+            ReportPlugin,
+        }
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            if not isinstance(attr, type) or attr in abstract:
+                continue
+            try:
+                if issubclass(attr, PluginDecoder):
+                    self.decoders.append(attr())
+                    logger.info("Loaded decoder plugin: %s", self.decoders[-1].name)
+                elif issubclass(attr, PluginAnalyzer):
+                    self.analyzers.append(attr())
+                    logger.info("Loaded analyzer plugin: %s", self.analyzers[-1].name)
+                elif issubclass(attr, DetectionPlugin):
+                    instance = attr()
+                    self._check_rule_ids(instance)
+                    self.detections.append(instance)
+                    logger.info("Loaded detection plugin: %s", instance.name)
+                elif issubclass(attr, ReportPlugin):
+                    self.reports.append(attr())
+                    logger.info("Loaded report plugin: %s", self.reports[-1].name)
+            except Exception as e:
+                logger.warning(
+                    "Failed to instantiate %s from plugin %s: %s",
+                    attr_name,
+                    plugin_name,
+                    e,
+                )
+
+    # --- Manifest plugins -------------------------------------------------
+
+    def _manifest_candidates(self) -> list[Path]:
+        candidates: set[Path] = set()
+        for directory in self.plugin_dirs:
+            directory = Path(directory)
+            if not directory.is_dir():
+                continue
+            if (directory / PLUGIN_MANIFEST_FILENAME).exists():
+                candidates.add(directory)
+            for child in directory.iterdir():
+                if child.is_dir() and (child / PLUGIN_MANIFEST_FILENAME).exists():
+                    candidates.add(child)
+        return sorted(candidates, key=str)
+
+    def _load_manifest_plugins(self) -> None:
+        """Discover and load manifest plugins in dependency order."""
+        manifests: dict[Path, PluginManifest] = {}
+        for path in self._manifest_candidates():
+            try:
+                manifests[path] = PluginManifest.load(path / PLUGIN_MANIFEST_FILENAME)
+            except Exception as exc:
+                logger.warning("Failed to read plugin manifest %s: %s", path, exc)
+                self.errors.append({"path": str(path), "error": str(exc)})
+
+        # Order by dependency edges (Kahn), name-sorted for determinism, so a
+        # plugin can depend on another regardless of directory order. Cyclic
+        # or unresolvable remainders load last and fail their dependency check
+        # with a precise error.
+        by_id = {manifest.plugin_id: path for path, manifest in manifests.items()}
+        ordered: list[Path] = []
+        remaining = dict(manifests)
+        while remaining:
+            ready = [
+                path
+                for path, manifest in remaining.items()
+                if all(
+                    dependency not in by_id or by_id[dependency] not in remaining
+                    for dependency in manifest.dependencies
+                )
+            ]
+            if not ready:
+                ready = list(remaining)  # cycle: load in stable order, fail below
+            for path in sorted(ready, key=str):
+                ordered.append(path)
+                remaining.pop(path)
+
+        for path in ordered:
+            self._load_manifest_plugin(path, manifests[path])
+
+    def _load_manifest_plugin(self, path: Path, manifest: PluginManifest) -> None:
+        try:
+            problems = validate_manifest(manifest)
+            if problems:
+                raise ValueError("; ".join(problems))
+            if manifest.plugin_id in self.manifest_plugins:
+                raise ValueError(f"duplicate plugin id: {manifest.plugin_id}")
+
+            for dependency, requirement in sorted(manifest.dependencies.items()):
+                loaded = self.manifest_plugins.get(dependency)
+                if loaded is None:
+                    raise ValueError(f"missing dependency: {dependency}")
+                if not satisfies(loaded.manifest.version, requirement):
+                    raise ValueError(
+                        f"dependency {dependency} version "
+                        f"{loaded.manifest.version} does not satisfy {requirement!r}"
+                    )
+
+            instance = _instantiate_entry_point(path, manifest)
+
+            registered = False
+            if isinstance(instance, PluginDecoder):
+                self.decoders.append(instance)
+                registered = True
+            if isinstance(instance, PluginAnalyzer):
+                self.analyzers.append(instance)
+                registered = True
+            if isinstance(instance, DetectionPlugin):
+                self._check_rule_ids(instance)
+                self.detections.append(instance)
+                registered = True
+            if isinstance(instance, ReportPlugin):
+                self.reports.append(instance)
+                registered = True
+            if not registered:
+                raise TypeError(
+                    "entry point class implements no supported plugin base class"
+                )
+
+            self.manifest_plugins[manifest.plugin_id] = LoadedPlugin(
+                manifest, instance, path
+            )
+            logger.info(
+                "Loaded manifest plugin: %s %s", manifest.plugin_id, manifest.version
+            )
+        except Exception as exc:
+            logger.warning("Failed to load plugin %s: %s", path, exc)
+            self.errors.append({"path": str(path), "error": str(exc)})
+
+    def _check_rule_ids(self, instance: DetectionPlugin) -> None:
+        """Enforce rule-ID reservations and uniqueness for detection plugins."""
+        rule_ids = [str(rule_id) for rule_id in instance.rule_ids]
+        if not rule_ids:
+            raise ValueError("detection plugin declares no rule_ids")
+        reserved = sorted(
+            rule_id
+            for rule_id in rule_ids
+            if rule_id.upper().startswith(RESERVED_RULE_PREFIX)
+        )
+        if reserved:
+            raise ValueError(
+                f"rule ids use the reserved built-in prefix "
+                f"{RESERVED_RULE_PREFIX!r}: {reserved}"
+            )
+        used = {rid for plugin in self.detections for rid in plugin.rule_ids}
+        duplicates = sorted(used & set(rule_ids))
+        if duplicates:
+            raise ValueError(f"duplicate detection rule ids: {duplicates}")
+
+    # --- Accessors ----------------------------------------------------------
+
+    def get_decoders(self) -> list[PluginDecoder]:
+        """Get all loaded decoder plugins."""
+        return self.decoders.copy()
+
+    def get_analyzers(self) -> list[PluginAnalyzer]:
+        """Get all loaded analyzer plugins."""
+        return self.analyzers.copy()
+
+    def get_detections(self) -> list[DetectionPlugin]:
+        """Get all loaded detection plugins."""
+        return self.detections.copy()
+
+    def get_reports(self) -> list[ReportPlugin]:
+        """Get all loaded report plugins."""
+        return self.reports.copy()
+
+    def get_plugin_info(self) -> dict[str, Any]:
+        """Get information about loaded plugins."""
+        return {
+            "api_version": PLUGIN_API_VERSION,
+            "plugin_dirs": [str(d) for d in self.plugin_dirs],
+            "loaded_plugins": list(self.loaded_plugins.keys()),
+            "manifest_plugins": [
+                loaded.manifest.to_dict()
+                for _, loaded in sorted(self.manifest_plugins.items())
+            ],
+            "decoders": [d.name for d in self.decoders],
+            "analyzers": [a.name for a in self.analyzers],
+            "detections": [d.name for d in self.detections],
+            "reports": [r.name for r in self.reports],
+            "errors": list(self.errors),
+        }
+
+
+def _instantiate_entry_point(plugin_dir: Path, manifest: PluginManifest) -> Any:
+    """Import a manifest plugin's entry-point module and instantiate its class."""
+
+    module_name, class_name = manifest.entry_point.split(":", 1)
+    module_path = plugin_dir / (module_name.replace(".", "/") + ".py")
+    package_path = plugin_dir / module_name.replace(".", "/") / "__init__.py"
+    source = module_path if module_path.exists() else package_path
+    if not source.exists():
+        raise FileNotFoundError(f"entry point module not found: {module_name}")
+
+    unique = "titan_plugin_" + manifest.plugin_id.replace(".", "_").replace("-", "_")
+    spec = importlib.util.spec_from_file_location(unique, source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to create module spec for {source}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[unique] = module
+    spec.loader.exec_module(module)
+
+    target = getattr(module, class_name, None)
+    if target is None:
+        raise AttributeError(f"entry point class not found: {class_name}")
+    if not isinstance(target, type):
+        raise TypeError(f"entry point {class_name} is not a class")
+    return target()
+
+
+# Compatibility alias for callers using the SDK package's name.
+PluginRegistry = PluginManager

--- a/titan_decoder/plugins/semver.py
+++ b/titan_decoder/plugins/semver.py
@@ -1,0 +1,137 @@
+"""Semantic versioning for the plugin SDK.
+
+Implements SemVer 2.0.0 parsing, precedence (including correct pre-release
+ordering: ``1.0.0-alpha < 1.0.0``), API compatibility for manifests, and the
+requirement syntax used by plugin dependency constraints (``^``, ``~``,
+comparator lists, exact versions, and ``*``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import total_ordering
+import re
+from typing import Any
+
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+def _prerelease_key(prerelease: str) -> tuple[Any, ...]:
+    """Precedence key for a pre-release string per SemVer 2.0.0.
+
+    A release (empty pre-release) sorts after every pre-release. Numeric
+    identifiers compare numerically and rank below alphanumeric ones.
+    """
+
+    if not prerelease:
+        return (1,)
+    parts: list[tuple[int, Any]] = []
+    for identifier in prerelease.split("."):
+        if identifier.isdigit():
+            parts.append((0, int(identifier)))
+        else:
+            parts.append((1, identifier))
+    return (0, tuple(parts))
+
+
+@total_ordering
+@dataclass(frozen=True)
+class Version:
+    """Parsed semantic version with correct precedence ordering."""
+
+    major: int
+    minor: int
+    patch: int
+    prerelease: str = ""
+
+    @classmethod
+    def parse(cls, value: "str | Version") -> "Version":
+        if isinstance(value, Version):
+            return value
+        text = str(value).strip()
+        # Accept MAJOR.MINOR shorthand (the legacy PLUGIN_API_VERSION form).
+        if re.fullmatch(r"\d+\.\d+", text):
+            text += ".0"
+        match = _SEMVER_RE.fullmatch(text)
+        if not match:
+            raise ValueError(f"invalid semantic version: {value!r}")
+        return cls(
+            int(match.group(1)),
+            int(match.group(2)),
+            int(match.group(3)),
+            match.group(4) or "",
+        )
+
+    def _key(self) -> tuple[Any, ...]:
+        return (self.major, self.minor, self.patch, _prerelease_key(self.prerelease))
+
+    def __lt__(self, other: "Version") -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._key() < other._key()
+
+    def __str__(self) -> str:
+        base = f"{self.major}.{self.minor}.{self.patch}"
+        return f"{base}-{self.prerelease}" if self.prerelease else base
+
+
+def is_manifest_api_compatible(declared: str, provided: str) -> bool:
+    """API compatibility rule for manifest plugins.
+
+    A plugin is loadable when its declared API has the same MAJOR as the
+    engine's and requires no MINOR features newer than the engine provides.
+    Raises ``ValueError`` for malformed versions (manifest validation
+    surfaces that as a manifest error).
+    """
+
+    declared_version = Version.parse(declared)
+    provided_version = Version.parse(provided)
+    return (
+        declared_version.major == provided_version.major
+        and declared_version.minor <= provided_version.minor
+    )
+
+
+def satisfies(version: "str | Version", requirement: str) -> bool:
+    """Return True if *version* satisfies a dependency *requirement*.
+
+    Supported forms: ``*`` / empty (anything), ``^X.Y.Z`` (compatible within
+    the major), ``~X.Y.Z`` (compatible within the minor), comma-separated
+    comparators (``>=1.0.0,<2.0.0``), and an exact version.
+    """
+
+    value = Version.parse(version)
+    text = requirement.strip()
+    if text in {"", "*"}:
+        return True
+    if text.startswith("^"):
+        floor = Version.parse(text[1:])
+        return floor <= value < Version(floor.major + 1, 0, 0)
+    if text.startswith("~"):
+        floor = Version.parse(text[1:])
+        return floor <= value < Version(floor.major, floor.minor + 1, 0)
+    if "," in text or text.startswith((">", "<", "=")):
+        for clause in text.split(","):
+            clause = clause.strip()
+            operator = next(
+                (op for op in (">=", "<=", "==", ">", "<") if clause.startswith(op)),
+                None,
+            )
+            if operator is None:
+                raise ValueError(f"invalid version requirement clause: {clause!r}")
+            target = Version.parse(clause[len(operator):].strip())
+            satisfied = {
+                ">=": value >= target,
+                "<=": value <= target,
+                "==": value == target,
+                ">": value > target,
+                "<": value < target,
+            }[operator]
+            if not satisfied:
+                return False
+        return True
+    return value == Version.parse(text)

--- a/titan_decoder/plugins/validation.py
+++ b/titan_decoder/plugins/validation.py
@@ -1,0 +1,270 @@
+"""Deep plugin validation for authors and operators.
+
+``validate_plugin`` checks a manifest plugin end to end: manifest contents,
+API compatibility, entry-point loading, capability match, constructor, and —
+via a bounded runtime probe — return types, output limits, artifact naming,
+and execution time. The CLI exposes it as ``--plugin-validate``.
+
+The runtime probe executes plugin code in-process on synthetic input. Only
+validate plugins you would be willing to run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import time
+from typing import Any
+
+from .contracts import (
+    AnalysisArtifact,
+    AnalyzerPlugin,
+    DecodeResult,
+    DecoderPlugin,
+    DetectionFinding,
+    DetectionPlugin,
+    PluginContext,
+    ReportPlugin,
+    ReportSection,
+)
+from .manifest import PLUGIN_MANIFEST_FILENAME, PluginManifest, validate_manifest
+from .registry import RESERVED_RULE_PREFIX, _instantiate_entry_point
+
+_PROBE_INPUT = b"Titan plugin validation probe"
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """One problem (or advisory) found while validating a plugin."""
+
+    level: str
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"level": self.level, "code": self.code, "message": self.message}
+
+
+@dataclass
+class PluginValidationReport:
+    """Aggregated validation outcome for one plugin directory."""
+
+    path: str
+    ok: bool = True
+    manifest: dict[str, Any] | None = None
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    def error(self, code: str, message: str) -> None:
+        self.ok = False
+        self.issues.append(ValidationIssue("error", code, message))
+
+    def warning(self, code: str, message: str) -> None:
+        self.issues.append(ValidationIssue("warning", code, message))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "ok": self.ok,
+            "manifest": self.manifest,
+            "issues": [issue.to_dict() for issue in self.issues],
+        }
+
+
+def _probe_decoder(instance: DecoderPlugin, context: PluginContext, report, limit):
+    can = instance.can_decode(_PROBE_INPUT, context)
+    if not isinstance(can, bool):
+        report.error("decoder.can_decode_type", "can_decode must return bool")
+    result = instance.decode(_PROBE_INPUT, context)
+    if isinstance(result, DecodeResult):
+        output = result.data
+    elif (
+        isinstance(result, tuple)
+        and len(result) == 2
+        and isinstance(result[0], bytes)
+        and isinstance(result[1], bool)
+    ):
+        output = result[0]
+    else:
+        report.error(
+            "decoder.result_type", "decode must return DecodeResult or (bytes, bool)"
+        )
+        return
+    if len(output) > limit:
+        report.error("decoder.output_limit", f"decode output exceeded {limit} bytes")
+
+
+def _probe_analyzer(instance: AnalyzerPlugin, context: PluginContext, report, limit):
+    can = instance.can_analyze(_PROBE_INPUT, context)
+    if not isinstance(can, bool):
+        report.error("analyzer.can_analyze_type", "can_analyze must return bool")
+    artifacts = instance.analyze(_PROBE_INPUT, context)
+    if len(artifacts) > context.max_children:
+        report.error(
+            "analyzer.child_limit",
+            f"analyze produced more than {context.max_children} artifacts",
+        )
+    for item in artifacts:
+        if isinstance(item, AnalysisArtifact):
+            artifact = item
+        elif (
+            isinstance(item, tuple)
+            and len(item) == 2
+            and isinstance(item[0], str)
+            and isinstance(item[1], bytes)
+        ):
+            try:
+                artifact = AnalysisArtifact(item[0], item[1])
+            except (TypeError, ValueError) as exc:
+                report.error("analyzer.artifact_name", str(exc))
+                continue
+        else:
+            report.error(
+                "analyzer.result_type",
+                "analyze must return AnalysisArtifact or (name, bytes) items",
+            )
+            continue
+        if len(artifact.data) > limit:
+            report.error(
+                "analyzer.output_limit", f"artifact exceeded {limit} bytes"
+            )
+
+
+def _probe_detection(instance: DetectionPlugin, context: PluginContext, report):
+    rule_ids = [str(rule_id) for rule_id in instance.rule_ids]
+    if not rule_ids:
+        report.error("detection.rule_ids", "detection plugin declares no rule_ids")
+    reserved = sorted(
+        rule_id
+        for rule_id in rule_ids
+        if rule_id.upper().startswith(RESERVED_RULE_PREFIX)
+    )
+    if reserved:
+        report.error(
+            "detection.reserved_rule_ids",
+            f"rule ids use the reserved built-in prefix: {reserved}",
+        )
+    for finding in instance.detect({}, {}, context):
+        if not isinstance(finding, DetectionFinding):
+            report.error(
+                "detection.result_type", "detect must return DetectionFinding items"
+            )
+        elif finding.rule_id not in rule_ids:
+            report.error(
+                "detection.undeclared_rule",
+                f"finding uses undeclared rule id: {finding.rule_id}",
+            )
+
+
+def _probe_report(instance: ReportPlugin, context: PluginContext, report):
+    for section in instance.build_sections({}, context):
+        if not isinstance(section, ReportSection):
+            report.error(
+                "report.result_type", "build_sections must return ReportSection items"
+            )
+
+
+def validate_plugin(
+    path: str | Path,
+    *,
+    runtime_probe: bool = True,
+    max_probe_seconds: float = 1.0,
+    max_probe_output_bytes: int = 1024 * 1024,
+) -> PluginValidationReport:
+    """Validate one manifest plugin directory (or its manifest file path)."""
+
+    plugin_dir = Path(path)
+    manifest_path = (
+        plugin_dir
+        if plugin_dir.name == PLUGIN_MANIFEST_FILENAME
+        else plugin_dir / PLUGIN_MANIFEST_FILENAME
+    )
+    plugin_dir = manifest_path.parent
+    report = PluginValidationReport(str(plugin_dir))
+
+    if not manifest_path.exists():
+        report.error("manifest.missing", f"missing {PLUGIN_MANIFEST_FILENAME}")
+        return report
+    try:
+        manifest = PluginManifest.load(manifest_path)
+        report.manifest = manifest.to_dict()
+    except Exception as exc:
+        report.error("manifest.invalid", str(exc))
+        return report
+    for problem in validate_manifest(manifest):
+        report.error("manifest.invalid", problem)
+    if not report.ok:
+        return report
+
+    if "network" in manifest.permissions:
+        report.warning(
+            "manifest.network_permission",
+            "plugin declares the network permission; Titan is offline-first "
+            "and permissions are policy metadata, not a sandbox",
+        )
+
+    try:
+        instance = _instantiate_entry_point(plugin_dir, manifest)
+    except Exception as exc:
+        report.error("entry_point.load_failed", str(exc))
+        return report
+
+    capability_bases = {
+        "decoder": DecoderPlugin,
+        "analyzer": AnalyzerPlugin,
+        "detection": DetectionPlugin,
+        "report": ReportPlugin,
+    }
+    implemented = {
+        capability
+        for capability, base in capability_bases.items()
+        if isinstance(instance, base)
+    }
+    missing = sorted(set(manifest.capabilities) - implemented)
+    if missing:
+        report.error(
+            "entry_point.capability_mismatch",
+            f"class does not implement declared capabilities: {missing}",
+        )
+        return report
+    undeclared = sorted(implemented - set(manifest.capabilities))
+    if undeclared:
+        report.warning(
+            "entry_point.undeclared_capability",
+            f"class implements capabilities not declared in the manifest: {undeclared}",
+        )
+
+    if not runtime_probe:
+        return report
+
+    context = PluginContext(
+        offline=True,
+        max_input_bytes=4096,
+        max_output_bytes=max_probe_output_bytes,
+        max_children=10,
+    )
+    start = time.monotonic()
+    try:
+        if isinstance(instance, DecoderPlugin):
+            _probe_decoder(instance, context, report, max_probe_output_bytes)
+        if isinstance(instance, AnalyzerPlugin):
+            _probe_analyzer(instance, context, report, max_probe_output_bytes)
+        if isinstance(instance, DetectionPlugin):
+            _probe_detection(instance, context, report)
+        if isinstance(instance, ReportPlugin):
+            _probe_report(instance, context, report)
+    except Exception as exc:
+        report.error("runtime.exception", f"{type(exc).__name__}: {exc}")
+    elapsed = time.monotonic() - start
+    if elapsed > max_probe_seconds:
+        report.error(
+            "runtime.timeout",
+            f"runtime probe took {elapsed:.3f}s (limit {max_probe_seconds}s)",
+        )
+    return report
+
+
+def validate_plugins(paths) -> tuple[bool, list[dict[str, Any]]]:
+    """Validate several plugin paths; returns (all_ok, reports_as_dicts)."""
+
+    results = [validate_plugin(path).to_dict() for path in paths]
+    return all(result["ok"] for result in results), results


### PR DESCRIPTION
## Summary

Implements Milestone 6 (Plugin SDK v1) by merging the uploaded package's SDK design with the existing plugin system — extending it rather than replacing it — and wiring the previously inert parts into the analysis pipeline.

**The four SDKs** (all behind the stable `titan_decoder.plugins.api` surface): `DecoderPlugin`, `AnalyzerPlugin`, `DetectionPlugin`, and `ReportPlugin`, with typed results (`DecodeResult`, `AnalysisArtifact`, `DetectionFinding`, `ReportSection`) and an optional `PluginContext` carrying the offline stance and resource bounds. Typed decode/analyze results unpack like the legacy tuples, so the engine consumes both plugin styles identically — zero engine changes needed.

**Backward compatible by construction:** single-file plugins (API 1.0) keep loading exactly as before, side by side with manifest plugins; `PLUGIN_API_VERSION` bumps additively to `1.1`, and the pre-existing `tests/test_plugin_api.py` passes unmodified.

**Manifest + semver:** `titan-plugin.json` (JSON Schema in `schemas/titan-plugin-manifest-v1.0.schema.json`) declares identity, versions, entry point, capabilities, permissions (policy metadata, not a sandbox), and dependencies. The semver engine implements correct SemVer 2.0.0 pre-release precedence (`1.0.0-alpha < 1.0.0` — fixed from the package, which sorted it backwards) and dependency requirements (`*`, `^`, `~`, comparator lists, exact). Manifest plugins load in deterministic dependency order (topological, not directory order).

**Pipeline integration (new — the package defined these SDKs but never executed them):**
- Detection plugins run in the detection stage after rule engines and **before risk scoring**, so plugin findings feed the risk assessment like rule matches; findings carry `source: {"type": "plugin"}`.
- Report plugins contribute JSON-serializable sections embedded under `plugin_report_sections` and rendered into Markdown/HTML case reports.
- Bounded output (200 findings / 20 sections per plugin); a failing plugin is skipped with a warning and can never abort an analysis.

**Guardrails:** the `TITAN-` rule prefix is reserved so plugins can't impersonate built-in detections (matching the rule-pack hardening from #110); rule IDs must be declared and unique across plugins; undeclared findings are dropped; duplicate plugin IDs rejected.

**Validation & CLI:** `--plugin-validate` (manifest contract, API compatibility, entry point, capability match, constructor, plus a bounded runtime probe checking return types, output limits, artifact names, declared rule IDs, and execution time), `--plugin-list` (discovery including per-plugin load errors), `--plugin-dir` (repeatable).

**Examples & docs:** one complete example plugin per capability in `examples/plugins/`, and `docs/PLUGIN_API.md` rewritten as a complete developer guide (manifest reference, all four SDKs with code, versioning rules, validation, trust model).

Golden fixtures regenerated for the additive run-manifest plugin-info change (`api_version` 1.0→1.1 plus new empty keys) — reviewed, no analysis output changed.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q                 # 568 passed
ruff check .              # all checks passed
mypy titan_decoder/       # no issues in 68 source files
```

- Notes: 33 new tests — semver (including the SemVer §11 pre-release precedence ladder), manifest field-by-field validation, registry (examples load; single-file + manifest coexistence; dependency ordering independent of directory order; unsatisfied dependencies; reserved/duplicate rule IDs; duplicate plugin IDs), deep validation (malformed manifests, capability mismatch, runtime type errors, undeclared detection rules), and integration (engine loads and *decodes with* an SDK decoder plugin end to end; detection plugins run in the stage and feed risk; a crashing plugin never aborts the stage; report sections render into Markdown/HTML case reports; CLI list/validate modes). Verified end-to-end with the real CLI: a ROT47-encoded sample was decoded by the example decoder plugin, the detection plugin fired and raised risk to MEDIUM, and the report plugin's section appeared in the JSON report and Markdown case report.

## Screenshots / Output (optional)

```
$ titan-decoder --file sample.bin --plugin-dir examples/plugins --enable-detections ...
decoders used: ['ROT47']
plugin detections: [('EXAMPLE-001', 'medium')]
risk: MEDIUM 26
plugin sections: ['example_summary']
case report has plugin section: True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q

---
_Generated by [Claude Code](https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q)_