### PR TITLE
Recover unmerged fixes from opus-4.8-bug-fix branch; de-flake reveal test

### DIFF
--- a/tests/test_smart_detection.py
+++ b/tests/test_smart_detection.py
@@ -100,3 +100,31 @@ def test_no_false_positives():
     ]
     # Should not have many high-confidence detections
     assert len(high_confidence_detections) <= 1
+
+
+def test_smart_detection_preserves_name_sorted_decoder_order():
+    """Smart detection must not break the engine's tie-break determinism.
+
+    Decode-score ties resolve to the first decoder tried, and TitanEngine
+    sorts self.decoders by name at init to make that reproducible. Smart
+    detection used to append newly-enabled optional decoders (e.g. Base32)
+    at the tail without re-sorting, so on an exact score tie the built-in
+    decoder always beat the smart-enabled one by append order — the
+    documented invariant silently failed on exactly the inputs that fire
+    smart detection.
+    """
+    from titan_decoder.core.engine import TitanEngine
+
+    engine = TitanEngine()
+    baseline_names = [getattr(d, "name", "") for d in engine.decoders]
+    assert baseline_names == sorted(baseline_names)
+    assert engine.base32_decoder not in engine.decoders  # off by default
+
+    engine.run_analysis(base64.b32encode(b"Secret test data"))
+
+    # Smart detection fired and registered the Base32 decoder mid-run...
+    assert engine.base32_decoder in engine.decoders
+    # ...and the list must still be name-sorted, keeping tie-breaks
+    # alphabetical (Base32 belongs before Base64, not at the tail).
+    names = [getattr(d, "name", "") for d in engine.decoders]
+    assert names == sorted(names)

--- a/tests/test_workbench_integrated_complete.py
+++ b/tests/test_workbench_integrated_complete.py
@@ -140,7 +140,13 @@ def test_analysis_reveals_results_on_short_terminals(monkeypatch):
             assert column.scroll_offset.y == 0
             worker = app.start_analysis()
             await app.workers.wait_for_complete([worker])
-            await pilot.pause()
+            # The reveal is scheduled via call_after_refresh, which under
+            # Textual 8's frame scheduling may take more than one pause to
+            # land; wait for the scroll instead of sampling a single frame.
+            for _ in range(20):
+                await pilot.pause()
+                if column.scroll_offset.y > 0:
+                    break
             assert column.scroll_offset.y > 0, (
                 "results panel was not scrolled into view"
             )

--- a/tests/test_workbench_integrated_presenters.py
+++ b/tests/test_workbench_integrated_presenters.py
@@ -8,6 +8,7 @@ from titan_decoder.workbench_ui.presenters import (
     iocs_text,
     strings_text,
     summary_text,
+    timeline_text,
 )
 
 
@@ -101,3 +102,16 @@ def test_malformed_nested_report_values_do_not_crash_presenters():
 
     assert "\\[@click=app.quit]" in decode_tree_text(snapshot)
     assert "score=0.000" in correlation_text(snapshot)
+
+
+def test_malformed_timeline_values_do_not_crash_timeline_view():
+    # Non-list timeline sources previously raised TypeError from the
+    # snapshot property, crashing the workbench Timeline view outright.
+    for report in (
+        {"timeline": 42},
+        {"timeline": True},
+        {"evidence": {"events": 99}},
+        {"evidence": {"events": {"invalid": "shape"}}, "timeline": "invalid"},
+    ):
+        text = timeline_text(AnalysisSnapshot(report=report))
+        assert text == "No timeline events recorded in the active report."

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -391,6 +391,10 @@ class TitanEngine:
                         logger.info(
                             f"Enabled Base32 decoder (confidence: {confidence:.2f})"
                         )
+            # The appends above put newly-enabled decoders at the tail, which
+            # would break the name-sorted order that decode-score tie
+            # resolution relies on. Restore the invariant before scoring.
+            self.decoders.sort(key=lambda d: getattr(d, "name", ""))
 
         # Prefer archive analyzers before heuristic decoders.
         # This avoids cases where a container format (e.g., ZIP) is "successfully"

--- a/titan_decoder/workbench_ui/models.py
+++ b/titan_decoder/workbench_ui/models.py
@@ -69,6 +69,8 @@ class AnalysisSnapshot:
             or self.report.get("evidence_timeline")
             or []
         )
+        if not isinstance(source, list):
+            return []
         return [item for item in source if isinstance(item, dict)]
 
     @property


### PR DESCRIPTION
## Summary

Recovers the two unmerged bug fixes stranded on `claude/opus-4.8-bug-fix-hrqsfz` (cherry-picked, original commits preserved) so the branch can be deleted, plus one de-flake surfaced while verifying them:

- **Engine tie-break determinism**: `TitanEngine` sorts `self.decoders` by name at init so decode-score ties resolve reproducibly, but smart detection appended newly-enabled optional decoders (e.g. Base32) at the tail without re-sorting — the documented invariant silently failed on exactly the inputs that fire smart detection. The list is now re-sorted after smart detection runs.
- **Workbench timeline crash guard**: a non-list `timeline`/`evidence.events` value in a loaded report raised `TypeError` from the `AnalysisSnapshot` timeline property, crashing the Timeline view outright. Non-list sources now yield an empty timeline.
- **De-flake** (new): `test_analysis_reveals_results_on_short_terminals` sampled the center column's scroll offset after a single `pilot.pause()`, but the reveal is scheduled via `call_after_refresh`, which under Textual 8's frame scheduling often needs more than one frame — the test failed ~70–90% of local runs on current `main`. It now waits for the scroll with a bounded poll.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`) — full suite, 641 passed, 7 skipped, with textual 8.2.8 installed.
- [x] I updated docs if flags/output contracts changed — no flags or output contracts changed; behavior fixes restore documented invariants.
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior — no dependencies added; the engine change *restores* determinism.

## Testing

- Command(s) run:

```bash
pytest -q
ruff check . && ruff format --check .
mypy titan_decoder/
```

- Notes: 641 passed / 7 skipped. The previously flaky reveal test passes 15/15 consecutive local runs after the de-flake (was ~1–3/10 before, on unmodified `main`).

## Screenshots / Output (optional)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVuC9aH1n5SN96PRwGmemr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVuC9aH1n5SN96PRwGmemr)_