### PR TITLE
Upgrade the interactive console to a dashboard-style workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+Interactive console upgrade:
+
+- The `titan` command now opens a dashboard-style console
+  (`titan_decoder/ui/`): session/system status panels (profile, network
+  mode, decoder and plugin counts, correlation database state), analysis
+  progress presentation, a concise analysis summary box with elapsed time,
+  a default report-save location (`~/.titan_decoder/reports/`), a
+  read-only Plugin SDK manager view (manifest and single-file plugins with
+  load errors, over the same directory set the engine searches), a saved-
+  reports browser, and expanded settings. Still stdlib-only, line-based
+  numeric navigation, and a pure presentation layer over the engine.
+- `EnhancedInteractiveApp` subclasses the existing `InteractiveApp`, which
+  remains unchanged (and remains the tested core); plugin status on the
+  dashboard is cached per session so menu redraws never re-execute plugin
+  modules.
+
 Plugin SDK v1 (Milestone 6):
 
 - Four plugin SDKs behind the stable `titan_decoder.plugins.api` surface:

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -3,6 +3,7 @@
 ## Users and operators
 
 - [USAGE.md](USAGE.md) — practical walkthroughs.
+- [INTERACTIVE_CONSOLE.md](INTERACTIVE_CONSOLE.md) — the `titan` terminal console.
 - [CLI_REFERENCE.md](CLI_REFERENCE.md) — command groups and examples.
 - [GRAPH_EXPORTS.md](GRAPH_EXPORTS.md) — JSON, DOT, and Mermaid output.
 - [EVIDENCE_AND_PROVENANCE.md](EVIDENCE_AND_PROVENANCE.md) — evidence ingestion and lineage.

