### PR TITLE
Harden HTML-entity, UU, and URL decoders against edge-case payloads

### DIFF
--- a/tests/test_decoder_dos.py
+++ b/tests/test_decoder_dos.py
@@ -4,8 +4,11 @@ from titan_decoder.decoders.base import HTMLEntityDecoder, URLDecoder
 
 
 def test_url_decoder_correctness():
+    # '+' stays literal outside a form-encoded context (no '?' query, no
+    # k=v&k=v body) so literal plus signs -- e.g. in embedded base64 -- are
+    # not corrupted.
     out, ok = URLDecoder().decode(b"%41%42%43 http%3A%2F%2Fevil.com a+b")
-    assert ok and out == b"ABC http://evil.com a b"
+    assert ok and out == b"ABC http://evil.com a+b"
 
 
 def test_html_entity_decoder_correctness():

--- a/tests/test_engine_hardening_fixes.py
+++ b/tests/test_engine_hardening_fixes.py
@@ -173,6 +173,25 @@ def test_html_entity_surrogate_does_not_void_decode():
     assert out == b"&#55296; ping & A &#xDFFF;"
 
 
+def test_url_decoder_plus_only_in_form_context():
+    # '+' is a space only in form-encoded contexts (a URL's query component or
+    # a bare k=v&k=v body). Converting it everywhere corrupted literal '+' --
+    # notably base64 embedded in percent-encoded payloads, where each converted
+    # '+' broke the next decode layer.
+    from titan_decoder.decoders.base import URLDecoder
+
+    dec = URLDecoder()
+    # '+' in the path stays literal; '+' in the query becomes a space.
+    out, ok = dec.decode(b"http://x/a+b/c%2Ed?q=hello+world&r=1")
+    assert ok and out == b"http://x/a+b/c.d?q=hello world&r=1"
+    # Percent-encoded base64: '+' must survive for the next decode layer.
+    out, ok = dec.decode(b"c2VjcmV0K3BhcnQ%3D")
+    assert ok and out == b"c2VjcmV0K3BhcnQ="
+    # Bare form-encoded body: '+' is a space.
+    out, ok = dec.decode(b"cmd=whoami+/all&dst=evil%2Ecom")
+    assert ok and out == b"cmd=whoami /all&dst=evil.com"
+
+
 def test_gzip_stream_with_percent_bytes_not_hijacked():
     import gzip as _gzip
     import json as _json

--- a/tests/test_engine_hardening_fixes.py
+++ b/tests/test_engine_hardening_fixes.py
@@ -159,6 +159,20 @@ def test_text_transform_decoders_do_not_fire_on_binary():
     assert ok and out == b"hi there"
 
 
+def test_html_entity_surrogate_does_not_void_decode():
+    # A numeric entity in the UTF-16 surrogate range (&#55296; = U+D800)
+    # produced a lone surrogate that chr() accepts but UTF-8 cannot encode;
+    # the blanket except then failed the whole decode, so one crafted entity
+    # disabled entity decoding for the entire payload. Surrogate entities must
+    # stay literal while the surrounding entities still decode.
+    from titan_decoder.decoders.base import HTMLEntityDecoder
+
+    dec = HTMLEntityDecoder()
+    out, ok = dec.decode(b"&#55296; ping &amp; &#x41; &#xDFFF;")
+    assert ok
+    assert out == b"&#55296; ping & A &#xDFFF;"
+
+
 def test_gzip_stream_with_percent_bytes_not_hijacked():
     import gzip as _gzip
     import json as _json

--- a/tests/test_uu_decoder.py
+++ b/tests/test_uu_decoder.py
@@ -53,3 +53,17 @@ def test_uudecode_graceful_on_garbage():
 
 def test_uudecode_disabled_by_default():
     assert UUDecoder().can_decode(_uuencode(b"x" * 20)) is False
