### PR TITLE
Document the native Windows desktop workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,13 @@ pip install -e '.[desktop-ui]'
 titan-ui
 ```
 
-For the terminal version, install `.[workbench-ui]` and run `titan-tui` or
-`titan-workbench-ui`.
+On Windows, the supported native configuration uses a PySide6 front end and a
+Debian analysis backend through WSL. Follow the one-time setup in the
+[Windows Desktop Workbench guide](docs/WINDOWS_DESKTOP_UI.md), then launch
+`Titan-Windows.cmd`. Native Explorer drag-and-drop is available in this build.
+
+For the separate terminal version, install `.[workbench-ui]` and run
+`titan-tui` or `titan-workbench-ui`.
 
 Add detections, risk, a readable explanation, and a separate Intelligence object:
 
@@ -315,7 +320,8 @@ See [docs/TESTING.md](docs/TESTING.md) and [CONTRIBUTING.md](CONTRIBUTING.md).
 | [Project charter](docs/PROJECT_CHARTER.md) | Mission, core principles, scope, and governance |
 | [Architecture](docs/ARCHITECTURE.md) | Components, boundaries, and system diagrams |
 | [CLI reference](docs/CLI_REFERENCE.md) | Command groups, outputs, and examples |
-| [Integrated workbench](docs/WORKBENCH_INTEGRATED_BUILD.md) | Textual UI installation, operation, and safety behavior |
+| [Windows desktop workbench](docs/WINDOWS_DESKTOP_UI.md) | Native setup, Debian bridge, drag-and-drop, and troubleshooting |
+| [Integrated workbench](docs/WORKBENCH_INTEGRATED_BUILD.md) | Native and Textual interface commands, operation, and safety behavior |
 | [Assurance pipeline](docs/ASSURANCE_PIPELINE.md) | Six fail-closed controls, verdict policy, VM and provenance attestations |
 | [Pipelines](docs/PIPELINES.md) | End-to-end execution, decoder engine, and analyzer pipeline |
 | [Developer guide](docs/DEVELOPER_GUIDE.md) | Repository layout and implementation workflow |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,6 +60,26 @@ flowchart TB
     JSON --> Vault
 ```
 
+## Windows desktop boundary
+
+The native Windows interface is deliberately separated from Debian analysis:
+
+```mermaid
+flowchart LR
+    Explorer["Windows Explorer / input dialogs"] --> Qt["Native PySide6 workbench"]
+    Qt -->|"JSON over stdin/stdout via wsl.exe"| Bridge["Debian WSL bridge"]
+    Bridge --> Services["Workbench services"]
+    Services --> Engine["TitanEngine"]
+    Engine --> Report["Deterministic report"]
+    Report --> Qt
+```
+
+`titan_decoder.desktop_ui.debian_services` translates Windows paths to `/mnt`
+paths and invokes `titan_decoder.desktop_ui.debian_bridge` inside the selected
+Debian distribution. The bridge transfers report state back to the native UI;
+it does not create a detonation or VM isolation boundary. See
+[WINDOWS_DESKTOP_UI.md](WINDOWS_DESKTOP_UI.md) for setup and operation.
+
 ## Key design rules
 
 1. The byte-analysis engine does not depend on case-report or UI rendering.
@@ -79,6 +99,8 @@ flowchart TB
 - `titan_decoder/core/risk_scoring.py` — operational risk.
 - `titan_decoder/core/graph_export.py` — graph serialization.
 - `titan_decoder/core/case_report.py` — Markdown/HTML reports.
+- `titan_decoder/desktop_ui/` — native PySide6 frontend and Debian WSL bridge.
+- `titan_decoder/workbench_ui/` — Textual terminal frontend and shared workbench services.
 - `titan_decoder/plugins.py` — plugin discovery and loading.
 - `tests/` — unit, contract, corpus, safety, and regression suites.
 

--- a/docs/DOCUMENTATION_INDEX.md
+++ b/docs/DOCUMENTATION_INDEX.md
@@ -5,7 +5,8 @@
 - [USAGE.md](USAGE.md) — practical walkthroughs.
 - [INTERACTIVE_CONSOLE.md](INTERACTIVE_CONSOLE.md) — the `titan` terminal console.
 - [ANALYST_WORKBENCH.md](ANALYST_WORKBENCH.md) — the `titan-workbench` report explorer.
