### PR TITLE
Add first-class YARA scanning across the artifact graph

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e '.[workbench-ui]'
           python -m pip install pytest ruff mypy pytest-cov hypothesis jsonschema
+          # Optional dependency exercised by tests/test_yara_integration.py;
+          # those tests importorskip when it is absent.
+          python -m pip install 'yara-python>=4.5.4'
 
       - name: Lint
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+First-class YARA integration:
+
+- Scan every artifact-graph node — raw, decoded, and extracted content —
+  with configured YARA rules during the detection stage, so signatures
+  match content that a scan of the raw input alone would never see.
+- Add `--yara-rules` (repeatable, file or directory) and configuration keys
+  for rule files, rule directories, and scan bounds (per-payload timeout,
+  node/match caps, bounded meta and matched-string capture).
+- Compile rule directories with one namespace per file, report matches in
+  deterministic order, and persist the fail-closed scan result as the
+  report's `yara` section.
+- Convert matches into `YARA:<namespace>:<rule>` detections (grouped per
+  rule with all matched node ids, severity and ATT&CK ids from rule meta)
+  that feed risk scoring, which now receives the previously-unused YARA
+  weighting input.
+- Route assurance's static YARA control through the same shared scanner,
+  giving Deep Scan and assurance rule-directory support and bounded
+  capture for free.
+- Keep YARA active under `--offline`: it is a purely local scan and no
+  longer disabled alongside network enrichment providers.
+- Ship a starter rule pack in `examples/yara_rules/` tuned for per-node
+  scanning (download cradles, encoded-command flags, PE-in-decoded-content,
+  UPX, JavaScript eval chains).
+
 Decoder and artifact-graph correctness:
 
 - Require raw Deflate input to be exactly one complete DEFLATE stream

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Titan is designed for repeatable analysis rather than opaque “best guess” de
 | Archive analysis | ZIP/TAR plus optional 7z, RAR, ISO, and CAB extraction with count/size/ratio limits |
 | Executables | Deeper PE/ELF section, entropy, import, entry-point, overlay, interpreter, and anomaly analysis |
 | Indicators | URLs, domains, IPs, emails, hashes, and normalized evidence indicators |
-| Detection | Built-in correlation rules and optional rule packs |
+| Detection | Built-in correlation rules, optional rule packs, and bounded YARA scanning of every artifact node (raw, decoded, and extracted content) |
 | Risk | Deterministic 0–100 risk assessment |
 | Intelligence | Classification, scored signals, artifact ranking, confidence, recommendation |
 | Threat intelligence | MITRE ATT&CK technique mapping, LOLBin identification, behavioral malware tags, node relationships |

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -74,9 +74,12 @@ titan-decoder --file sample.bin --enable-detections --out report.json
 titan-decoder --file sample.bin --enable-detections --explain
 titan-decoder --file sample.bin --intelligence-out intelligence.json
 titan-decoder --file sample.bin --enable-detections --fail-on-risk-level HIGH
