### PR TITLE
Fix optional format readiness and archive extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Engine coverage, isolation, and response workflow:
   F1, specificity, accuracy, and per-component quality gates.
 - Expose Deep Scan in the native Windows workbench and add CLI commands for
   scanning, quarantine listing/restoration, and calibration.
+- Install the format extra in the supported Windows/WSL setup and make
+  `--doctor` report optional-format readiness, missing modules, and recovery
+  guidance; manual optional decoders now fail with an actionable message.
+  Restore 7z extraction for the current py7zr API and correct ISO member-path
+  resolution.
 
 Integrated workbench interface redesign:
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ git clone https://github.com/pragmaconflux/titan1.git
 cd titan1
 python -m venv .venv
 source .venv/bin/activate
-pip install -e '.[dev,workbench-ui]'
+pip install -e '.[dev,workbench-ui,formats]'
 ```
 
 Install optional Brotli, Zstandard, 7z, RAR, ISO, and CAB support with
@@ -131,7 +131,7 @@ titan-decoder --file suspicious.bin --out report.json
 Launch the native desktop workbench after installing its extra:
 
 ```bash
-pip install -e '.[desktop-ui]'
+pip install -e '.[desktop-ui,formats]'
 titan-ui
 ```
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -186,4 +186,8 @@ titan-decoder --list-rule-packs
 titan-decoder --print-schema-version
 ```
 
-These commands are side-effect-light and suitable for installation checks and CI diagnostics.
+These commands are side-effect-light and suitable for installation checks and
+CI diagnostics. `--doctor` reports `ready` or `degraded`, imports every optional
+format module to detect broken native installations, lists missing modules, and
+prints the command needed to install the `formats` extra. Missing optional
+libraries are warnings rather than a core-engine failure.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -20,11 +20,15 @@ From the repo root:
 
 - Editable install (recommended while you’re developing):
 
-  - `pip install -e .`
+  - `pip install -e '.[formats]'`
 
 - Optional enrichment dependencies:
 
   - `pip install -r requirements-optional.txt`
+
+Use `titan-decoder --doctor` after installation. The `optional_formats`
+section identifies missing or broken Brotli, Zstandard, 7z, RAR, ISO, and CAB
+libraries instead of allowing those features to fail silently.
 
 Installing Titan provides these command-line entry points; optional interfaces
 require their matching extras:

--- a/docs/WINDOWS_DESKTOP_UI.md
+++ b/docs/WINDOWS_DESKTOP_UI.md
@@ -55,7 +55,7 @@ sudo apt update
 sudo apt install -y python3-venv
 python3 -m venv .venv
 .venv/bin/python -m pip install --upgrade pip
-.venv/bin/python -m pip install -e .
+.venv/bin/python -m pip install -e '.[formats]'
 ```
 
 Replace the example repository path with the location of your clone. The
@@ -70,12 +70,13 @@ Open PowerShell in the same repository and create `.venv-windows`:
 cd C:\path\to\titan1
 py -m venv .venv-windows
 .\.venv-windows\Scripts\python.exe -m pip install --upgrade pip
-.\.venv-windows\Scripts\python.exe -m pip install -e ".[desktop-ui]"
+.\.venv-windows\Scripts\python.exe -m pip install -e ".[desktop-ui,formats]"
 ```
 
-This installs Titan, PySide6, and the native desktop assets into the Windows
-environment. The environments are machine-local and are not committed to the
-repository.
+This installs Titan, PySide6, the native desktop assets, and the optional
+format libraries into the Windows environment. The Debian command installs the
+same format libraries for the actual analysis backend. The environments are
+machine-local and are not committed to the repository.
 
 ## Launch
 
@@ -183,9 +184,15 @@ isolation.
 
 ### The launcher says the Windows environment is not installed
 
-Create `.venv-windows` and install `.[desktop-ui]` using the Windows setup
+Create `.venv-windows` and install `.[desktop-ui,formats]` using the Windows setup
 commands above. The launcher requires
 `.venv-windows\Scripts\pythonw.exe` in the repository.
+
+### A decoder is listed but optional format support is unavailable
+
+Run `titan-decoder --doctor` in both environments. Its `optional_formats`
+section reports every required module and provides an install hint. Re-run the
+setup commands above when the status is `degraded`.
 
 ### The Debian analysis backend failed
 

--- a/docs/WORKBENCH_INTEGRATED_BUILD.md
+++ b/docs/WORKBENCH_INTEGRATED_BUILD.md
@@ -9,7 +9,7 @@ different interfaces with different optional dependencies.
 ### Native desktop workbench
 
 ```bash
-python -m pip install -e '.[desktop-ui]'
+python -m pip install -e '.[desktop-ui,formats]'
 titan-ui
 ```
 