+
+
+def test_uudecode_corrupt_line_keeps_rest():
+    # A single corrupt data line used to abort the whole decode (the retry's
+    # exception escaped to the blanket handler), discarding every line already
+    # recovered. Corrupt lines must be skipped, keeping the rest.
+    dec = UUDecoder(enabled=True)
+    payload = b"A" * 45 + b"B" * 45 + b"C" * 45
+    data = _uuencode(payload)
+    lines = data.split(b"\n")
+    lines[2] = b"\x7f!!! not a valid uu line !!!"  # clobber the middle data line
+    out, ok = dec.decode(b"\n".join(lines))
+    assert ok is True
+    assert out == b"A" * 45 + b"C" * 45

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -1147,6 +1147,7 @@ class URLDecoder(Decoder):
             # only past the first '?', or throughout a bare k=v&k=v body
             # ('&' never occurs in base64, so that shape is a safe signal).
             qpos = text.find("?")
+            plus_from: int | None
             if qpos != -1:
                 plus_from = qpos
             elif "=" in text and "&" in text:
@@ -1238,8 +1239,8 @@ class HTMLEntityDecoder(Decoder):
                         return chr(code)
                     except (ValueError, OverflowError):
                         return m.group(0)
-                code = self._NAMED.get(name.lower())
-                return chr(code) if code is not None else m.group(0)
+                named = self._NAMED.get(name.lower())
+                return chr(named) if named is not None else m.group(0)
 
             decoded = self._ENTITY_RE.sub(_sub, text).encode("utf-8")
             return decoded, decoded != data

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -1194,15 +1194,26 @@ class HTMLEntityDecoder(Decoder):
             # text[i:] and re-ran the regex for every character (O(n^2)), which
             # hangs on entity-heavy payloads.
             def _sub(m: "re.Match") -> str:
+                # Numeric entities in the UTF-16 surrogate range (U+D800..DFFF)
+                # are kept literal: chr() accepts them but the resulting lone
+                # surrogate cannot be UTF-8-encoded, so one crafted entity
+                # (e.g. &#55296;) would make encode() raise and void the whole
+                # decode. Same handling as UnicodeEscapeDecoder.
                 dec, hexv, name = m.group(1), m.group(2), m.group(3)
                 if dec is not None:
                     try:
-                        return chr(int(dec))
+                        code = int(dec)
+                        if 0xD800 <= code <= 0xDFFF:
+                            return m.group(0)
+                        return chr(code)
                     except (ValueError, OverflowError):
                         return m.group(0)
                 if hexv is not None:
                     try:
-                        return chr(int(hexv, 16))
+                        code = int(hexv, 16)
+                        if 0xD800 <= code <= 0xDFFF:
+                            return m.group(0)
+                        return chr(code)
                     except (ValueError, OverflowError):
                         return m.group(0)
                 code = self._NAMED.get(name.lower())

--- a/titan_decoder/decoders/base.py
+++ b/titan_decoder/decoders/base.py
@@ -918,8 +918,16 @@ class UUDecoder(Decoder):
                     # Some encoders strip trailing whitespace; recompute the
                     # expected line length (length char + data chars, same
                     # formula as CPython's uu module) and retry on that slice.
-                    nchars = (((line[0] - 32) & 0x3F) * 4 + 5) // 3
-                    out += binascii.a2b_uu(line[:nchars])
+                    try:
+                        nchars = (((line[0] - 32) & 0x3F) * 4 + 5) // 3
+                        out += binascii.a2b_uu(line[:nchars])
+                    except binascii.Error:
+                        # Truly corrupt line. Skip it and keep decoding:
+                        # aborting here used to discard every line already
+                        # recovered, so one flipped byte mid-file lost the
+                        # whole artifact. Best-effort recovery of the
+                        # remaining lines is what triage needs.
+                        continue
 
             decoded = bytes(out)
             if decoded:
@@ -1131,6 +1139,20 @@ class URLDecoder(Decoder):
     def decode(self, data: bytes) -> Tuple[bytes, bool]:
         try:
             text = data.decode("utf-8")