-- [WORKBENCH_INTEGRATED_BUILD.md](WORKBENCH_INTEGRATED_BUILD.md) — the optional Textual forensic workbench.
+- [WINDOWS_DESKTOP_UI.md](WINDOWS_DESKTOP_UI.md) — native Windows setup, Debian bridge, drag-and-drop, and troubleshooting.
+- [WORKBENCH_INTEGRATED_BUILD.md](WORKBENCH_INTEGRATED_BUILD.md) — native and Textual workbench commands and shared capabilities.
 - [LOCAL_AI_ANALYST.md](LOCAL_AI_ANALYST.md) — the `titan-analyst` grounded Q&A tool.
 - [CLI_REFERENCE.md](CLI_REFERENCE.md) — command groups and examples.
 - [GRAPH_EXPORTS.md](GRAPH_EXPORTS.md) — JSON, DOT, and Mermaid output.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,9 +26,14 @@ From the repo root:
 
   - `pip install -r requirements-optional.txt`
 
-Installing gives you **two commands**:
+Installing Titan provides these command-line entry points; optional interfaces
+require their matching extras:
 
 - **`titan`** — the interactive, menu-driven UI (see below). Easiest way in.
+- **`titan-ui`** — the native PySide6 desktop workbench. On Windows, see
+  [WINDOWS_DESKTOP_UI.md](WINDOWS_DESKTOP_UI.md) for the Debian-backed setup.
+- **`titan-tui`** / **`titan-workbench-ui`** — the optional Textual terminal
+  workbench installed with `.[workbench-ui]`.
 - **`titan-workbench`** — explore completed JSON reports: decode trees, graphs, IOCs, timelines, search, investigation workspaces, exports. See [ANALYST_WORKBENCH.md](ANALYST_WORKBENCH.md).
 - **`titan-analyst`** — ask grounded questions about completed reports ("Why is this High Risk?"); deterministic by default, optional local model backend. See [LOCAL_AI_ANALYST.md](LOCAL_AI_ANALYST.md).
 - **`titan-decoder`** — the scriptable CLI used throughout the rest of this guide.

