### PR TITLE
Update PLUGIN_API.md example manifest license to AGPL-3.0-or-later

### DIFF
--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -53,7 +53,7 @@ Each manifest plugin directory contains `titan-plugin.json`
   "capabilities": ["decoder"],
   "description": "Reverses ROT47-obfuscated printable ASCII.",
   "author": "You",
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "permissions": [],
   "dependencies": {}
 }


### PR DESCRIPTION
## Summary

Updates the sample `titan-plugin.json` manifest in `docs/PLUGIN_API.md` to declare `"license": "AGPL-3.0-or-later"` instead of `"MIT"`, aligning the last remaining license reference in the repo with the project's AGPL relicense (#120). This example was previously left as-is intentionally (it depicts a third-party plugin author's own license), but is now updated at the maintainer's request so all in-repo license references read AGPL.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) or explain why not — docs-only, one-word change in an example manifest; no code paths affected.
- [x] I updated docs if flags/output contracts changed — this PR is itself a docs change; no flags or output contracts changed.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior — docs only.

## Testing

- Command(s) run:

```bash
# none — documentation-only change
```

- Notes: a repo-wide sweep confirms no non-AGPL license references remain.

## Screenshots / Output (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQRtJ7ZsSb6W8kaPLgAy6b

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQRtJ7ZsSb6W8kaPLgAy6b)_