+            # '+' means space only in the application/x-www-form-urlencoded
+            # context: a URL's query component, or a bare form-encoded body.
+            # Converting it everywhere corrupted '+' that is literal data --
+            # most damagingly base64 embedded in percent-encoded payloads,
+            # where each converted '+' broke the next decode layer. Convert
+            # only past the first '?', or throughout a bare k=v&k=v body
+            # ('&' never occurs in base64, so that shape is a safe signal).
+            qpos = text.find("?")
+            if qpos != -1:
+                plus_from = qpos
+            elif "=" in text and "&" in text:
+                plus_from = -1
+            else:
+                plus_from = None
             # Use a bytearray: byte concatenation in a loop (result += ...) is
             # O(n^2) and hangs on percent-heavy payloads.
             result = bytearray()
@@ -1145,7 +1167,7 @@ class URLDecoder(Decoder):
                         continue
                     except ValueError:
                         pass
-                if ch == "+":
+                if ch == "+" and plus_from is not None and i > plus_from:
                     result += b" "
                 else:
                     result += ch.encode("utf-8")


### PR DESCRIPTION
## Summary

Full verification pass over all 21 engine decoders (round-trip exercises, adversarial edge cases, fuzzing, and an end-to-end layered-payload run through `TitanEngine`), fixing the three defects it surfaced:

- **HTMLEntityDecoder**: a numeric entity in the UTF-16 surrogate range (e.g. `&#55296;` = U+D800) produced a lone surrogate that `chr()` accepts but UTF-8 cannot encode; the blanket `except` then failed the whole decode, so one crafted entity disabled entity decoding for the entire payload. Surrogate entities now stay literal (matching `UnicodeEscapeDecoder`'s handling) while surrounding entities still decode.
- **UUDecoder**: a data line that failed even the trailing-whitespace repair raised out of the decode loop and discarded every line already recovered — one flipped byte lost the whole artifact. Corrupt lines are now skipped so the remaining lines still decode.
- **URLDecoder**: `+` was converted to space everywhere, corrupting literal plus signs — most damagingly base64 embedded in percent-encoded payloads, where each converted `+` broke the next decode layer. The conversion now applies only in form-encoded contexts: past the first `?` of a URL, or throughout a bare `k=v&k=v` body (`&` never occurs in base64, so that shape is a safe signal).

Regression tests added for all three; one existing test that asserted the old everywhere-conversion `+` behavior was updated to the new contract.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) — full suite, 633 passed, 13 skipped.
- [x] I updated docs if flags/output contracts changed — no flags changed; the URLDecoder `+` contract change is documented in the decoder docstring/comments and its tests.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior — stdlib-only edits to `titan_decoder/decoders/base.py`, fully deterministic.

## Testing

- Command(s) run:

```bash
pytest -q
ruff check . && ruff format --check .
python fuzz/fuzz_decoders.py --seconds 30
```

- Notes: 633 tests pass (630 existing + 3 new regression tests). Fuzzer reports 0 invariant violations. A 72-check round-trip exercise of every registered decoder (line-wrapped base64, concatenated/truncated compression streams, decompression bombs, repeating XOR keys, unpadded base32, surrogate pairs, BOMs, binary false-positive bait) passes. End-to-end engine run peels `base64(gzip(utf-16-le(PowerShell)))` down to the plaintext IOC.

## Screenshots / Output (optional)

```
>>> HTMLEntityDecoder().decode(b"&#55296; ping &amp; &#x41;")
(b'&#55296; ping & A', True)          # was (input, False)

>>> URLDecoder().decode(b"c2VjcmV0K3BhcnQ%3D")
(b'c2VjcmV0K3BhcnQ=', True)           # was b'c2VjcmV0K3BhcnQ=' with '+' -> ' '
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVuC9aH1n5SN96PRwGmemr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVuC9aH1n5SN96PRwGmemr)_