--- a/docs/INTERACTIVE_CONSOLE.md
+++ b/docs/INTERACTIVE_CONSOLE.md
@@ -1,0 +1,42 @@
+# Interactive Console
+
+The `titan` command (also `titan-decoder --interactive` or
+`python -m titan_decoder.interactive`) opens a stdlib-only terminal
+application suitable for local shells, SSH, and Codespaces. It is a pure
+presentation layer over the existing engine — it does not duplicate
+decoding, detection, correlation, or plugin logic.
+
+## Screens
+
+- **Dashboard** — session panel (engine version, profile, network mode,
+  aggressive toggle) and system panel (decoder count, plugin count with
+  load-error indicator, correlation database status, reports directory),
+  rendered as responsive side-by-side boxes.
+- **Analyze input** `[1]` — full recursive engine run with progress
+  presentation, a concise analysis summary box (nodes, IOCs, detections,
+  correlation hits, depth), elapsed time, the standard engine summary, and
+  an optional JSON report save (defaults to
+  `~/.titan_decoder/reports/latest.json`; `-` skips).
+- **Decode with one decoder** `[2]` and **Decoder catalog** `[3]` — the
+  existing single-decoder workflow and catalog listing.
+- **Plugin manager** `[4]` — read-only Plugin SDK status over the same
+  directory set the engine searches: manifest plugins with version and
+  capabilities, single-file plugins, and per-plugin load errors.
+- **Reports browser** `[5]` — the 20 most recent saved JSON reports; opening
+  one renders its summary box and engine summary.
+- **Settings** `[6]` — analysis profile (safe/fast/full), network mode
+  (offline/online), aggressive auto-detect toggle, and the session reports
+  directory.
+
+## Behavior notes
+
+- Offline mode (the default) wraps analysis in the network guard, exactly
+  like `--offline` on the CLI.
+- Plugin status shown on the dashboard is cached per session; the plugin
+  manager screen refreshes it. Listing plugins loads their modules — the
+  same trust model as running an analysis with plugins installed.
+- All keyboard interaction is line-based numeric navigation; Ctrl+D or
+  Ctrl+C ends the session cleanly.
+- The classic minimal UI remains available in-process as
+  `titan_decoder.interactive.InteractiveApp`; the enhanced console
+  (`titan_decoder.ui.console.EnhancedInteractiveApp`) subclasses it.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -48,23 +48,28 @@ If you’d rather not memorize flags, just run:
 titan          # or: titan-decoder --interactive   (same thing)
 ```
 
-You get a menu:
+You get a dashboard (session and system status panels) and a menu
+(see [INTERACTIVE_CONSOLE.md](INTERACTIVE_CONSOLE.md) for the full tour):
 
-- **[1] Auto-detect & decode** — paste a payload (or point at a file) and let the
-  full engine recursively decode it and extract IOCs. It prints the decode tree
-  and any indicators found.
-- **[2] Choose a specific decoder** — pick one decoder (Base64, Hex, XOR, ROT13,
+- **[1] Analyze input** — paste a payload (or point at a file) and let the
+  full engine recursively decode it and extract IOCs. It prints a summary
+  box, the decode tree, any indicators found, and offers to save the JSON
+  report (default `~/.titan_decoder/reports/latest.json`).
+- **[2] Decode with one decoder** — pick one decoder (Base64, Hex, XOR, ROT13,
   Gzip, URL, UTF-16, …) and feed it typed text, a hex string, or a file. Good for
   short/simple test strings, which single-decoder mode handles directly.
-- **[3] List available decoders**.
-- **[4] Options** — switch the analysis profile (safe/fast/full), toggle
-  offline/online, and turn on **aggressive auto-detect**.
+- **[3] Decoder catalog** — list available decoders.
+- **[4] Plugin manager** — Plugin SDK status: loaded plugins and load errors.
+- **[5] Reports browser** — reopen recently saved JSON reports.
+- **[6] Settings** — switch the analysis profile (safe/fast/full), toggle
+  offline/online, turn on **aggressive auto-detect**, and set the session
+  reports directory.
 
 After a decode you can **save the output**: single-decoder mode offers to write
 the raw decoded bytes to a file, and auto-detect offers to save the full JSON
 report (the same structure documented below).
 
-**Aggressive auto-detect** (Options → [3]) makes an auto-detect run try harder:
+**Aggressive auto-detect** (Settings → [3]) makes an auto-detect run try harder:
 it enables the opt-in decoders (Base32/UUencode/Quoted-Printable/ASN.1), searches
 deeper, and keeps weaker/shorter decodes. It’s handy for hands-on testing but
 noisier for real triage. It is **session-only** — it never changes the defaults

--- a/tests/test_enhanced_interactive.py
+++ b/tests/test_enhanced_interactive.py
@@ -1,0 +1,178 @@
+"""Tests for the enhanced interactive console (dashboard ``titan`` UI).
+
+Same approach as test_interactive.py: drive the loop with injected
+input/output (no real TTY) and assert observable behavior. The enhanced app
+subclasses InteractiveApp, so base behaviors (payload reading, engine
+config, aggressive toggle semantics) are covered by the existing suite.
+"""
+
+import base64
+import io
+import json
+from pathlib import Path
+
+from titan_decoder.interactive import Style, main as interactive_main
+from titan_decoder.ui.console import EnhancedInteractiveApp
+from titan_decoder.ui.widgets import box, crop, progress_bar, two_column
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples" / "plugins"
+
+
+def _run(script, app=None):
+    it = iter(script)
+
+    def fake_input(prompt=""):
+        return next(it)
+
+    out = io.StringIO()
+    if app is None:
+        app = EnhancedInteractiveApp(input_fn=fake_input, out=out, style=Style(False))
+    else:
+        app.input_fn = fake_input
+        app.out = out
+    rc = app.run()
+    return rc, out.getvalue()
+
+
+def test_dashboard_and_menu():
+    rc, text = _run(["q"])
+    assert rc == 0
+    assert "FORENSIC INTELLIGENCE CONSOLE" in text
+    assert "QUICK ACTIONS" in text
+    assert "SESSION" in text and "SYSTEM" in text
+    assert "Plugin manager" in text
+    assert "Reports browser" in text
+    assert "Session closed." in text
+
+
+def test_exhausted_input_quits_cleanly():
+    # EOF from the input function unwinds via _QuitSignal, not a crash.
+    def eof_input(prompt=""):
+        raise EOFError
+
+    out = io.StringIO()
+    app = EnhancedInteractiveApp(input_fn=eof_input, out=out, style=Style(False))
+    assert app.run() == 0
+    assert "Session closed." in out.getvalue()
+
+
+def test_settings_toggle_aggressive_and_reports_dir(tmp_path):
+    out = io.StringIO()
+    script = iter(["6", "3", "4", str(tmp_path / "reports"), "b", "q"])
+    app = EnhancedInteractiveApp(
+        input_fn=lambda prompt="": next(script), out=out, style=Style(False)
+    )
+    assert app.run() == 0
+    assert "Aggressive auto-detect is now on" in out.getvalue()
+    assert app.aggressive is True
+    assert app.reports_dir == tmp_path / "reports"
+
+
+def test_auto_detect_saves_report(tmp_path):
+    payload = base64.b64encode(b"hello interactive world").decode()
+    out = io.StringIO()
+    script = iter(["1", "1", payload, "", "q"])
+    app = EnhancedInteractiveApp(
+        input_fn=lambda prompt="": next(script), out=out, style=Style(False)
+    )
+    app.reports_dir = tmp_path / "reports"
+    assert app.run() == 0
+    text = out.getvalue()
+    assert "ANALYSIS SUMMARY" in text
+    assert "Saved report" in text
+    saved = json.loads((tmp_path / "reports" / "latest.json").read_text())
+    assert saved["node_count"] >= 2
+
+
+def test_plugin_manager_lists_manifest_plugins():
+    out = io.StringIO()
+    script = iter(["4", "q"])
+    app = EnhancedInteractiveApp(
+        input_fn=lambda prompt="": next(script), out=out, style=Style(False)
+    )
+    app.config.set("plugin_dirs", [str(EXAMPLES)])
+    assert app.run() == 0
+    text = out.getvalue()
+    assert "PLUGIN MANAGER" in text
+    assert "example.rot47" in text
+    assert "decoder" in text
+
+
+def test_reports_browser_opens_saved_report(tmp_path):
+    report = {
+        "meta": {"analysis_id": "browse-test"},
+        "node_count": 1,
+        "nodes": [{"id": 0, "depth": 0}],
+        "iocs": {"urls": ["http://example.test"]},
+        "detections": [],
+    }
+    reports_dir = tmp_path / "reports"
+    reports_dir.mkdir()
+    (reports_dir / "case.json").write_text(json.dumps(report))
+
+    out = io.StringIO()
+    script = iter(["5", "1", "q"])
+    app = EnhancedInteractiveApp(
+        input_fn=lambda prompt="": next(script), out=out, style=Style(False)
+    )
+    app.reports_dir = reports_dir
+    assert app.run() == 0
+    text = out.getvalue()
+    assert "REPORTS BROWSER" in text
+    assert "case.json" in text
+    assert "ANALYSIS SUMMARY" in text
+    assert "IOC count         1" in text
+
+
+def test_reports_browser_handles_missing_dir(tmp_path):
+    out = io.StringIO()
+    script = iter(["5", "q"])
+    app = EnhancedInteractiveApp(
+        input_fn=lambda prompt="": next(script), out=out, style=Style(False)
+    )
+    app.reports_dir = tmp_path / "nonexistent"
+    assert app.run() == 0
+    assert "No reports directory exists yet." in out.getvalue()
+
+
+def test_unknown_option_keeps_loop_alive():
+    rc, text = _run(["9", "q"])
+    assert rc == 0
+    assert "Unknown option" in text
+
+
+def test_decoder_catalog_invalid_selection():
+    rc, text = _run(["2", "99", "q"])
+    assert rc == 0
+    assert "DECODER CATALOG" in text
+    assert "Invalid selection." in text
+
+
+def test_main_entry_point_uses_enhanced_app(monkeypatch):
+    calls = {}
+
+    def fake_run(self):
+        calls["class"] = type(self).__name__
+        return 0
+
+    monkeypatch.setattr(EnhancedInteractiveApp, "run", fake_run)
+    assert interactive_main([]) == 0
+    assert calls["class"] == "EnhancedInteractiveApp"
+
+
+def test_widgets_render_and_bound():
+    rendered = box("TEST", ["alpha", "beta"], 40)
+    lines = rendered.splitlines()
+    assert "TEST" in lines[0] and "alpha" in rendered
+    assert all(len(line) == 40 for line in lines)
+
+    columns = two_column("L", ["one"], "R", ["a", "b", "c"], 80)
+    widths = {len(line) for line in columns.splitlines()}
+    assert widths == {80}
+
+    assert progress_bar(1, 2, 10).count("█") == 5
+    assert progress_bar(5, 2, 10).count("█") == 10  # clamped
+    assert progress_bar(1, 0, 10).count("█") == 0  # zero total
+
+    assert crop("abcdef", 4) == "abc…"
+    assert crop("abc", 4) == "abc"

--- a/titan_decoder/interactive.py
+++ b/titan_decoder/interactive.py
@@ -597,7 +597,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     """Console entry point for the ``titan`` command."""
     # No flags today; accept and ignore argv so `python -m` / wrappers work and
     # there's room to grow (e.g. --no-color) without breaking callers.
-    return InteractiveApp().run()
+    # The enhanced console subclasses InteractiveApp; the base app remains the
+    # stable, tested core the upgrade layers presentation on top of.
+    from .ui.console import EnhancedInteractiveApp
+
+    return EnhancedInteractiveApp().run()
 
 
 if __name__ == "__main__":

--- a/titan_decoder/ui/__init__.py
+++ b/titan_decoder/ui/__init__.py
@@ -1,0 +1,5 @@
+"""Terminal UI package: the enhanced interactive console for ``titan``."""
+
+from .console import EnhancedInteractiveApp
+
+__all__ = ["EnhancedInteractiveApp"]

--- a/titan_decoder/ui/console.py
+++ b/titan_decoder/ui/console.py
@@ -1,0 +1,355 @@
+"""Enhanced interactive console (the ``titan`` command).
+
+A dashboard-style upgrade of :class:`titan_decoder.interactive.InteractiveApp`
+— still stdlib-only, still a pure presentation layer over the existing
+engine, decoders, Plugin SDK, and correlation database. All engine behavior
+(profiles, offline guard, aggressive auto-detect) is inherited from the base
+app; this class only changes what the session looks like and adds read-only
+views (plugin manager, reports browser).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any
+
+from .. import __version__ as TITAN_VERSION
+from ..interactive import (
+    InteractiveApp,
+    _QuitSignal,
+    format_decode_result,
+    format_engine_summary,
+)
+from .widgets import box, progress_bar, terminal_width, two_column
+
+
+class EnhancedInteractiveApp(InteractiveApp):
+    """Dashboard-style interactive console over the standard app."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reports_dir = Path.home() / ".titan_decoder" / "reports"
+        # Plugin *status* is a read-only count for the dashboard. Computing it
+        # loads (executes) plugin modules, so it is cached per session and
+        # refreshed only by the plugin manager view.
+        self._plugin_status_cache: "tuple[int, int] | None" = None
+
+    # -- plugin discovery -----------------------------------------------------
+
+    def _plugin_manager(self):
+        """A PluginManager over the same directory set the engine searches."""
+        from ..plugins import PluginManager
+
+        manager = PluginManager()
+        for plugin_dir in self.config.get("plugin_dirs", []) or []:
+            manager.add_plugin_dir(Path(plugin_dir))
+        manager.add_plugin_dir(Path.home() / ".titan_decoder" / "plugins")
+        manager.add_plugin_dir(Path(__file__).resolve().parents[1] / "plugins")
+        manager.load_plugins()
+        return manager
+
+    def _plugin_status(self) -> "tuple[int, int]":
+        """(plugin_count, error_count), cached for the dashboard."""
+        if self._plugin_status_cache is None:
+            try:
+                manager = self._plugin_manager()
+                count = len(manager.manifest_plugins) + len(manager.loaded_plugins)
+                self._plugin_status_cache = (count, len(manager.errors))
+            except Exception:
+                self._plugin_status_cache = (0, 1)
+        return self._plugin_status_cache
+
+    # -- banner / dashboard ----------------------------------------------------
+
+    def _banner(self) -> None:
+        width = terminal_width()
+        self._print()
+        self._print(self.st.cyan(self.st.bold("  TITAN // FORENSIC INTELLIGENCE CONSOLE")))
+        self._print(self.st.dim(f"  deterministic analysis · v{TITAN_VERSION} · terminal workspace"))
+        self._print("  " + "═" * max(10, width - 4))
+
+    def _dashboard(self) -> None:
+        width = terminal_width() - 4
+        plugins, errors = self._plugin_status()
+        session = [
+            f"Engine      v{TITAN_VERSION}",
+            f"Profile     {self.profile}",
+            f"Network     {'offline' if self.offline else 'online'}",
+            f"Aggressive  {'on' if self.aggressive else 'off'}",
+        ]
+        correlation = Path.home() / ".titan_decoder" / "correlation.sqlite3"
+        system = [
+            f"Decoders     {len(self.registry)}",
+            f"Plugins      {plugins}" + (f" ({errors} errors)" if errors else ""),
+            f"Correlation  {'ready' if correlation.exists() else 'not initialized'}",
+            f"Reports dir  {self.reports_dir}",
+        ]
+        rendered = two_column("SESSION", session, "SYSTEM", system, width)
+        self._print("  " + rendered.replace("\n", "\n  "))
+
+    def _menu(self) -> str:
+        self._print()
+        self._dashboard()
+        self._print()
+        self._print(self.st.bold("  QUICK ACTIONS"))
+        self._print(f"    [1] {self.st.green('Analyze input')}          full recursive engine")
+        self._print("    [2] Decode with one decoder")
+        self._print("    [3] Decoder catalog")
+        self._print("    [4] Plugin manager")
+        self._print("    [5] Reports browser")
+        self._print("    [6] Settings")
+        self._print("    [q] Quit")
+        return self._ask(self.st.cyan("  titan> ")).strip().lower()
+
+    def _activity(self, label: str) -> None:
+        self._print(self.st.dim(f"  {progress_bar(1, 3)} {label}"))
+
+    # -- analysis ---------------------------------------------------------------
+
+    def _summary_box(self, report: "dict[str, Any]") -> str:
+        nodes = report.get("nodes") or []
+        iocs = report.get("iocs") or {}
+        detections = report.get("detections") or []
+        relationships = (report.get("correlation") or {}).get("relationships") or []
+        return box(
+            "ANALYSIS SUMMARY",
+            [
+                f"Nodes             {len(nodes)}",
+                f"IOC count         {sum(len(v) for v in iocs.values() if isinstance(v, list))}",
+                f"Detections        {len(detections)}",
+                f"Correlation hits  {len(relationships)}",
+                f"Maximum depth     {max((int(n.get('depth', 0) or 0) for n in nodes), default=0)}",
+            ],
+            terminal_width() - 4,
+        )
+
+    def action_auto_detect(self) -> None:
+        payload = self._read_payload()
+        if payload is None:
+            return
+        data, _ = payload
+        self._print()
+        mode = " [aggressive]" if self.aggressive else ""
+        self._activity(f"Running recursive decoders and analyzers{mode}")
+        started = time.monotonic()
+        try:
+            if self.offline:
+                from ..core.offline_guard import block_network
+
+                with block_network():
+                    report = self._configured_engine().run_analysis(data)
+            else:
+                report = self._configured_engine().run_analysis(data)
+        except Exception as exc:  # keep the UI alive on engine errors
+            self._print(self.st.red(f"  Analysis failed: {exc}"))
+            return
+        self._print()
+        self._print("  " + self._summary_box(report).replace("\n", "\n  "))
+        self._print(self.st.dim(f"  Completed in {time.monotonic() - started:.2f}s"))
+        self._print()
+        self._print(format_engine_summary(self.st, report))
+        self._print()
+        self._save_report(report)
+
+    def _save_report(self, report: "dict[str, Any]") -> None:
+        default = self.reports_dir / "latest.json"
+        answer = self._ask(
+            f"  Save JSON report [{default}] (Enter=default, -=skip): "
+        ).strip().strip("'\"")
+        if answer == "-":
+            return
+        path = Path(os.path.expanduser(answer)) if answer else default
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+            self._print(self.st.green(f"  Saved report → {path}"))
+        except OSError as exc:
+            self._print(self.st.red(f"  Could not save report: {exc}"))
+
+    # -- decoder catalog ---------------------------------------------------------
+
+    def action_pick_decoder(self) -> None:
+        self._print()
+        self._print(self.st.bold("  DECODER CATALOG"))
+        for index, choice in enumerate(self.registry, 1):
+            self._print(f"    [{index:>2}] {choice.label:<20} {self.st.dim(choice.description)}")
+        self._print("    [b] Back")
+        sel = self._ask(self.st.cyan("  decoder> ")).strip().lower()
+        if sel in {"", "b", "back"}:
+            return
+        if not sel.isdigit() or not 1 <= int(sel) <= len(self.registry):
+            self._print(self.st.red("  Invalid selection."))
+            return
+        choice = self.registry[int(sel) - 1]
+        payload = self._read_payload()
+        if payload is None:
+            return
+        data, source_len = payload
+        self._activity(f"Running {choice.label}")
+        try:
+            decoded, success = choice.factory().decode(data)
+        except Exception as exc:
+            self._print(self.st.red(f"  Decoder raised an error: {exc}"))
+            return
+        self._print()
+        self._print(format_decode_result(self.st, choice.label, source_len, decoded, success))
+        if success and decoded:
+            self._print()
+            self._maybe_save(decoded, "Save decoded output to")
+
+    # -- plugin manager -----------------------------------------------------------
+
+    def action_plugins(self) -> None:
+        self._print()
+        try:
+            manager = self._plugin_manager()
+        except Exception as exc:
+            self._print(self.st.red(f"  Plugin discovery failed: {exc}"))
+            return
+        count = len(manager.manifest_plugins) + len(manager.loaded_plugins)
+        self._plugin_status_cache = (count, len(manager.errors))
+        search = ", ".join(str(p) for p in manager.plugin_dirs)
+        self._print(
+            "  "
+            + box(
+                "PLUGIN MANAGER",
+                [
+                    f"Search path  {search}",
+                    f"Loaded       {count}",
+                    f"Errors       {len(manager.errors)}",
+                ],
+                terminal_width() - 4,
+            ).replace("\n", "\n  ")
+        )
+        for plugin_id, loaded in sorted(manager.manifest_plugins.items()):
+            capabilities = ", ".join(loaded.manifest.capabilities)
+            self._print(
+                f"    {self.st.green('✓')} {plugin_id:<28} "
+                f"v{loaded.manifest.version:<10} {capabilities}"
+            )
+        for name in sorted(manager.loaded_plugins):
+            self._print(f"    {self.st.green('✓')} {name:<28} {self.st.dim('single-file plugin')}")
+        for error in manager.errors:
+            self._print(f"    {self.st.red('✗')} {error['path']}: {error['error']}")
+
+    # -- reports browser ------------------------------------------------------------
+
+    def action_reports(self) -> None:
+        self._print()
+        self._print(self.st.bold("  REPORTS BROWSER"))
+        if not self.reports_dir.exists():
+            self._print(self.st.dim("  No reports directory exists yet."))
+            return
+        reports = sorted(
+            self.reports_dir.glob("*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )[:20]
+        if not reports:
+            self._print(self.st.dim("  No JSON reports found."))
+            return
+        for index, path in enumerate(reports, 1):
+            self._print(f"    [{index}] {path.name}")
+        self._print("    [b] Back")
+        sel = self._ask(self.st.cyan("  report> ")).strip().lower()
+        if sel in {"", "b", "back"}:
+            return
+        if not sel.isdigit() or not 1 <= int(sel) <= len(reports):
+            self._print(self.st.red("  Invalid report selection."))
+            return
+        try:
+            report = json.loads(reports[int(sel) - 1].read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            self._print(self.st.red(f"  Could not open report: {exc}"))
+            return
+        self._print()
+        self._print("  " + self._summary_box(report).replace("\n", "\n  "))
+        self._print()
+        self._print(format_engine_summary(self.st, report))
+
+    # -- settings ----------------------------------------------------------------------
+
+    def action_options(self) -> None:
+        while True:
+            self._print()
+            self._print(
+                "  "
+                + box(
+                    "SETTINGS",
+                    [
+                        f"[1] Analysis profile      {self.profile}",
+                        f"[2] Network mode          {'offline' if self.offline else 'online'}",
+                        f"[3] Aggressive detection  {'on' if self.aggressive else 'off'}",
+                        f"[4] Reports directory     {self.reports_dir}",
+                        "[b] Back",
+                    ],
+                    terminal_width() - 4,
+                ).replace("\n", "\n  ")
+            )
+            sel = self._ask(self.st.cyan("  settings> ")).strip().lower()
+            if sel in {"", "b", "back"}:
+                return
+            if sel == "1":
+                value = self._ask("  Profile (safe/fast/full): ").strip().lower()
+                if value in {"safe", "fast", "full"}:
+                    self.profile = value
+                else:
+                    self._print(self.st.red("  Unknown profile."))
+            elif sel == "2":
+                value = self._ask("  Network (offline/online): ").strip().lower()
+                if value in {"offline", "off"}:
+                    self.offline = True
+                elif value in {"online", "on"}:
+                    self.offline = False
+                else:
+                    self._print(self.st.red("  Unknown network mode."))
+            elif sel == "3":
+                # Simple toggle, same semantics as the base app: aggressive
+                # only affects auto-detect and is fully session-scoped.
+                self.aggressive = not self.aggressive
+                state = "on" if self.aggressive else "off"
+                self._print(self.st.green(f"  Aggressive auto-detect is now {state}."))
+                if self.aggressive:
+                    self._print(
+                        self.st.dim(
+                            "  Heads-up: expect more (and weaker) results — good for "
+                            "hands-on testing, noisier for real triage."
+                        )
+                    )
+            elif sel == "4":
+                value = self._ask("  Reports directory: ").strip()
+                if value:
+                    self.reports_dir = Path(os.path.expanduser(value))
+            else:
+                self._print(self.st.red("  Unknown setting."))
+
+    # -- main loop -----------------------------------------------------------------------
+
+    def run(self) -> int:
+        self._banner()
+        try:
+            while True:
+                choice = self._menu()
+                if choice in {"q", "quit", "exit"}:
+                    break
+                if choice == "1":
+                    self.action_auto_detect()
+                elif choice == "2":
+                    self.action_pick_decoder()
+                elif choice == "3":
+                    self.action_list_decoders()
+                elif choice == "4":
+                    self.action_plugins()
+                elif choice == "5":
+                    self.action_reports()
+                elif choice == "6":
+                    self.action_options()
+                elif choice:
+                    self._print(self.st.red("  Unknown option — choose 1 through 6, or q."))
+        except (_QuitSignal, KeyboardInterrupt):
+            self._print()
+        self._print(self.st.dim("  Session closed."))
+        return 0

--- a/titan_decoder/ui/widgets.py
+++ b/titan_decoder/ui/widgets.py
@@ -1,0 +1,59 @@
+"""Small stdlib-only terminal widgets for the interactive console.
+
+Pure text rendering — no cursor control, no external dependencies — so the
+console keeps working over SSH, in Codespaces, and in scripted tests.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import Sequence
+
+
+def terminal_width(default: int = 88) -> int:
+    """Usable terminal width, clamped so layouts stay readable."""
+    return max(68, min(120, shutil.get_terminal_size((default, 24)).columns))
+
+
+def crop(text: object, width: int) -> str:
+    """Crop *text* to *width* columns, marking truncation with an ellipsis."""
+    text = str(text)
+    if len(text) <= width:
+        return text
+    return text[: max(0, width - 1)] + "…"
+
+
+def box(title: str, lines: Sequence[str], width: int = 88) -> str:
+    """Render a single-line-border box with a title and content lines."""
+    width = max(30, width)
+    inner = width - 4
+    label = f" {crop(title, inner - 2)} "
+    out = ["┌" + label + "─" * max(0, width - len(label) - 2) + "┐"]
+    out += ["│ " + crop(line, inner).ljust(inner) + " │" for line in lines]
+    out += ["└" + "─" * (width - 2) + "┘"]
+    return "\n".join(out)
+
+
+def two_column(
+    left_title: str,
+    left_lines: Sequence[str],
+    right_title: str,
+    right_lines: Sequence[str],
+    width: int = 88,
+    gap: int = 2,
+) -> str:
+    """Render two boxes side by side, padded to equal height."""
+    half = (width - gap) // 2
+    left = box(left_title, left_lines, half).splitlines()
+    right = box(right_title, right_lines, width - gap - half).splitlines()
+    height = max(len(left), len(right))
+    left += [" " * half] * (height - len(left))
+    right += [" " * (width - gap - half)] * (height - len(right))
+    return "\n".join(a + " " * gap + b for a, b in zip(left, right))
+
+
+def progress_bar(value: float, total: float, width: int = 24) -> str:
+    """Render a fixed-width progress bar; out-of-range values are clamped."""
+    ratio = 0.0 if total <= 0 else max(0.0, min(1.0, value / total))
+    used = round(ratio * width)
+    return "[" + "█" * used + "·" * (width - used) + "]"


### PR DESCRIPTION
## Summary

Integrates the interactive UI upgrade package as a new `titan_decoder/ui/` package. `EnhancedInteractiveApp` subclasses the existing `InteractiveApp` — which stays byte-for-byte the tested core (its test suite passes unmodified) — and remains stdlib-only, line-based, and a pure presentation layer over the engine.

**What the `titan` command now shows:**
- **Dashboard home screen** — SESSION panel (engine version, profile, network mode, aggressive toggle) and SYSTEM panel (decoder count, plugin count with load-error indicator, correlation DB status, reports directory) in responsive side-by-side boxes.
- **Analyze input** — progress presentation, an analysis summary box (nodes, IOCs, detections, correlation hits, max depth), elapsed time, and a default report-save location (`~/.titan_decoder/reports/latest.json`, `-` to skip).
- **Plugin manager** — read-only Plugin SDK status over the same directory set the engine searches: manifest plugins with version/capabilities, single-file plugins, and per-plugin load errors.
- **Reports browser** — reopen the 20 most recent saved JSON reports with summary + engine summary.
- **Settings** — profile, network mode, aggressive toggle (base-app semantics and warnings preserved), session reports directory.

**Fixes made while adapting the package** (it was written against APIs that don't exist here):
- Plugin views now use the Milestone 6 `PluginManager` over the engine's real search-directory set — the package called `PluginRegistry.discover()` and `registry.plugins`, neither of which exist, so its plugin screens would have shown "Plugin SDK not installed" forever.
- `run()` catches `_QuitSignal`, so Ctrl+D exits the session cleanly instead of crashing (the package only caught `EOFError`/`StopIteration`, but the base app's `_ask` translates EOF into `_QuitSignal`).
- Plugin status on the dashboard is cached per session — the package re-discovered (and therefore re-executed) every plugin module on each menu redraw.

Docs: new `docs/INTERACTIVE_CONSOLE.md`, USAGE.md menu walkthrough updated to the new layout, documentation index entry, changelog.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not.
- [x] I updated docs if flags/output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q                 # 579 passed
ruff check .              # all checks passed
mypy titan_decoder/       # no issues in 71 source files
```

