### PR TITLE
Change license from GPL-3.0-or-later to AGPL-3.0-or-later

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,17 +7,15 @@
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+software for all its users.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -26,44 +24,34 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -72,7 +60,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -549,35 +537,45 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -635,40 +633,29 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Affero General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
+For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Tests](https://github.com/pragmaconflux/titan1/actions/workflows/tests.yml/badge.svg)](https://github.com/pragmaconflux/titan1/actions/workflows/tests.yml)
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue)](pyproject.toml)
-[![License](https://img.shields.io/badge/License-GPLv3-green)](LICENSE)
+[![License](https://img.shields.io/badge/License-AGPLv3-green)](LICENSE)
 
 Titan Decoder Engine is a dependency-light Python framework for analyzing encoded, compressed, archived, and structured payloads. It builds a bounded transformation graph, records provenance for every artifact, extracts indicators, evaluates detections, computes risk, and produces deterministic Intelligence summaries for analysts.
 
@@ -313,4 +313,4 @@ Titan is under active development. The deterministic core, report contracts, and
 
 ## License
 
-GNU General Public License v3.0 or later (GPL-3.0-or-later). See [LICENSE](LICENSE).
+GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later). See [LICENSE](LICENSE).

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -89,7 +89,7 @@ structured decoded evidence.
 
 ## Licensing Philosophy
 
-Titan uses the GNU General Public License v3 (GPLv3) — see
+Titan uses the GNU Affero General Public License v3 (AGPLv3) — see
 [LICENSE](../LICENSE).
 
 The choice reflects the project's commitment to:
@@ -98,7 +98,8 @@ The choice reflects the project's commitment to:
 - Community collaboration
 - Auditable software
 - Long-term openness
-- Ensuring distributed improvements remain available under GPL
+- Ensuring distributed improvements remain available under the same
+  license, including when Titan is offered as a network service
 
 ## Governance
 

--- a/docs/sbom.cdx.json
+++ b/docs/sbom.cdx.json
@@ -65,7 +65,7 @@
       "licenses": [
         {
           "license": {
-            "id": "GPL-3.0-or-later"
+            "id": "AGPL-3.0-or-later"
           }
         }
       ],

--- a/examples/plugins/marker_detection/titan-plugin.json
+++ b/examples/plugins/marker_detection/titan-plugin.json
@@ -8,7 +8,7 @@
   "capabilities": ["detection"],
   "description": "Example detection plugin: flags a synthetic marker string in decoded nodes.",
   "author": "Titan examples",
-  "license": "GPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later",
   "permissions": [],
   "dependencies": {}
 }

--- a/examples/plugins/rot47_decoder/titan-plugin.json
+++ b/examples/plugins/rot47_decoder/titan-plugin.json
@@ -8,7 +8,7 @@
   "capabilities": ["decoder"],
   "description": "Example decoder plugin: reverses ROT47-obfuscated printable ASCII.",
   "author": "Titan examples",
-  "license": "GPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later",
   "permissions": [],
   "dependencies": {}
 }

--- a/examples/plugins/string_analyzer/titan-plugin.json
+++ b/examples/plugins/string_analyzer/titan-plugin.json
@@ -8,7 +8,7 @@
   "capabilities": ["analyzer"],
   "description": "Example analyzer plugin: extracts printable ASCII strings as an artifact.",
   "author": "Titan examples",
-  "license": "GPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later",
   "permissions": [],
   "dependencies": {}
 }

--- a/examples/plugins/summary_report/titan-plugin.json
+++ b/examples/plugins/summary_report/titan-plugin.json
@@ -8,7 +8,7 @@
   "capabilities": ["report"],
   "description": "Example report plugin: contributes a summary section to case reports.",
   "author": "Titan examples",
-  "license": "GPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later",
   "permissions": [],
   "dependencies": {}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "titan-decoder"
 dynamic = ["version"]
 description = "Deterministic payload decoding and analysis engine — recursive decoding, forensic provenance, IOC extraction, detections, and analyst-oriented intelligence"
 readme = "README.md"
-license = "GPL-3.0-or-later"
+license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
 authors = [
     { name = "PragmaConflux", email = "pragmaconflux@users.noreply.github.com" },

--- a/tools/gen_sbom.py
+++ b/tools/gen_sbom.py
@@ -70,7 +70,7 @@ def build_sbom(deterministic: bool = True) -> dict:
             "name": "titan-decoder",
             "version": __version__,
             "description": "Advanced payload decoding and analysis engine",
-            "licenses": [{"license": {"id": "GPL-3.0-or-later"}}],
+            "licenses": [{"license": {"id": "AGPL-3.0-or-later"}}],
             "purl": _purl("titan-decoder", __version__),
         },
         "tools": [{"name": "gen_sbom.py", "vendor": "PragmaConflux"}],


### PR DESCRIPTION
## Summary

Relicenses the project from GPL-3.0-or-later to AGPL-3.0-or-later, extending copyleft to cover network use (users interacting with Titan over a network must be offered the source):

- `LICENSE` — replaced with the complete official GNU AGPL v3 text from gnu.org (verified against the canonical version).
- `pyproject.toml` — `license = "AGPL-3.0-or-later"`.
- `README.md` — updated the license badge and the License section.
- `docs/PROJECT_CHARTER.md` — Licensing Philosophy section now names AGPLv3 and notes the network-service copyleft guarantee.
- `tools/gen_sbom.py` and `docs/sbom.cdx.json` — SBOM generator emits `AGPL-3.0-or-later`; committed SBOM regenerated.
- `examples/plugins/*/titan-plugin.json` — the four bundled example plugin manifests updated.

As with #118, the `-or-later` variant is used; the example manifest in `docs/PLUGIN_API.md` (a third-party plugin author's own license field) is intentionally untouched.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not — ran the SBOM-related suite (`tests/test_supply_chain.py`); no runtime code paths change beyond the SBOM generator.
- [x] I updated docs if flags/output contracts changed — README and project charter updated; no flags or output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior — no dependencies added; SBOM regeneration remains deterministic.

## Testing

- Command(s) run:

```bash
python tools/gen_sbom.py
python -m pytest tests/test_supply_chain.py -q
```

- Notes: all 4 supply-chain tests pass; a repo-wide sweep confirms no plain-GPL references remain.

## Screenshots / Output (optional)

```
Wrote CycloneDX SBOM (7 components) to docs/sbom.cdx.json
....                                                                     [100%]
4 passed in 0.03s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYARA9T6rpaJvyurgYJcLP

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYARA9T6rpaJvyurgYJcLP)_