### PR TITLE
Fix Brotli stream validation

### DIFF
--- a/tests/test_advanced_decoders.py
+++ b/tests/test_advanced_decoders.py
@@ -99,6 +99,21 @@ def test_brotli_decoder_round_trip_when_dependency_is_available():
     assert BrotliDecoder(max_output=4).decode(encoded) == (encoded, False)
 
 
+def test_brotli_decoder_preserves_binary_whitespace_and_rejects_truncation():
+    brotli = pytest.importorskip("brotli")
+    source = b"payload-14-AAAAAAAAAAAAAA"
+    # This complete stream ends in form-feed (0x0c).  Treating the opaque
+    # compressed bytes as surrounding text used to strip that byte and
+    # silently return only b"payload" with success=True.
+    compressed = bytes.fromhex("1b1800f81d0936ce72617d90b4d52d31347022a8c2f2ea074d22914b0c")
+    assert brotli.decompress(compressed) == source
+    encoded = b"brotli:" + compressed
+    assert BrotliDecoder().decode(encoded) == (source, True)
+
+    truncated = encoded[:-1]
+    assert BrotliDecoder().decode(truncated) == (truncated, False)
+
+
 def test_zstandard_decoder_round_trip_when_dependency_is_available():
     zstandard = pytest.importorskip("zstandard")
     source = b"bounded Zstandard payload"

--- a/titan_decoder/decoders/advanced.py
+++ b/titan_decoder/decoders/advanced.py
@@ -333,7 +333,10 @@ class BrotliDecoder(Decoder):
         return "Brotli"
 
     def _decode(self, data: bytes) -> bytes | None:
-        value = data.strip()
+        # Only discard whitespace before the textual transport label.  The
+        # bytes after ``brotli:`` are an opaque binary stream, so stripping
+        # them can remove a legitimate final compressed byte.
+        value = data.lstrip()
         if not value.lower().startswith(b"brotli:"):
             return None
         value = value[7:]
@@ -346,6 +349,11 @@ class BrotliDecoder(Decoder):
                 output.extend(decoder.process(value[offset : offset + 64 * 1024]))
                 if len(output) > self.max_output:
                     return None
+            # brotli.Decompressor.process() can return partial output without
+            # raising when the input ends before the stream does.  Never
+            # report that partial evidence as a successful decode.
+            if not decoder.is_finished():
+                return None
             return bytes(output) if output else None
         except Exception:
             return None


### PR DESCRIPTION
## Summary

- preserve opaque Brotli payload bytes instead of stripping trailing binary whitespace
- reject incomplete Brotli streams unless the incremental decoder reaches end-of-stream
- add regression coverage for valid whitespace-ending streams and truncated input

## Root cause

The decoder treated the bytes following the textual `brotli:` marker as surrounding text and called `strip()` on the entire input. A legitimate compressed stream ending in a whitespace-valued byte was therefore truncated. The incremental Brotli API can also return partial output for truncated input without raising, and the decoder did not verify completion before reporting success.

## Impact

Titan no longer reports partial or corrupted Brotli output as a successful decode, preventing downstream analysis from operating on incomplete evidence.

## Validation

- `python -m pytest -q`: 755 passed, 9 skipped
- `python -m ruff check titan_decoder tests`: passed
- `python -m mypy titan_decoder`: passed
- `git diff --check`: passed