--- a/tests/test_advanced_decoders.py
+++ b/tests/test_advanced_decoders.py
@@ -3,6 +3,8 @@
 import base64
 import zlib
 
+import pytest
+
 from titan_decoder.core.engine import TitanEngine
 from titan_decoder.decoders.advanced import (
     Ascii85Decoder,
@@ -64,6 +66,22 @@ def test_optional_compression_decoders_fail_closed_when_unavailable_or_invalid()
     zstd_payload = b"\x28\xb5\x2f\xfdnot-a-frame"
     assert ZstandardDecoder().can_decode(zstd_payload)
     assert ZstandardDecoder().decode(zstd_payload) == (zstd_payload, False)
+
+
+def test_brotli_decoder_round_trip_when_dependency_is_available():
+    brotli = pytest.importorskip("brotli")
+    source = b"bounded Brotli payload"
+    encoded = b"brotli:" + brotli.compress(source)
+    assert BrotliDecoder().decode(encoded) == (source, True)
+    assert BrotliDecoder(max_output=4).decode(encoded) == (encoded, False)
+
+
+def test_zstandard_decoder_round_trip_when_dependency_is_available():
+    zstandard = pytest.importorskip("zstandard")
+    source = b"bounded Zstandard payload"
+    encoded = zstandard.ZstdCompressor().compress(source)
+    assert ZstandardDecoder().decode(encoded) == (source, True)
+    assert ZstandardDecoder(max_output=4).decode(encoded) == (encoded, False)
 
 
 def test_advanced_decoders_are_registered_and_name_sorted():

--- a/tests/test_cli_doctor_jsonl_vault.py
+++ b/tests/test_cli_doctor_jsonl_vault.py
@@ -17,6 +17,18 @@ def test_cli_doctor_outputs_json_and_exits_zero(monkeypatch, capsys):
     assert diag["ok"] is True
     assert "python" in diag
     assert "optional_dependencies" in diag
+    assert set(diag["optional_formats"]["modules"]) == {
+        "brotli",
+        "zstandard",
+        "py7zr",
+        "rarfile",
+        "pycdlib",
+        "cabarchive",
+    }
+    assert diag["optional_formats"]["ready"] is (
+        not diag["optional_formats"]["missing"]
+    )
+    assert diag["status"] in {"ready", "degraded"}
     assert "version" in diag
     assert "schema_version" in diag
 

--- a/tests/test_optional_formats.py
+++ b/tests/test_optional_formats.py
@@ -1,0 +1,34 @@
+from titan_decoder.optional_formats import (
+    OPTIONAL_FORMAT_MODULES,
+    optional_format_availability,
+    optional_format_status,
+)
+
+
+def test_optional_format_availability_imports_every_declared_module():
+    imported = []
+
+    def importer(name):
+        imported.append(name)
+        if name == "cabarchive":
+            raise ImportError("missing")
+        return object()
+
+    availability = optional_format_availability(importer)
+
+    assert tuple(imported) == OPTIONAL_FORMAT_MODULES
+    assert availability["brotli"] is True
+    assert availability["cabarchive"] is False
+
+
+def test_optional_format_status_explains_degraded_readiness():
+    def importer(name):
+        if name in {"rarfile", "pycdlib"}:
+            raise RuntimeError("broken native dependency")
+        return object()
+
+    status = optional_format_status(importer)
+
+    assert status["ready"] is False
+    assert status["missing"] == ["pycdlib", "rarfile"]
+    assert "titan-decoder[formats]" in status["install_hint"]

--- a/tests/test_structured_analyzers.py
+++ b/tests/test_structured_analyzers.py
@@ -6,6 +6,8 @@ import json
 import struct
 import zipfile
 
+import pytest
+
 from titan_decoder.core.analyzers.structured import (
     EmailAnalyzer,
     LnkAnalyzer,
@@ -110,6 +112,47 @@ def test_optional_archive_recognition_fails_closed_without_valid_payload():
     fake_cab = b"MSCF" + b"not a valid cabinet"
     assert analyzer.can_analyze(fake_cab)
     assert analyzer.analyze(fake_cab) == []
+
+
+def test_optional_7z_analyzer_extracts_with_current_py7zr_api():
+    py7zr = pytest.importorskip("py7zr")
+    payload = b"bounded 7z payload"
+    output = io.BytesIO()
+    with py7zr.SevenZipFile(output, mode="w") as archive:
+        archive.writestr(payload, "nested/evidence.txt")
+
+    data = output.getvalue()
+    analyzer = OptionalArchiveAnalyzer()
+    assert analyzer.can_analyze(data)
+    assert dict(analyzer.analyze(data)) == {"evidence.txt": payload}
+
+
+def test_optional_iso_analyzer_uses_complete_member_paths():
+    pycdlib = pytest.importorskip("pycdlib")
+    payload = b"bounded ISO payload"
+    image = pycdlib.PyCdlib()
+    image.new(interchange_level=3)
+    image.add_fp(io.BytesIO(payload), len(payload), iso_path="/EVIDENCE.TXT;1")
+    output = io.BytesIO()
+    image.write_fp(output)
+    image.close()
+
+    data = output.getvalue()
+    analyzer = OptionalArchiveAnalyzer()
+    assert analyzer.can_analyze(data)
+    assert dict(analyzer.analyze(data)) == {"EVIDENCE.TXT1": payload}
+
+
+def test_optional_cab_analyzer_extracts_members():
+    cabarchive = pytest.importorskip("cabarchive")
+    payload = b"bounded CAB payload"
+    archive = cabarchive.CabArchive()
+    archive["evidence.txt"] = cabarchive.CabFile(payload)
+
+    data = archive.save()
+    analyzer = OptionalArchiveAnalyzer()
+    assert analyzer.can_analyze(data)
+    assert dict(analyzer.analyze(data)) == {"evidence.txt": payload}
 
 
 def test_structured_analyzers_are_registered_deterministically():

--- a/tests/test_workbench_ui_services.py
+++ b/tests/test_workbench_ui_services.py
@@ -1,3 +1,5 @@
+import pytest
+
 from titan_decoder.workbench_ui.services import WorkbenchServices
 
 
@@ -24,3 +26,27 @@ def test_backend_capabilities_advertise_extended_contract(tmp_path):
     assert capabilities["features"]["isolated_manifest_plugins"] is True
     assert "ASCII85" in capabilities["decoders"]
     assert "OfficeOOXML" in capabilities["analyzers"]
+    assert (
+        capabilities["optional_format_support"]["modules"]
+        == capabilities["optional_formats"]
+    )
+
+
+def test_manual_optional_decoder_reports_a_missing_library(monkeypatch):
+    services = WorkbenchServices()
+    index = next(
+        index
+        for index, choice in enumerate(services.registry)
+        if choice.label == "Brotli"
+    )
+    monkeypatch.setattr(
+        "titan_decoder.workbench_ui.services.optional_format_status",
+        lambda: {
+            "modules": {"brotli": False},
+            "ready": False,
+            "missing": ["brotli"],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="formats"):
+        services.run_decoder(index, b"brotli:not-compressed", "sample.bin")

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -5,6 +5,7 @@ import json
 import sys
 import random
 from pathlib import Path
+from typing import Any
 
 from . import __version__ as TITAN_VERSION
 from .core.engine import TitanEngine
@@ -14,6 +15,7 @@ from .core.offline_guard import block_network, is_network_blocked
 from .core.evidence_parsers import parse_evidence_file, combine_parse_results
 from .core.evidence_correlation import top_pivots, build_last_seen, build_entity_hints
 from .core.evidence_links import build_links_from_evidence_events, top_links
+from .optional_formats import optional_format_status
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -1797,8 +1799,10 @@ def _run_doctor(config: Config) -> dict:
         except Exception as e:
             pack_results.append({"path": str(p), "ok": False, "error": str(e)})
 
-    diag = {
+    format_status = optional_format_status()
+    diag: dict[str, Any] = {
         "ok": True,
+        "status": "ready" if format_status["ready"] else "degraded",
         "python": sys.version.split(" ")[0],
         "platform": platform.platform(),
         "version": TITAN_VERSION,
@@ -1809,7 +1813,17 @@ def _run_doctor(config: Config) -> dict:
             "yara": has("yara"),
             "yaml": has("yaml"),
             "requests": has("requests"),
+            **format_status["modules"],
         },
+        "optional_formats": format_status,
+        "warnings": (
+            []
+            if format_status["ready"]
+            else [
+                "Optional format support is incomplete; install the formats extra "
+                "to enable Brotli, Zstandard, 7z, RAR, ISO, and CAB handling."
+            ]
+        ),
         "rule_packs": pack_results,
     }
 

--- a/titan_decoder/core/analyzers/structured.py
+++ b/titan_decoder/core/analyzers/structured.py
@@ -7,8 +7,10 @@ from email.parser import BytesParser
 import html
 import io
 import json
+from pathlib import Path, PurePosixPath
 import re
 import struct
+import tempfile
 from typing import Any, Iterable
 import zipfile
 
@@ -24,6 +26,16 @@ def _safe_name(value: str, fallback: str = "artifact.bin") -> str:
     value = value.replace("\\", "/").rsplit("/", 1)[-1]
     value = "".join(char for char in value if char.isalnum() or char in "._- ")
     return value[:160] or fallback
+
+
+def _safe_archive_path(value: str) -> PurePosixPath | None:
+    """Return a normalized relative archive path or reject unsafe members."""
+    path = PurePosixPath(value.replace("\\", "/"))
+    if path.is_absolute() or not path.parts:
+        return None
+    if any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    return path
 
 
 class _Collector:
@@ -479,15 +491,54 @@ class OptionalArchiveAnalyzer(Analyzer):
             import py7zr  # type: ignore[import-not-found]
 
             with py7zr.SevenZipFile(io.BytesIO(data), mode="r") as archive:
-                if not hasattr(archive, "readall"):
+                selected: list[tuple[str, PurePosixPath]] = []
+                selected_total = 0
+                for info in sorted(archive.list(), key=lambda item: item.filename):
+                    relative = _safe_archive_path(str(info.filename))
+                    declared_size = int(info.uncompressed or 0)
+                    compressed_size = int(info.compressed or 0)
+                    if (
+                        relative is None
+                        or info.is_directory
+                        or info.is_symlink
+                        or declared_size <= 0
+                        or declared_size > self.max_item
+                        or selected_total + declared_size > self.max_total
+                        or (
+                            compressed_size
+                            and declared_size / compressed_size > self.max_ratio
+                        )
+                    ):
+                        continue
+                    selected.append((str(info.filename), relative))
+                    selected_total += declared_size
+                    if len(selected) >= self.max_artifacts:
+                        break
+
+                if not selected:
                     return []
-                extracted = archive.readall()
-            collector = _Collector(self.max_artifacts, self.max_total, self.max_item)
-            for name, stream in sorted(extracted.items()):
-                content = stream.read(self.max_item + 1)
-                if len(content) <= self.max_item:
-                    collector.add(_safe_name(name), content)
-            return collector.items
+
+                collector = _Collector(
+                    self.max_artifacts, self.max_total, self.max_item
+                )
+                with tempfile.TemporaryDirectory(prefix="titan-7z-") as directory:
+                    archive.extract(
+                        path=directory,
+                        targets=[name for name, _ in selected],
+                    )
+                    root = Path(directory).resolve()
+                    for name, relative in selected:
+                        target = root.joinpath(*relative.parts)
+                        if target.is_symlink():
+                            continue
+                        resolved = target.resolve()
+                        if root not in resolved.parents or not resolved.is_file():
+                            continue
+                        with resolved.open("rb") as stream:
+                            content = stream.read(self.max_item + 1)
+                        if len(content) <= self.max_item:
+                            collector.add(_safe_name(name), content)
+                return collector.items
         except Exception:
             return []
 
@@ -518,12 +569,23 @@ class OptionalArchiveAnalyzer(Analyzer):
             image.open_fp(io.BytesIO(data))
             collector = _Collector(self.max_artifacts, self.max_total, self.max_item)
             try:
-                for _, _, files in image.walk(iso_path="/"):
+                for directory, _, files in image.walk(iso_path="/"):
                     for entry in files:
-                        path = str(entry)
+                        parent = str(directory).rstrip("/")
+                        path = f"{parent}/{entry}"
+                        record: Any = image.get_record(iso_path=path)
+                        declared_size = int(record.data_length)
+                        if (
+                            declared_size <= 0
+                            or declared_size > self.max_item
+                            or collector.total + declared_size > self.max_total
+                        ):
+                            continue
                         output = io.BytesIO()
                         image.get_file_from_iso_fp(output, iso_path=path)
-                        collector.add(_safe_name(path), output.getvalue())
+                        content = output.getvalue()
+                        if len(content) <= self.max_item:
+                            collector.add(_safe_name(path), content)
                         if len(collector.items) >= self.max_artifacts:
                             return collector.items
             finally:

--- a/titan_decoder/optional_formats.py
+++ b/titan_decoder/optional_formats.py
@@ -1,0 +1,52 @@
+"""Shared readiness checks for Titan's optional format libraries."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Callable
+
+
+OPTIONAL_FORMAT_MODULES = (
+    "brotli",
+    "zstandard",
+    "py7zr",
+    "rarfile",
+    "pycdlib",
+    "cabarchive",
+)
+
+FORMAT_DECODER_REQUIREMENTS = {
+    "Brotli": "brotli",
+    "Zstandard": "zstandard",
+}
+
+FORMAT_INSTALL_HINT = "python -m pip install 'titan-decoder[formats]'"
+
+
+def optional_format_availability(
+    importer: Callable[[str], Any] = importlib.import_module,
+) -> dict[str, bool]:
+    """Import each library so broken native installs are reported as unavailable."""
+    available: dict[str, bool] = {}
+    for module in OPTIONAL_FORMAT_MODULES:
+        try:
+            importer(module)
+            available[module] = True
+        except Exception:
+            available[module] = False
+    return available
+
+
+def optional_format_status(
+    importer: Callable[[str], Any] = importlib.import_module,
+) -> dict[str, Any]:
+    """Return a stable, user-facing readiness summary for the ``formats`` extra."""
+    modules = optional_format_availability(importer)
+    missing = sorted(module for module, present in modules.items() if not present)
+    return {
+        "ready": not missing,
+        "modules": modules,
+        "available": sorted(module for module, present in modules.items() if present),
+        "missing": missing,
+        "install_hint": FORMAT_INSTALL_HINT,
+    }

--- a/titan_decoder/workbench_ui/services.py
+++ b/titan_decoder/workbench_ui/services.py
@@ -4,7 +4,6 @@ from dataclasses import replace
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable
-import importlib.util
 import json
 import os
 import platform
@@ -19,6 +18,11 @@ from titan_decoder.config import Config
 from titan_decoder.core.assurance import AssuranceEngine
 from titan_decoder.core.engine import TitanEngine
 from titan_decoder.interactive import build_decoder_registry
+from titan_decoder.optional_formats import (
+    FORMAT_DECODER_REQUIREMENTS,
+    FORMAT_INSTALL_HINT,
+    optional_format_status,
+)
 
 from .models import AnalysisSnapshot, WorkbenchState
 
@@ -73,6 +77,7 @@ class WorkbenchServices:
         ).encode("utf-8")
         from titan_decoder.core.engine import SCHEMA_VERSION
 
+        format_status = optional_format_status()
         return {
             "protocol_version": WORKBENCH_PROTOCOL_VERSION,
             "engine_version": TITAN_VERSION,
@@ -90,17 +95,8 @@ class WorkbenchServices:
                 - {""}
             ),
             "plugins": engine.plugin_manager.get_plugin_info(),
-            "optional_formats": {
-                module: importlib.util.find_spec(module) is not None
-                for module in (
-                    "brotli",
-                    "zstandard",
-                    "py7zr",
-                    "rarfile",
-                    "pycdlib",
-                    "cabarchive",
-                )
-            },
+            "optional_formats": format_status["modules"],
+            "optional_format_support": format_status,
             "features": {
                 "progress_events": True,
                 "cancellation": True,
@@ -354,6 +350,14 @@ class WorkbenchServices:
         )
         started = time.monotonic()
         choice = self.registry[index]
+        required_module = FORMAT_DECODER_REQUIREMENTS.get(choice.label)
+        if required_module and not optional_format_status()["modules"].get(
+            required_module, False
+        ):
+            raise RuntimeError(
+                f"{choice.label} support is unavailable because {required_module} "
+                f"is not importable. Install it with: {FORMAT_INSTALL_HINT}"
+            )
         decoded, success = choice.factory().decode(data)
         self._progress(
             {"stage": "complete", "percent": 100, "message": "Decoder complete"}


### PR DESCRIPTION
## What changed

- install the `formats` extra in the documented Windows and Debian setup paths
- make `titan-decoder --doctor` import-check and report all six optional format libraries with ready/degraded status and recovery guidance
- expose the same readiness information to the workbench and give missing manual decoders an actionable error
- restore 7z extraction with the current py7zr API and fix ISO member-path resolution
- add real round-trip coverage for Brotli, Zstandard, 7z, ISO, and CAB

## Root cause

The optional libraries were declared but not installed by the supported desktop setup commands, and the doctor only reported unrelated enrichment packages. Separately, the 7z analyzer relied on py7zr's removed `readall()` API and the ISO analyzer attempted extraction with incomplete member paths.

## Impact

Fresh Windows/WSL installs can enable the advertised formats consistently, operators can diagnose missing or broken libraries before analysis, and supported archive payloads now produce artifacts instead of failing silently.

## Validation

- Windows doctor: all six optional formats ready
- Debian doctor: all six optional formats ready
- Windows full suite: 754 passed, 9 skipped
- Debian focused suite: 35 passed
- Ruff check and format check: passed
- mypy: passed (112 source files)
- wheel and sdist build plus `twine check`: passed
