### PR TITLE
Add project charter to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ See [docs/TESTING.md](docs/TESTING.md) and [CONTRIBUTING.md](CONTRIBUTING.md).
 | Document | Purpose |
 |---|---|
 | [Documentation index](docs/DOCUMENTATION_INDEX.md) | Complete operator, developer, and maintainer map |
+| [Project charter](docs/PROJECT_CHARTER.md) | Mission, core principles, scope, and governance |
 | [Architecture](docs/ARCHITECTURE.md) | Components, boundaries, and system diagrams |
 | [CLI reference](docs/CLI_REFERENCE.md) | Command groups, outputs, and examples |
 | [Pipelines](docs/PIPELINES.md) | End-to-end execution, decoder engine, and analyzer pipeline |

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -26,5 +26,6 @@
 
 ## Maintainers
 
+- [PROJECT_CHARTER.md](PROJECT_CHARTER.md) — mission, core principles, scope, and governance.
 - [ROADMAP.md](ROADMAP.md) — shipped and planned work.
 - [RELEASING.md](RELEASING.md) — release process.

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -1,0 +1,137 @@
+# Titan Project Charter
+
+## Executive Summary
+
+Titan is an offline-first, deterministic forensic decoding engine that
+transforms digital evidence into trustworthy forensic intelligence while
+preserving transparency, provenance, reproducibility, analyst control,
+and privacy.
+
+## Mission
+
+Build an open, evidence-first forensic platform that enables
+investigators to understand malicious artifacts without relying on
+opaque cloud services or unsupported AI conclusions.
+
+## Vision
+
+Titan will evolve into a comprehensive forensic intelligence platform
+while remaining rooted in deterministic decoding. Every future
+capability — correlation, investigation memory, local AI, endpoint
+response, and reporting — must strengthen the decoder rather than
+replace it.
+
+## Core Principles
+
+- Offline by Design
+- Decoder First
+- Evidence First
+- Deterministic by Design
+- AI Explains, Never Invents
+- Defensive by Design
+- Analyst in Control
+- Transparent & Auditable
+- Privacy Respecting
+- Community Driven
+
+## Project Scope
+
+### Titan Is
+
+- A forensic decoding engine.
+- A forensic intelligence platform.
+- A defensive incident-response assistant.
+- A local-first investigation platform.
+- An extensible platform through plugins.
+
+### Titan Is Not
+
+- An offensive security framework.
+- A malware creation platform.
+- A hack-back tool.
+- A surveillance platform.
+- A cloud-dependent AI product.
+
+## Product Editions
+
+### Guided
+
+Home users, small businesses, and IT staff.
+
+### Analyst
+
+SOC analysts, incident responders, consultants, threat hunters, and law
+enforcement.
+
+### Expert
+
+Malware researchers, DFIR laboratories, reverse engineers, and plugin
+developers.
+
+## High-Level Architecture
+
+Evidence Collection → Decoder Pipeline → Analysis → Detection →
+Correlation → Investigation Memory → Local AI Analyst → Reporting &
+Response
+
+The decoder pipeline is the foundation. Every subsystem consumes
+structured decoded evidence.
+
+## Roadmap Themes
+
+- Strengthen the decoder ecosystem.
+- Build investigation memory.
+- Expand endpoint response.
+- Preserve offline-first operation.
+- Grow the plugin ecosystem.
+- Support Guided, Analyst, and Expert editions.
+- Build a trusted open-source community.
+
+## Licensing Philosophy
+
+Titan uses the GNU General Public License v3 (GPLv3) — see
+[LICENSE](../LICENSE).
+
+The choice reflects the project's commitment to:
+
+- Transparency
+- Community collaboration
+- Auditable software
+- Long-term openness
+- Ensuring distributed improvements remain available under GPL
+
+## Governance
+
+Major architectural decisions should reinforce Titan's guiding
+principles. Features that conflict with the project's philosophy should
+be reconsidered before implementation.
+
+## Success Criteria
+
+Titan succeeds when it:
+
+- Preserves forensic integrity.
+- Produces deterministic, reproducible analysis.
+- Keeps evidence under the investigator's control.
+- Provides grounded AI explanations.
+- Maintains the decoder as the heart of the platform.
+- Helps investigators understand incidents rather than merely detect them.
+
+## Non-Negotiable Design Principles
+
+Titan shall never:
+
+- Upload evidence automatically.
+- Require cloud services.
+- Require remote AI.
+- Invent forensic evidence.
+- Modify evidence without preserving provenance.
+- Become an offensive security platform.
+
+## Long-Term Vision
+
+Titan will become an offline-first, deterministic forensic decoding
+engine that transforms decoded evidence into forensic intelligence,
+institutional investigation memory, grounded local AI explanations, and
+defensive incident response while preserving transparency,
+reproducibility, analyst control, and privacy.


### PR DESCRIPTION
## Summary

Adds the Titan Project Charter to the repository so contributors can see the project's mission, principles, and governance before proposing changes:

- `docs/PROJECT_CHARTER.md` — mission, vision, core principles, scope (what Titan is and is not), product editions, high-level architecture, roadmap themes, licensing philosophy, governance, success criteria, non-negotiable design principles, and long-term vision.
- `docs/DOCUMENTATION_INDEX.md` — linked from the Maintainers section.
- `README.md` — added to the documentation map.

Formatting notes: cleaned up list/em-dash conversion artifacts from the source document without changing the wording, with one exception — the licensing section now says Titan "uses" GPLv3 (linking to `LICENSE`) rather than "is intended to use," since the relicense landed in #118.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not — docs-only change; no code paths affected.
- [x] I updated docs if flags/output contracts changed — this PR is itself documentation; no flags or output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior — docs only.

## Testing

- Command(s) run:

```bash
# none — documentation-only change
```

- Notes: verified the relative links (charter → `../LICENSE`, index and README → charter) resolve within the repo.

## Screenshots / Output (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYARA9T6rpaJvyurgYJcLP

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYARA9T6rpaJvyurgYJcLP)_