--- a/docs/WINDOWS_DESKTOP_UI.md
+++ b/docs/WINDOWS_DESKTOP_UI.md
@@ -1,0 +1,214 @@
+# Windows Desktop Workbench
+
+Titan's Windows workbench is a native PySide6 application. It runs directly on
+Windows, receives Explorer drag-and-drop events, and supplies the taskbar icon
+and desktop integration. Primary analysis is delegated to Titan running inside
+Debian through WSL.
+
+This arrangement gives the interface native Windows behavior while keeping the
+analysis environment in Debian. WSL is a genuine Linux environment, but it is
+not a security boundary for executing hostile samples. Titan performs static
+analysis and does not require recovered payloads to be run.
+
+## Components
+
+| Component | Runs in | Purpose |
+|---|---|---|
+| `titan-ui` / `Titan-Windows.cmd` | Windows | Native PySide6 desktop workbench |
+| `debian_bridge` | Debian under WSL | Runs Titan analysis and returns the report |
+| `titan-tui` / `titan-workbench-ui` | Current terminal | Optional Textual terminal workbench |
+| `titan-workbench` | Current terminal | Dependency-free completed-report explorer |
+
+The native and terminal workbenches are separate interfaces. `titan-ui` is not
+an alias for `titan-tui`.
+
+## Prerequisites
+
+- Windows 10 or Windows 11;
+- Python 3.10 or newer installed on Windows;
+- WSL with a distribution named `Debian`;
+- the Titan repository stored on a Windows drive that Debian can access under
+  `/mnt`, such as `C:\path\to\titan1` and `/mnt/c/path/to/titan1`.
+
+Check the installed WSL distributions from PowerShell:
+
+```powershell
+wsl --list --verbose
+```
+
+If the Debian distribution uses another name, see
+[Choose another Debian distribution](#choose-another-debian-distribution).
+
+## One-time setup
+
+The launcher and bridge intentionally use two different virtual environments.
+Keep their names exactly as shown.
+
+### 1. Prepare the Debian analysis environment
+
+Open Debian, change to the repository through its `/mnt` path, and create the
+`.venv` environment:
+
+```bash
+cd /mnt/c/path/to/titan1
+sudo apt update
+sudo apt install -y python3-venv
+python3 -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -e .
+```
+
+Replace the example repository path with the location of your clone. The
+Windows bridge invokes `.venv/bin/python` directly, so activating this
+environment is not required when the desktop application runs.
+
+### 2. Prepare the native Windows environment
+
+Open PowerShell in the same repository and create `.venv-windows`:
+
+```powershell
+cd C:\path\to\titan1
+py -m venv .venv-windows
+.\.venv-windows\Scripts\python.exe -m pip install --upgrade pip
+.\.venv-windows\Scripts\python.exe -m pip install -e ".[desktop-ui]"
+```
+
+This installs Titan, PySide6, and the native desktop assets into the Windows
+environment. The environments are machine-local and are not committed to the
+repository.
+
+## Launch
+
+From PowerShell or File Explorer, run:
+
+```powershell
+.\Titan-Windows.cmd
+```
+
+The launcher uses `.venv-windows\Scripts\pythonw.exe`, so it opens the
+workbench without a separate console window. For debugging, keep a console and
+launch the module directly:
+
+```powershell
+.\.venv-windows\Scripts\python.exe -m titan_decoder.desktop_ui.app
+```
+
+After activating `.venv-windows`, `titan-ui` launches the same native module.
+
+## How analysis crosses into Debian
+
+```text
+Explorer drop or file picker
+        -> native PySide6 workbench on Windows
+        -> wsl.exe -d Debian
+        -> .venv/bin/python -m titan_decoder.desktop_ui.debian_bridge
+        -> deterministic Titan report
+        -> native workbench results
+```
+
+The bridge translates ordinary drive paths such as
+`C:\Evidence\sample.bin` to `/mnt/c/Evidence/sample.bin`. Pasted text and byte
+input are transferred as encoded data instead of being written to a temporary
+file.
+
+The **Analyze** actions use the Debian bridge. A manually selected decoder in
+the right-hand Decoder Workbench runs in the native process against the data
+already loaded into the UI.
+
+## Drag and drop
+
+Drop a local file or folder from Windows File Explorer onto the large **DROP
+FILES HERE** area. The native application receives the Explorer event and
+starts analysis. Clicking the drop area opens Titan's dark file picker, and
+pressing `A` opens the text-input action.
+
+If a file can be selected in the picker but cannot be dropped, confirm that:
+
+1. the native `Titan-Windows.cmd`/`titan-ui` application is running, rather
+   than `titan-tui` inside Windows Terminal;
+2. File Explorer and Titan run at the same privilege level—Windows blocks
+   drag-and-drop from a non-elevated process into an elevated process;
+3. the source is a local file or folder with a path visible to Debian under
+   `/mnt`.
+
+Terminal emulators cannot provide the same native Explorer event to a Textual
+application. `titan-tui` accepts a path when the terminal turns a drop into
+bracketed pasted text, but that behavior depends on the terminal.
+
+## Workbench controls
+
+- **PROFILE** cycles the analysis profile.
+- **NETWORK** starts in offline mode. Enabling it displays a warning because
+  network-capable analyzers or plugins may send hashes, indicators, URLs,
+  domains, or other sample-derived data to external services. Titan does not
+  automatically upload the evidence file, but plugin behavior is controlled by
+  the plugin. Enable online mode only when investigation policy permits it.
+- **AGGRESSIVE** enables deeper and lower-confidence decoding attempts. It may
+  find more candidates and also produce more noise.
+- **Recent samples** retains archived sample records independently of whether
+  an item is hidden from **Latest Analysis Results**.
+
+## Choose another Debian distribution
+
+The default WSL distribution name is `Debian`. Override it before launching:
+
+```powershell
+$env:TITAN_WSL_DISTRIBUTION = "Debian-Testing"
+.\Titan-Windows.cmd
+```
+
+Use the exact name reported by `wsl --list --verbose`. Set the variable in the
+user environment if the choice should persist across PowerShell sessions.
+
+For frontend development only, the Debian bridge can be bypassed so analysis
+runs in the Windows process:
+
+```powershell
+$env:TITAN_DESKTOP_BACKEND = "local"
+.\Titan-Windows.cmd
+```
+
+The supported Windows deployment uses the default `debian` backend. The local
+override is useful for UI tests and troubleshooting, not as additional sample
+isolation.
+
+## Troubleshooting
+
+### The launcher says the Windows environment is not installed
+
+Create `.venv-windows` and install `.[desktop-ui]` using the Windows setup
+commands above. The launcher requires
+`.venv-windows\Scripts\pythonw.exe` in the repository.
+
+### The Debian analysis backend failed
+
+Verify all three layers:
+
+```powershell
+wsl --list --verbose
+wsl -d Debian -- bash -lc "cd /mnt/c/path/to/titan1 && .venv/bin/python -c 'import titan_decoder; print(titan_decoder.__version__)'"
+```
+
+Adjust the repository path and distribution name. If the second command fails,
+recreate the Debian `.venv` and reinstall Titan from inside Debian.
+
+### A moved clone no longer analyzes
+
+Both environments use editable installs, and the bridge locates Debian from the
+native source tree. Reinstall Titan in `.venv-windows` and `.venv` after moving
+the repository.
+
+### The desktop shortcut has the wrong icon
+
+Point the shortcut at `Titan-Windows.cmd` and choose
+`titan_decoder\desktop_ui\assets\titan-metallic.ico` as its icon. Windows may
+cache old shortcut artwork; recreating the shortcut or restarting Explorer
+refreshes that cache.
+
+## Safety boundary
+
+Treat unknown input as untrusted even when Titan reports no findings. A static
+result is evidence, not permission to execute the sample. WSL shares resources
+and filesystem access with its Windows host and must not be described as a VM
+detonation boundary. Use Titan's assurance controls and an approved isolated VM
+workflow when a conclusive verdict requires dynamic execution.

--- a/docs/WORKBENCH_INTEGRATED_BUILD.md
+++ b/docs/WORKBENCH_INTEGRATED_BUILD.md
@@ -1,17 +1,34 @@
 # Titan Forensic Workbench — Integrated Build
 
-This build advances the Phase 9.1 shell toward the approved visual design.
+Titan provides a native PySide6 desktop workbench and a Textual terminal
+workbench. Both use the same deterministic engine and report model, but they are
+different interfaces with different optional dependencies.
 
 ## Install and launch
 
+### Native desktop workbench
+
 ```bash
-python -m pip install -e '.[workbench-ui]'
+python -m pip install -e '.[desktop-ui]'
 titan-ui
 ```
 
-The existing `titan-workbench-ui` command remains an equivalent alias.
+On Windows, use the two-environment setup and `Titan-Windows.cmd` launcher
+documented in [WINDOWS_DESKTOP_UI.md](WINDOWS_DESKTOP_UI.md). That build receives
+native File Explorer drag-and-drop events and delegates analysis to Debian
+through WSL.
 
-## Terminal file drops
+### Textual terminal workbench
+
+```bash
+python -m pip install -e '.[workbench-ui]'
+titan-tui
+```
+
+`titan-workbench-ui` is an equivalent alias for `titan-tui`. Neither command is
+an alias for the native `titan-ui` application.
+
+## Textual terminal file drops
 
 Titan accepts a single file or folder dropped anywhere in the workbench when
 the terminal emulator represents the drop as a bracketed paste. The path is
@@ -23,6 +40,9 @@ The terminal emulator still owns the operating-system drop operation. If it
 does not emit the path, click the drop zone and paste the path manually. A drop
 is only auto-analyzed when it resolves to an existing local file or directory;
 ordinary pasted text continues to be treated as evidence.
+
+For native Windows Explorer drag-and-drop and its troubleshooting steps, use
+the [Windows Desktop Workbench guide](WINDOWS_DESKTOP_UI.md).
 
 ## Analysis outcomes
 
@@ -38,7 +58,7 @@ Assurance blockers are shown in the findings card. The workbench automatically
 runs Titan's offline static suite; VM and provenance controls consume the
 hash-bound provider attestations configured in `~/.titan_decoder/config.json`.
 
-## Implemented
+## Shared workbench capabilities
 
 - permanent left, center, and right columns;
 - compact custom header and status bar with live session state;
@@ -57,10 +77,16 @@ hash-bound provider attestations configured in `~/.titan_decoder/config.json`.
 - session settings for profile, offline mode, and aggressive detection;
 - detailed dark forensic theme.
 
+The native desktop additionally provides desktop dialogs, native Explorer file
+drops, application artwork, and the Debian analysis bridge. Some navigation and
+presentation details differ between the PySide6 and Textual front ends.
+
 ## Safety
 
-The new UI is a presentation layer. It does not replace or duplicate Titan's
-analysis logic, and the existing `titan` command remains unchanged.
+The workbench interfaces are presentation layers. They do not replace or
+duplicate Titan's analysis logic, and the existing `titan` command remains
+unchanged. WSL is not a VM isolation boundary; do not execute unknown or
+recovered payloads merely because the workbench can inspect them.
 
 
 ## Completion recovery update


### PR DESCRIPTION
## Summary

- add a complete setup and launch guide for the native PySide6 Windows workbench and Debian WSL analysis bridge
- correct the `titan-ui` versus `titan-tui`/`titan-workbench-ui` dependency and command mapping
- document Explorer drag-and-drop, online-mode warnings, backend overrides, troubleshooting, and the WSL safety boundary
- update the README, usage guide, documentation index, and architecture map

## Why

The Windows UI was present on `main`, but the related documentation still mixed the native and Textual interfaces and did not explain the two virtual environments required by `Titan-Windows.cmd` and the Debian bridge.

## Impact

Documentation only. Existing commands and application behavior are unchanged.

## Validation

- 30 focused desktop/workbench tests passed
- Windows PySide6 desktop imports passed
- Debian bridge imports passed
- local Markdown links resolve
- `git diff --check` passed