+titan-decoder --file sample.bin --enable-detections --yara-rules rules/ --yara-rules extra.yar
 ```
 
 The Intelligence object is attached to every normal report. Detection and risk inputs are richer when `--enable-detections` is set. `--fail-on-risk-level` is intended for CI and returns a non-zero status when the configured threshold is met or exceeded.
+
+`--yara-rules` (repeatable, file or directory) scans every artifact-graph node — raw, decoded, and extracted content — with the given YARA rules; matches become `YARA:<namespace>:<rule>` detections and feed risk scoring. Requires the optional `yara-python` dependency, works fully offline, and is bounded and fail-closed. See [DETECTION_AND_RISK.md](DETECTION_AND_RISK.md).
 
 ## Evidence ingestion
 

--- a/docs/DETECTION_AND_RISK.md
+++ b/docs/DETECTION_AND_RISK.md
@@ -46,6 +46,34 @@ low/medium/high/critical. Patterns must compile at validation time.
 Fixture packs demonstrating valid, duplicate-ID, and invalid rules live in
 `tests/fixtures/rule_packs/` and back `tests/test_rule_pack_validation.py`.
 
+## YARA scanning across the artifact graph
+
+With `--enable-detections` and one or more `--yara-rules` sources (a rules
+file or a directory of `.yar`/`.yara` files, repeatable), Titan scans **every
+artifact-graph node** — the raw input plus all decoded and extracted content —
+so signatures match content that a scan of the raw bytes alone would never
+see. Rules can also be configured persistently via `enable_yara`,
+`yara_rules_path`, `yara_rules_files`, and `yara_rules_dirs`.
+
+Scanning is bounded and deterministic: rule files load in sorted order with
+one namespace per file, per-payload scans time out
+(`yara_timeout_seconds`, default 10), and node, match, meta, and
+matched-string capture counts are capped (`yara_max_nodes`,
+`yara_max_matches`, `yara_max_meta_bytes`, `yara_max_strings_per_match`,
+`yara_max_string_bytes`). The full result — including scanner state, rule
+sources, and per-node matches — is persisted as the report's `yara` section,
+and it is fail-closed: when YARA was requested but the library or rules are
+unavailable, the state says so explicitly.
+
+Matches also become detections (one per distinct rule, carrying every matched
+node id) with rule ids of the form `YARA:<namespace>:<rule>`, so they feed
+risk scoring and intelligence exactly like correlation rules. Rules can carry
+`severity` (low/medium/high/critical) and `attack_id` meta fields to control
+that mapping; severity defaults to medium.
+
+YARA requires the optional `yara-python` dependency and works fully offline.
+A starter pack lives in `examples/yara_rules/`.
+
 ## ATT&CK metadata
 
 Every built-in rule carries static `attack_ids` — the MITRE ATT&CK technique IDs the rule indicates — and rule packs can declare the same field per rule. Triggered detections expose `attack_ids`, and the Threat Intelligence Engine consumes them as corroborating technique evidence (see [THREAT_INTELLIGENCE.md](THREAT_INTELLIGENCE.md)). A test asserts that every referenced ID exists in the bundled ATT&CK catalog, so rules and catalog cannot drift apart.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,6 +53,40 @@ formats, richer memory-image analysis, and provider-specific VM integrations.
 Any new parser or decoder should land with a labeled positive/negative corpus
 slice and resource-bound regression tests.
 
+## Enterprise-competitiveness track
+
+Ordered by leverage. Each item ships incrementally behind Titan's existing
+constraints: deterministic, bounded, offline-first, fail-closed.
+
+1. **Detection content at scale.** YARA scanning of every artifact-graph
+   node shipped (see DETECTION_AND_RISK.md); next: grow the built-in rule
+   library and starter packs aggressively, expand the calibration corpus
+   toward thousands of labeled cases, and publish per-rule precision/recall
+   from the calibration gate.
+2. **Malware config extraction.** Family identification plus C2/config
+   recovery (addresses, keys, campaign ids) as isolated manifest plugins on
+   the existing out-of-process worker substrate, with a documented extractor
+   SDK and a seed set of extractors for prevalent families.
+3. **Format coverage depth.** .NET assembly structure, MSI/NSIS/InnoSetup
+   installers, OneNote, RTF exploit structures, Excel 4.0 XLM macros, VBA
+   p-code, PDF stream filters with JavaScript extraction, Mach-O, APK/DEX,
+   VHD/VHDX, and password-protected archives (`infected`). Every new parser
+   lands with a labeled corpus slice and resource-bound regression tests.
+4. **Service mode.** A `titan-server` deployment shape: REST API, work
+   queue, horizontally scalable workers, artifact store, and hash-based
+   dedup cache (reference architecture: CCCS Assemblyline), so Titan runs as
+   pipeline infrastructure rather than a single-process CLI.
+5. **Bounded emulation.** Instruction-budgeted, no-I/O emulation for
+   shellcode (Unicorn-class) and sandboxed JavaScript evaluation for
+   deobfuscation — deterministic and fail-closed by construction, extending
+   static analysis past string-building obfuscation without becoming a
+   sandbox.
+6. **Proof and ecosystem.** Published benchmark runs against public corpora,
+   a public accuracy dashboard fed by calibration output, third-party audit
+   of the parsing surface (extending the fuzz harness), MISP/STIX export,
+   and a community plugin registry. Positioning: forensic-grade,
+   deterministic, offline-first, court-ready provenance.
+
 ## Local AI assistant (shipped as Milestone 8)
 
 The requirements that guided the design — optional and disabled by

--- a/docs/report.schema.json
+++ b/docs/report.schema.json
@@ -205,6 +205,17 @@
     "detections": {"type": "array"},
     "risk_assessment": {"type": "object"},
     "enrichment": {"type": "object"},
+    "yara": {
+      "type": "object",
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["completed", "unavailable", "not_configured"]
+        },
+        "matches": {"type": "array"}
+      },
+      "additionalProperties": true
+    },
     "evidence": {
       "type": "object",
       "properties": {

--- a/examples/yara_rules/titan_starter.yar
+++ b/examples/yara_rules/titan_starter.yar
@@ -1,0 +1,87 @@
+/*
+  Titan starter YARA pack.
+
+  These rules are written for Titan's per-node scanning: they assume they
+  will also run against decoded and extracted artifacts, so they match
+  plain-text tradecraft that is usually hidden under encoding layers in
+  the raw input. Severity and ATT&CK metadata flow into Titan detections
+  via the `severity` and `attack_id` meta fields.
+
+  Usage: titan-decoder --file sample --enable-detections \
+             --yara-rules examples/yara_rules
+*/
+
+rule Titan_PowerShell_Download_Cradle
+{
+    meta:
+        description = "PowerShell download cradle (IEX + web download primitives)"
+        severity = "high"
+        attack_id = "T1059.001"
+    strings:
+        $iex1 = "IEX" nocase
+        $iex2 = "Invoke-Expression" nocase
+        $dl1 = "DownloadString" nocase
+        $dl2 = "DownloadFile" nocase
+        $dl3 = "Net.WebClient" nocase
+        $dl4 = "Invoke-WebRequest" nocase
+        $dl5 = "Start-BitsTransfer" nocase
+    condition:
+        any of ($iex*) and any of ($dl*)
+}
+
+rule Titan_Encoded_Command_Invocation
+{
+    meta:
+        description = "PowerShell hidden-window or encoded-command invocation flags"
+        severity = "medium"
+        attack_id = "T1027"
+    strings:
+        $host1 = "powershell" nocase
+        $host2 = "pwsh" nocase
+        $flag1 = "-EncodedCommand" nocase
+        $flag2 = "-enc " nocase
+        $flag3 = "-WindowStyle Hidden" nocase
+        $flag4 = "-ExecutionPolicy Bypass" nocase
+    condition:
+        any of ($host*) and any of ($flag*)
+}
+
+rule Titan_Executable_In_Decoded_Content
+{
+    meta:
+        description = "Windows PE executable recovered from analyzed content"
+        severity = "medium"
+        attack_id = "T1027.009"
+    condition:
+        uint16(0) == 0x5A4D and
+        uint32(uint32(0x3C)) == 0x00004550
+}
+
+rule Titan_UPX_Packed_Executable
+{
+    meta:
+        description = "UPX-packed PE executable"
+        severity = "medium"
+        attack_id = "T1027.002"
+    strings:
+        $upx0 = "UPX0"
+        $upx1 = "UPX1"
+        $upx_sig = "UPX!"
+    condition:
+        uint16(0) == 0x5A4D and 2 of them
+}
+
+rule Titan_JavaScript_Eval_Decode_Chain
+{
+    meta:
+        description = "JavaScript eval over runtime-decoded content"
+        severity = "medium"
+        attack_id = "T1027.013"
+    strings:
+        $chain1 = "eval(String.fromCharCode" nocase
+        $chain2 = "eval(unescape" nocase
+        $chain3 = "eval(atob" nocase
+        $chain4 = "eval(decodeURIComponent" nocase
+    condition:
+        any of them
+}

--- a/tests/golden/expected/cfb_macro.doc.json
+++ b/tests/golden/expected/cfb_macro.doc.json
@@ -248,7 +248,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/golden/expected/gzip_text.bin.json
+++ b/tests/golden/expected/gzip_text.bin.json
@@ -279,7 +279,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/golden/expected/high_entropy.bin.json
+++ b/tests/golden/expected/high_entropy.bin.json
@@ -221,7 +221,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/golden/expected/multi_ioc.txt.json
+++ b/tests/golden/expected/multi_ioc.txt.json
@@ -229,7 +229,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/golden/expected/nested_base64.txt.json
+++ b/tests/golden/expected/nested_base64.txt.json
@@ -248,7 +248,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/golden/expected/pdf_js.pdf.json
+++ b/tests/golden/expected/pdf_js.pdf.json
@@ -249,7 +249,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/golden/expected/plain_iocs.txt.json
+++ b/tests/golden/expected/plain_iocs.txt.json
@@ -228,7 +228,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/golden/expected/xor_url.bin.json
+++ b/tests/golden/expected/xor_url.bin.json
@@ -254,7 +254,15 @@
       "trusted_hashes_path": null,
       "vault_db_path": null,
       "vault_dir": null,
-      "yara_rules_path": null
+      "yara_max_matches": 200,
+      "yara_max_meta_bytes": 4096,
+      "yara_max_nodes": 300,
+      "yara_max_string_bytes": 128,
+      "yara_max_strings_per_match": 8,
+      "yara_rules_dirs": [],
+      "yara_rules_files": [],
+      "yara_rules_path": null,
+      "yara_timeout_seconds": 10
     },
     "limits": {
       "analysis_timeout_seconds": 300,

--- a/tests/test_yara_integration.py
+++ b/tests/test_yara_integration.py
@@ -1,0 +1,182 @@
+"""Tests for bounded, deterministic YARA scanning across the artifact graph."""
+
+import base64
+import json
+
+import pytest
+
+from titan_decoder import cli
+from titan_decoder.config import Config
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.core.yara_scanner import (
+    YaraScanner,
+    yara_matches_to_detections,
+    yara_available,
+)
+
+yara = pytest.importorskip("yara")
+
+MARKER_RULE = """
+rule Titan_Test_Marker {
+  meta:
+    description = "Titan integration test marker"
+    severity = "high"
+    attack_id = "T1105"
+  strings:
+    $a = "titan-yara-marker"
+  condition:
+    $a
+}
+"""
+
+
+def _write_rules(tmp_path, name="marker.yar", body=MARKER_RULE):
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _args(argv):
+    return cli.build_parser().parse_args(argv)
+
+
+def test_yara_matches_decoded_content_invisible_in_raw_input(tmp_path):
+    rules = _write_rules(tmp_path)
+    payload = b"titan-yara-marker http://yara.example/stage"
+    sample = base64.b64encode(payload)
+    engine = TitanEngine()
+    engine.run_analysis(sample)
+    payloads = engine.artifact_payloads()
+
+    scanner = YaraScanner({"enable_yara": True, "yara_rules_path": str(rules)})
+    result = scanner.scan(payloads)
+    assert result["state"] == "completed"
+    matched_nodes = {match["node_id"] for match in result["matches"]}
+    # The marker only exists after base64 decoding, so the match must be on
+    # a decoded node — scanning the raw input alone finds nothing.
+    assert matched_nodes and all(node_id > 0 for node_id in matched_nodes)
+    root_only = YaraScanner({"enable_yara": True, "yara_rules_path": str(rules)}).scan(
+        payloads[:1]
+    )
+    assert root_only["matches"] == []
+
+
+def test_yara_scan_is_deterministic_and_namespaced_by_file(tmp_path):
+    directory = tmp_path / "rules"
+    directory.mkdir()
+    _write_rules(directory, "b_second.yar", MARKER_RULE.replace("Marker", "Second"))
+    _write_rules(directory, "a_first.yar")
+    scanner_config = {"enable_yara": True, "yara_rules_dirs": [str(directory)]}
+    payloads = [(0, b"prefix titan-yara-marker suffix")]
+
+    first = YaraScanner(scanner_config).scan(payloads)
+    second = YaraScanner(scanner_config).scan(payloads)
+    assert first == second
+    assert first["state"] == "completed"
+    assert [match["namespace"] for match in first["matches"]] == [
+        "a_first",
+        "b_second",
+    ]
+    match = first["matches"][0]
+    assert match["rule"] == "Titan_Test_Marker"
+    assert match["severity"] == "high"
+    assert match["meta"]["attack_id"] == "T1105"
+    assert match["strings"][0]["data"] == "titan-yara-marker"
+
+
+def test_yara_fails_closed_when_rules_are_missing_or_disabled(tmp_path):
+    assert yara_available() is True
+    missing = YaraScanner(
+        {"enable_yara": True, "yara_rules_path": str(tmp_path / "missing.yar")}
+    ).scan([(0, b"data")])
+    assert missing["state"] == "unavailable"
+    assert "not found" in missing["reason"]
+
+    disabled = YaraScanner({}).scan([(0, b"data")])
+    assert disabled["state"] == "not_configured"
+
+    broken = _write_rules(tmp_path, "broken.yar", "rule Broken { condition: ")
+    invalid = YaraScanner({"enable_yara": True, "yara_rules_path": str(broken)}).scan(
+        [(0, b"data")]
+    )
+    assert invalid["state"] == "unavailable"
+    assert "compilation failed" in invalid["reason"]
+
+
+def test_yara_match_limit_is_enforced(tmp_path):
+    rules = _write_rules(tmp_path)
+    payloads = [(0, b"titan-yara-marker"), (1, b"titan-yara-marker again")]
+    result = YaraScanner(
+        {
+            "enable_yara": True,
+            "yara_rules_path": str(rules),
+            "yara_max_matches": 1,
+        }
+    ).scan(payloads)
+    assert len(result["matches"]) == 1
+    assert result["match_limit_reached"] is True
+
+
+def test_yara_matches_convert_to_grouped_detections(tmp_path):
+    rules = _write_rules(tmp_path)
+    payloads = [(0, b"titan-yara-marker"), (3, b"titan-yara-marker again")]
+    result = YaraScanner({"enable_yara": True, "yara_rules_path": str(rules)}).scan(
+        payloads
+    )
+    detections = yara_matches_to_detections(result)
+    assert len(detections) == 1
+    detection = detections[0]
+    assert detection["rule_id"] == "YARA:marker:Titan_Test_Marker"
+    assert detection["severity"] == "high"
+    assert detection["node_ids"] == [0, 3]
+    assert detection["attack_ids"] == ["T1105"]
+    assert detection["source"] == {
+        "type": "yara",
+        "namespace": "marker",
+        "rule": "Titan_Test_Marker",
+    }
+    assert yara_matches_to_detections({"state": "unavailable", "matches": []}) == []
+
+
+def test_cli_detection_stage_runs_yara_and_feeds_risk(tmp_path):
+    rules = _write_rules(tmp_path)
+    sample = base64.b64encode(b"titan-yara-marker http://yara.example/stage")
+    args = _args(["--file", "x", "--enable-detections", "--yara-rules", str(rules)])
+    config = Config(tmp_path / "missing-config.json")
+    engine = TitanEngine(config)
+    report = engine.run_analysis(sample)
+
+    detections, risk = cli.run_detections_stage(args, config, report, None, engine)
+
+    assert report["yara"]["state"] == "completed"
+    yara_detections = [
+        item for item in detections if item["source"].get("type") == "yara"
+    ]
+    assert [item["rule_id"] for item in yara_detections] == [
+        "YARA:marker:Titan_Test_Marker"
+    ]
+    assert risk["breakdown"]["yara"] > 0
+    assert any(reason.startswith("YARA:") for reason in risk["top_reasons"])
+    # The persisted report stays JSON-serializable with the new section.
+    json.dumps(report)
+
+
+def test_cli_offline_mode_keeps_yara_enabled(tmp_path):
+    rules = _write_rules(tmp_path)
+    args = _args(
+        [
+            "--file",
+            "x",
+            "--offline",
+            "--enable-detections",
+            "--yara-rules",
+            str(rules),
+        ]
+    )
+    config = Config(tmp_path / "missing-config.json")
+    cli.apply_runtime_config(args, config)
+    engine = TitanEngine(config)
+    report = engine.run_analysis(base64.b64encode(b"titan-yara-marker"))
+    cli.run_detections_stage(args, config, report, None, engine)
+    assert report["yara"]["state"] == "completed"
+    assert report["yara"]["matches"]

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -364,6 +364,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory of detection rule packs to load (.json/.yml/.yaml). Can be repeated.",
     )
     parser.add_argument(
+        "--yara-rules",
+        action="append",
+        type=Path,
+        help=(
+            "YARA rules file or directory of .yar/.yara files, scanned against "
+            "every artifact-graph node (raw, decoded, and extracted content). "
+            "Implies YARA scanning for the run; requires --enable-detections "
+            "and the optional yara-python dependency. Can be repeated."
+        ),
+    )
+    parser.add_argument(
         "--rules-validate",
         action="append",
         type=Path,
@@ -695,7 +706,8 @@ def apply_runtime_config(args, config) -> None:
     if args.offline:
         config.set("enable_geo_enrichment", False)
         config.set("enable_whois", False)
-        config.set("enable_yara", False)
+        # YARA is a purely local scan and stays available offline; only the
+        # network-dependent enrichment providers are disabled here.
 
     # Extra plugin directories: merged into config so the engine's plugin
     # manager discovers them alongside the configured and default dirs.
@@ -1012,6 +1024,49 @@ def _run_detection_plugins(args, config, report, iocs, engine):
     return results
 
 
+def _run_yara_stage(args, config, report, detections, engine):
+    """Scan every artifact-graph node with configured YARA rules.
+
+    ``--yara-rules`` sources are merged into the configured file/directory
+    lists and imply enabling YARA for the run. The full bounded scan result
+    is persisted as ``report["yara"]``, and matches are appended to
+    ``detections`` (one entry per distinct rule, carrying all matched node
+    ids) so they feed risk scoring and intelligence like any other rule.
+    Returns the raw match list for the risk engine's YARA weighting.
+    """
+    from .core.yara_scanner import YaraScanner, yara_matches_to_detections
+
+    cli_sources = list(getattr(args, "yara_rules", None) or [])
+    if cli_sources:
+        files = list(config.get("yara_rules_files", []) or [])
+        dirs = list(config.get("yara_rules_dirs", []) or [])
+        for source in cli_sources:
+            source = Path(source)
+            if source.is_dir():
+                dirs.append(str(source))
+            else:
+                files.append(str(source))
+        config.set("yara_rules_files", files)
+        config.set("yara_rules_dirs", dirs)
+        config.set("enable_yara", True)
+    if not config.get("enable_yara", False):
+        return None
+
+    scanner = YaraScanner(config._config)
+    payloads = engine.artifact_payloads() if engine is not None else []
+    result = scanner.scan(payloads)
+    report["yara"] = result
+    detections.extend(yara_matches_to_detections(result))
+    if result.get("state") != "completed":
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "YARA scanning was requested but did not run: %s",
+            result.get("reason") or result.get("state"),
+        )
+    return result.get("matches") or None
+
+
 def run_detections_stage(args, config, report, evidence_result, engine=None):
     """Run detection rules, detection plugins, and risk scoring if requested.
 
@@ -1055,8 +1110,12 @@ def run_detections_stage(args, config, report, evidence_result, engine=None):
             report.setdefault("meta", {})
             report["meta"]["rule_packs"] = rules_engine.rule_packs
 
+        yara_matches = _run_yara_stage(args, config, report, detections, engine)
+
         risk_engine = RiskScoringEngine()
-        risk_assessment = risk_engine.compute_risk_score(report, iocs, detections)
+        risk_assessment = risk_engine.compute_risk_score(
+            report, iocs, detections, yara_matches=yara_matches
+        )
 
         # Persist these in the report for downstream tooling.
         report["detections"] = detections

--- a/titan_decoder/config.py
+++ b/titan_decoder/config.py
@@ -111,6 +111,16 @@ class Config:
         "correlation_db_path": None,
         "enable_yara": False,  # Optional YARA scanning on decoded artifacts
         "yara_rules_path": None,
+        # Additional YARA sources and bounds. Directories are compiled with
+        # one namespace per rule file so match provenance survives merging.
+        "yara_rules_files": [],  # list of individual rule files
+        "yara_rules_dirs": [],  # list of directories of .yar/.yara files
+        "yara_timeout_seconds": 10,  # per-payload scan timeout
+        "yara_max_matches": 200,  # total matches recorded per run
+        "yara_max_nodes": 300,  # payloads scanned per run (node order)
+        "yara_max_meta_bytes": 4096,  # serialized meta captured per match
+        "yara_max_strings_per_match": 8,
+        "yara_max_string_bytes": 128,
         # Fail-closed assurance providers. Attestations are JSON documents named
         # <sha256>.json and are accepted only when their embedded hash matches.
         "enable_assurance": True,

--- a/titan_decoder/core/assurance.py
+++ b/titan_decoder/core/assurance.py
@@ -479,52 +479,9 @@ class AssuranceEngine:
         return sorted(values)
 
     def _scan_yara(self, payloads: Sequence[tuple[int, bytes]]) -> dict[str, Any]:
-        if not self.config.get("enable_yara", False):
-            return {"state": "not_configured", "matches": []}
-        rules_path = self.config.get("yara_rules_path")
-        if not rules_path or not Path(str(rules_path)).expanduser().is_file():
-            return {
-                "state": "unavailable",
-                "matches": [],
-                "reason": "configured YARA rules file was not found",
-            }
-        if not payloads:
-            return {
-                "state": "unavailable",
-                "matches": [],
-                "reason": "raw artifact payloads were not supplied to the scanner",
-            }
-        try:
-            import yara
-        except ImportError:
-            return {
-                "state": "unavailable",
-                "matches": [],
-                "reason": "yara-python is not installed",
-            }
-        try:
-            rules = yara.compile(filepath=str(Path(str(rules_path)).expanduser()))
-            matches: list[dict[str, Any]] = []
-            for node_id, data in payloads[:300]:
-                for match in rules.match(data=data, timeout=10):
-                    matches.append(
-                        {
-                            "node_id": node_id,
-                            "rule": str(match.rule),
-                            "tags": [str(tag) for tag in match.tags],
-                        }
-                    )
-                    if len(matches) >= 100:
-                        break
-                if len(matches) >= 100:
-                    break
-            return {"state": "completed", "matches": matches}
-        except Exception as exc:
-            return {
-                "state": "unavailable",
-                "matches": [],
-                "reason": f"YARA scan failed: {type(exc).__name__}",
-            }
+        from .yara_scanner import YaraScanner
+
+        return YaraScanner(self.config).scan(list(payloads or []))
 
     @staticmethod
     def _root_hash(report: Mapping[str, Any]) -> str | None:

--- a/titan_decoder/core/yara_scanner.py
+++ b/titan_decoder/core/yara_scanner.py
@@ -1,0 +1,284 @@
+"""Deterministic, bounded YARA scanning over every artifact-graph node.
+
+YARA support is an optional dependency (``yara-python``). The scanner is
+fail-closed and explicit about its state: when YARA was requested but the
+library or the configured rules are unavailable, the result says so instead
+of silently scanning nothing. Scanning covers every node payload in graph
+order — including decoded and extracted content — so signatures match
+content that a scan of the raw input alone would never see.
+
+Every output is deterministic: rule files load in sorted order, one
+namespace per file, matches are reported in (node order, namespace, rule)
+order, and all captured data (tags, meta, matched strings) is bounded and
+sorted.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import re
+from typing import Any, Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+_RULE_SUFFIXES = (".yar", ".yara")
+_NAMESPACE_SAFE = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def yara_available() -> bool:
+    """Return True when the optional yara-python dependency is importable."""
+    try:
+        import yara  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _namespace_for(path: Path) -> str:
+    return _NAMESPACE_SAFE.sub("_", path.stem)[:100] or "rules"
+
+
+def _severity_from_meta(meta: Mapping[str, Any]) -> str:
+    value = str(meta.get("severity", "")).lower()
+    return value if value in {"low", "medium", "high", "critical"} else "medium"
+
+
+class YaraScanner:
+    """Compile configured YARA rules and scan node payloads with bounds."""
+
+    def __init__(self, config: Mapping[str, Any]):
+        self.enabled = bool(config.get("enable_yara", False))
+        self.rules_path = config.get("yara_rules_path")
+        self.rules_files = list(config.get("yara_rules_files") or [])
+        self.rules_dirs = list(config.get("yara_rules_dirs") or [])
+        self.timeout_seconds = max(1, int(config.get("yara_timeout_seconds", 10)))
+        self.max_matches = max(1, int(config.get("yara_max_matches", 200)))
+        self.max_nodes = max(1, int(config.get("yara_max_nodes", 300)))
+        self.max_meta_bytes = max(64, int(config.get("yara_max_meta_bytes", 4096)))
+        self.max_strings_per_match = max(
+            0, int(config.get("yara_max_strings_per_match", 8))
+        )
+        self.max_string_bytes = max(8, int(config.get("yara_max_string_bytes", 128)))
+        self._rules: Any = None
+        self._sources: list[str] = []
+        self._load_error: str | None = None
+        self._loaded = False
+
+    # -- rule loading ----------------------------------------------------
+
+    def _rule_files(self) -> list[Path]:
+        """Resolve configured sources to a sorted, de-duplicated file list."""
+        files: list[Path] = []
+        single_files = [self.rules_path] if self.rules_path else []
+        for value in (*single_files, *self.rules_files):
+            candidate = Path(str(value)).expanduser()
+            if not candidate.is_file():
+                raise FileNotFoundError(
+                    f"configured YARA rules file was not found: {candidate}"
+                )
+            files.append(candidate)
+        for value in self.rules_dirs:
+            directory = Path(str(value)).expanduser()
+            if not directory.is_dir():
+                raise FileNotFoundError(
+                    f"configured YARA rules directory was not found: {directory}"
+                )
+            found = [
+                path
+                for path in directory.iterdir()
+                if path.is_file() and path.suffix.lower() in _RULE_SUFFIXES
+            ]
+            if not found:
+                raise FileNotFoundError(
+                    f"YARA rules directory contains no .yar/.yara files: {directory}"
+                )
+            files.extend(found)
+        unique = sorted(
+            {path.resolve() for path in files},
+            key=lambda path: path.as_posix().casefold(),
+        )
+        if not unique:
+            raise FileNotFoundError("no YARA rules were configured")
+        return unique
+
+    def load(self) -> None:
+        """Compile all configured rule files, one namespace per file."""
+        if self._loaded:
+            return
+        self._loaded = True
+        if not self.enabled:
+            return
+        try:
+            import yara
+        except ImportError:
+            self._load_error = "yara-python is not installed"
+            return
+        try:
+            files = self._rule_files()
+            filepaths: dict[str, str] = {}
+            for path in files:
+                namespace = _namespace_for(path)
+                index = 2
+                while namespace in filepaths:
+                    namespace = f"{_namespace_for(path)}_{index}"
+                    index += 1
+                filepaths[namespace] = str(path)
+            self._rules = yara.compile(filepaths=filepaths)
+            self._sources = sorted(filepaths.values(), key=str.casefold)
+        except yara.Error as exc:
+            self._load_error = f"YARA rule compilation failed: {exc}"[:1000]
+        except (OSError, ValueError) as exc:
+            self._load_error = str(exc)[:1000]
+
+    # -- scanning --------------------------------------------------------
+
+    def _capture_strings(self, match: Any) -> list[dict[str, Any]]:
+        captured: list[dict[str, Any]] = []
+        for string in list(getattr(match, "strings", ()))[: self.max_strings_per_match]:
+            instances = list(getattr(string, "instances", ()))[:1]
+            snippet = ""
+            offset = None
+            if instances:
+                raw = bytes(instances[0].matched_data)[: self.max_string_bytes]
+                snippet = raw.decode("ascii", errors="backslashreplace")
+                offset = int(instances[0].offset)
+            captured.append(
+                {
+                    "identifier": str(string.identifier),
+                    "offset": offset,
+                    "data": snippet,
+                }
+            )
+        return sorted(captured, key=lambda item: str(item["identifier"]))
+
+    def _capture_meta(self, match: Any) -> dict[str, Any]:
+        meta: dict[str, Any] = {}
+        budget = self.max_meta_bytes
+        for key in sorted(getattr(match, "meta", {}) or {}):
+            value = match.meta[key]
+            if not isinstance(value, (bool, int)):
+                value = str(value)[:512]
+            cost = len(str(key)) + len(str(value))
+            if cost > budget:
+                break
+            budget -= cost
+            meta[str(key)] = value
+        return meta
+
+    def scan(self, payloads: Sequence[tuple[int, bytes]]) -> dict[str, Any]:
+        """Scan node payloads and return a deterministic result envelope."""
+        if not self.enabled:
+            return {"state": "not_configured", "matches": []}
+        self.load()
+        if self._load_error is not None:
+            return {
+                "state": "unavailable",
+                "matches": [],
+                "reason": self._load_error,
+            }
+        if self._rules is None:
+            return {
+                "state": "unavailable",
+                "matches": [],
+                "reason": "YARA rules were not loaded",
+            }
+        if not payloads:
+            return {
+                "state": "unavailable",
+                "matches": [],
+                "reason": "raw artifact payloads were not supplied to the scanner",
+            }
+        import yara
+
+        matches: list[dict[str, Any]] = []
+        scanned = 0
+        errors = 0
+        truncated = False
+        for node_id, data in payloads[: self.max_nodes]:
+            if not isinstance(data, bytes) or not data:
+                continue
+            scanned += 1
+            try:
+                found = self._rules.match(data=data, timeout=self.timeout_seconds)
+            except yara.TimeoutError:
+                errors += 1
+                continue
+            except yara.Error:
+                errors += 1
+                continue
+            for match in sorted(
+                found, key=lambda item: (str(item.namespace), str(item.rule))
+            ):
+                meta = self._capture_meta(match)
+                matches.append(
+                    {
+                        "node_id": int(node_id),
+                        "namespace": str(match.namespace),
+                        "rule": str(match.rule),
+                        "tags": sorted(str(tag) for tag in match.tags),
+                        "meta": meta,
+                        "severity": _severity_from_meta(meta),
+                        "strings": self._capture_strings(match),
+                    }
+                )
+                if len(matches) >= self.max_matches:
+                    truncated = True
+                    break
+            if truncated:
+                break
+        return {
+            "state": "completed",
+            "rules_sources": list(self._sources),
+            "scanned_nodes": scanned,
+            "scan_errors": errors,
+            "match_limit_reached": truncated,
+            "matches": matches,
+        }
+
+
+def yara_matches_to_detections(
+    scan_result: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Convert scan matches into detection entries for the detection stage.
+
+    Matches of the same rule across several nodes collapse into one detection
+    carrying every matched node id, so risk scoring weighs distinct
+    signatures rather than repetition of one signature.
+    """
+    matches = scan_result.get("matches")
+    if scan_result.get("state") != "completed" or not isinstance(matches, list):
+        return []
+    grouped: dict[str, dict[str, Any]] = {}
+    for match in matches:
+        if not isinstance(match, Mapping):
+            continue
+        namespace = str(match.get("namespace") or "rules")
+        rule = str(match.get("rule") or "")
+        if not rule:
+            continue
+        rule_id = f"YARA:{namespace}:{rule}"
+        raw_meta = match.get("meta")
+        meta: Mapping[str, Any] = raw_meta if isinstance(raw_meta, Mapping) else {}
+        entry = grouped.setdefault(
+            rule_id,
+            {
+                "rule_id": rule_id,
+                "name": str(meta.get("description") or rule)[:200],
+                "description": str(meta.get("description") or "")[:1000],
+                "severity": str(match.get("severity") or "medium"),
+                "attack_ids": [],
+                "node_ids": [],
+                "source": {"type": "yara", "namespace": namespace, "rule": rule},
+            },
+        )
+        node_id = match.get("node_id")
+        if isinstance(node_id, int) and node_id not in entry["node_ids"]:
+            entry["node_ids"].append(node_id)
+        attack_id = str(meta.get("attack_id") or "")
+        if attack_id and attack_id not in entry["attack_ids"]:
+            entry["attack_ids"].append(attack_id)
+    for entry in grouped.values():
+        entry["node_ids"].sort()
+        entry["attack_ids"].sort()
+    return [grouped[key] for key in sorted(grouped)]


### PR DESCRIPTION
## Summary

First chunk of the enterprise-competitiveness track (now codified in `docs/ROADMAP.md`): first-class, bounded, deterministic YARA scanning wired into the detection stage.

- **Per-node scanning**: `--yara-rules` (repeatable, file or directory) scans **every artifact-graph node** — raw input plus all decoded and extracted content — so signatures match content that a scan of the raw bytes alone would never see (e.g. a base64-wrapped PowerShell cradle is caught on the decoded node).
- **New `titan_decoder/core/yara_scanner.py`**: rule directories compile with one namespace per file in sorted order; matches report in (node, namespace, rule) order; per-payload scan timeouts; node/match/meta/matched-string capture all capped via new config keys. Fail-closed result envelope (`completed` / `unavailable` / `not_configured` with reason) persisted as the report's `yara` section.
- **Detections + risk**: matches convert to `YARA:<namespace>:<rule>` detections — grouped per rule with all matched node ids, severity and ATT&CK ids from rule meta — and feed the risk engine's previously-unwired `yara_matches` weighting.
- **Shared scanner**: assurance's static YARA control now delegates to the same scanner, so assurance and Deep Scan gain rules-directory support and bounded capture.
- **Offline fix**: YARA stays active under `--offline`; it is a purely local scan and was previously disabled alongside network enrichment providers.
- **Content + docs**: starter rule pack in `examples/yara_rules/` tuned for per-node scanning; docs in DETECTION_AND_RISK.md and CLI_REFERENCE.md; `yara` section added to the report schema; golden fixtures regenerated for the new config keys in run manifests (config-key diff only, no behavioral changes).

## Checklist

- [x] I am not including real incident evidence, logs, browser history databases, or other sensitive data.
- [x] I am not including secrets (API keys/tokens/passwords).
- [x] I ran tests locally (`pytest -q`).
- [x] I updated docs if flags/output contracts changed (CLI_REFERENCE, DETECTION_AND_RISK, README, report schema, CHANGELOG, ROADMAP).
- [x] Changes are dependency-light and preserve offline-first, deterministic behavior (yara-python remains optional; scanner is fail-closed when absent).

## Testing

- Command(s) run:

```bash
pytest -q        # 754 passed, 1 skipped
ruff check .     # clean
ruff format --check .
mypy titan_decoder  # no issues in 112 files
```

- Notes: new `tests/test_yara_integration.py` (7 tests, importorskip-gated on yara-python) covers decoded-node matching invisible in raw input, deterministic namespaced directory loading, fail-closed missing/broken/disabled states, match-limit enforcement, grouped detection conversion, CLI detection-stage integration feeding risk, and offline-mode YARA availability.

## Screenshots / Output (optional)

```
$ titan-decoder --file cradle.b64 --enable-detections --yara-rules examples/yara_rules
yara: completed, 1 match
  node 1 (decoded): titan_starter:Titan_PowerShell_Download_Cradle severity=high
detections: ["YARA:titan_starter:Titan_PowerShell_Download_Cradle", "TITAN-003"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYkQaMWZqLp4GKPZ7XGVFB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYkQaMWZqLp4GKPZ7XGVFB)_