- Notes: 11 new tests drive the console with injected I/O — dashboard/menu rendering, clean EOF exit, settings (aggressive toggle + reports directory), a full analyze-and-save flow against the real engine, the plugin manager listing the example manifest plugins, the reports browser (open a saved report; missing directory), invalid selections keeping the loop alive, the `main()` entry point using the enhanced app, and widget rendering bounds (fixed box widths, clamped progress bar, crop). Also verified by driving the real `python -m titan_decoder.interactive` with piped input under an isolated `$HOME`: dashboard rendered, an offline analysis decoded Base64 and extracted IOCs, the report saved to `~/.titan_decoder/reports/latest.json`, and the reports browser listed it back.

## Screenshots / Output (optional)

```
  TITAN // FORENSIC INTELLIGENCE CONSOLE
  deterministic analysis · v2.0.2 · terminal workspace
  ══════════════════════════════════════════════════════════════════
  ┌ SESSION ──────────────────────┐  ┌ SYSTEM ───────────────────────┐
  │ Engine      v2.0.2            │  │ Decoders     21               │
  │ Profile     fast              │  │ Plugins      0                │
  │ Network     offline           │  │ Correlation  not initialized  │
  │ Aggressive  off               │  │ Reports dir  ~/.titan_decoder…│
  └───────────────────────────────┘  └───────────────────────────────┘
  QUICK ACTIONS
    [1] Analyze input          full recursive engine
    ...
  ┌ ANALYSIS SUMMARY ─────────────────────────────┐
  │ Nodes             2                           │
  │ IOC count         2                           │
  ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q

---
_Generated by [Claude Code](https://claude.ai/code/session_012ec9qbLcoXw1kJrres4y7q)_