### PR TITLE
Add isolated config extractor SDK

### DIFF
--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -1,7 +1,8 @@
 # Plugin SDK v1
 
-Titan can be extended without modifying the core through four plugin SDKs:
-**decoders**, **analyzers**, **detections**, and **report sections**. All
+Titan can be extended without modifying the core through five plugin SDKs:
+**decoders**, **analyzers**, **detections**, **malware configuration
+extractors**, and **report sections**. All
 public types live in `titan_decoder.plugins.api` — third-party plugins import
 only from that module; it is the compatibility surface covered by the
 versioned API contract.
@@ -13,7 +14,7 @@ Two styles are supported side by side:
 | Style | API | Layout | Capabilities |
 |---|---|---|---|
 | Single-file | 1.0 | one `.py` file in a plugin directory | decoder, analyzer |
-| Manifest | 1.1 | a directory with `titan-plugin.json` + entry-point module | decoder, analyzer, detection, report |
+| Manifest | 1.1+ | a directory with `titan-plugin.json` + entry-point module | decoder, analyzer, detection, extractor, report |
 
 Plugin directories are searched in this order: `plugin_dirs` from
 configuration, `--plugin-dir` CLI arguments, `~/.titan_decoder/plugins`, and
@@ -21,11 +22,14 @@ the built-in plugin path. Every directory is scanned for both styles.
 
 ## API versioning
 
-The engine provides `PLUGIN_API_VERSION` (currently `1.1`, MAJOR.MINOR):
+The engine provides `PLUGIN_API_VERSION` (currently `1.2`, MAJOR.MINOR):
 
 - **MAJOR** bump = breaking change to base-class signatures or semantics.
 - **MINOR** bump = additive, backward-compatible extension. (`1.1` added the
   manifest SDK; every API `1.0` plugin still loads and runs unchanged.)
+
+API 1.2 adds the extractor capability and `ConfigExtraction`; older 1.0/1.1
+plugins remain compatible.
 
 Single-file plugins may declare a module-level `PLUGIN_API_VERSION`; they are
 skipped on a MAJOR mismatch. Manifest plugins must declare `api_version` and
@@ -156,6 +160,36 @@ Rules of the road (enforced at load and validation time):
 - Rule IDs must be unique across all loaded plugins.
 - At most 200 findings per plugin per run are accepted.
 
+## Malware configuration extractor SDK
+
+```python
+from titan_decoder.plugins.api import ConfigExtraction, ExtractorPlugin
+
+class FamilyConfigExtractor(ExtractorPlugin):
+    @property
+    def name(self):
+        return "Family Config"
+
+    def can_extract(self, data, context=None):
+        return data.startswith(b"FAMILY-CONFIG|")
+
+    def extract(self, data, context=None):
+        return [ConfigExtraction(
+            family="ExampleFamily",
+            confidence=0.95,
+            values={"sleep_ms": 5000},
+            c2=("https://c2.example/gate",),
+            keys=("001122",),
+            campaign_id="red-team",
+        )]
+```
+
+Extractors run over every raw, decoded, and extracted artifact node. Results
+are bounded, sorted, and stored in `report["config_extractions"]` with the
+source node ID and plugin name. Manifest extractors use the same isolated,
+offline worker as other plugin capabilities. `values` and `metadata` must be
+JSON-serializable; `confidence` must be between 0 and 1.
+
 ## Report SDK
 
 ```python
@@ -261,7 +295,7 @@ legacy plugin.
 
 Complete working examples — one per capability — live in
 `examples/plugins/`: `rot47_decoder`, `string_analyzer`, `marker_detection`,
-and `summary_report`. All four pass `--plugin-validate` and are exercised by
+`config_extractor`, and `summary_report`. All five pass `--plugin-validate` and are exercised by
 the test suite (`tests/test_plugin_sdk.py`,
 `tests/test_plugin_sdk_integration.py`).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -64,9 +64,10 @@ constraints: deterministic, bounded, offline-first, fail-closed.
    toward thousands of labeled cases, and publish per-rule precision/recall
    from the calibration gate.
 2. **Malware config extraction.** Family identification plus C2/config
-   recovery (addresses, keys, campaign ids) as isolated manifest plugins on
-   the existing out-of-process worker substrate, with a documented extractor
-   SDK and a seed set of extractors for prevalent families.
+   recovery (addresses, keys, campaign ids) now has a documented API 1.2
+   extractor SDK, isolated-worker transport, validation, report integration,
+   and a complete synthetic example; next: ship and calibrate the seed set of
+   extractors for prevalent families.
 3. **Format coverage depth.** .NET assembly structure, MSI/NSIS/InnoSetup
    installers, OneNote, RTF exploit structures, Excel 4.0 XLM macros, VBA
    p-code, PDF stream filters with JavaScript extraction, Mach-O, APK/DEX,

--- a/examples/plugins/config_extractor/plugin.py
+++ b/examples/plugins/config_extractor/plugin.py
@@ -1,0 +1,37 @@
+"""Example malware-configuration extractor for a synthetic beacon format."""
+
+from titan_decoder.plugins.api import ConfigExtraction, ExtractorPlugin
+
+
+class TitanBeaconConfigExtractor(ExtractorPlugin):
+    name = "Titan Beacon Config"
+    _MARKER = b"TITAN-BEACON|"
+
+    def can_extract(self, data, context=None):
+        return data.startswith(self._MARKER) and len(data) <= 64 * 1024
+
+    def extract(self, data, context=None):
+        if not self.can_extract(data, context):
+            return []
+        values = {}
+        for field in data[len(self._MARKER) :].split(b"|")[:32]:
+            key, separator, value = field.partition(b"=")
+            if not separator:
+                continue
+            label = key.decode("ascii", errors="ignore").strip().lower()[:64]
+            text = value.decode("utf-8", errors="replace").strip()[:4096]
+            if label and text:
+                values[label] = text
+        c2 = (values["c2"],) if "c2" in values else ()
+        keys = (values["key"],) if "key" in values else ()
+        return [
+            ConfigExtraction(
+                family="TitanBeacon",
+                confidence=1.0,
+                values=values,
+                c2=c2,
+                keys=keys,
+                campaign_id=values.get("campaign"),
+                metadata={"format": "synthetic-example-v1"},
+            )
+        ]

--- a/examples/plugins/config_extractor/titan-plugin.json
+++ b/examples/plugins/config_extractor/titan-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0",
+  "id": "example.config-extractor",
+  "name": "Titan Beacon Config Extractor",
+  "version": "1.0.0",
+  "api_version": "1.2.0",
+  "entry_point": "plugin:TitanBeaconConfigExtractor",
+  "capabilities": ["extractor"],
+  "description": "Example bounded extractor for a synthetic beacon configuration envelope.",
+  "author": "Titan examples",
+  "license": "AGPL-3.0-or-later",
+  "permissions": [],
+  "dependencies": {}
+}

--- a/schemas/titan-plugin-manifest-v1.0.schema.json
+++ b/schemas/titan-plugin-manifest-v1.0.schema.json
@@ -48,6 +48,7 @@
           "decoder",
           "analyzer",
           "detection",
+          "extractor",
           "report"
         ]
       }

--- a/tests/golden/expected/cfb_macro.doc.json
+++ b/tests/golden/expected/cfb_macro.doc.json
@@ -127,11 +127,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/golden/expected/gzip_text.bin.json
+++ b/tests/golden/expected/gzip_text.bin.json
@@ -158,11 +158,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/golden/expected/high_entropy.bin.json
+++ b/tests/golden/expected/high_entropy.bin.json
@@ -100,11 +100,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/golden/expected/multi_ioc.txt.json
+++ b/tests/golden/expected/multi_ioc.txt.json
@@ -108,11 +108,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/golden/expected/nested_base64.txt.json
+++ b/tests/golden/expected/nested_base64.txt.json
@@ -127,11 +127,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/golden/expected/pdf_js.pdf.json
+++ b/tests/golden/expected/pdf_js.pdf.json
@@ -128,11 +128,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/golden/expected/plain_iocs.txt.json
+++ b/tests/golden/expected/plain_iocs.txt.json
@@ -107,11 +107,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/golden/expected/xor_url.bin.json
+++ b/tests/golden/expected/xor_url.bin.json
@@ -133,11 +133,12 @@
       ],
       "plugins": {
         "analyzers": [],
-        "api_version": "1.1",
+        "api_version": "1.2",
         "decoders": [],
         "detections": [],
         "errors": [],
         "execution_mode": "isolated",
+        "extractors": [],
         "legacy_plugins_in_process": false,
         "loaded_plugins": [],
         "manifest_plugins": [],

--- a/tests/test_plugin_sdk.py
+++ b/tests/test_plugin_sdk.py
@@ -7,6 +7,7 @@ import pytest
 
 from titan_decoder.plugins import (
     AnalysisArtifact,
+    ConfigExtraction,
     DecodeResult,
     DetectionFinding,
     PluginManager,
@@ -92,6 +93,18 @@ def test_detection_finding_validation():
     assert finding.attack_ids == ("T1", "T2")
     with pytest.raises(ValueError):
         DetectionFinding("X-1", "n", "d", "catastrophic")
+
+
+def test_config_extraction_validation_and_normalization():
+    value = ConfigExtraction(
+        "Example", 0.9, {"port": 443}, c2=("b.example", "a.example", "a.example")
+    )
+    assert value.c2 == ("a.example", "b.example")
+    assert value.to_dict()["values"] == {"port": 443}
+    with pytest.raises(ValueError):
+        ConfigExtraction("", 0.5, {})
+    with pytest.raises(ValueError):
+        ConfigExtraction("Example", 1.1, {})
 
 
 def test_report_section_validation():
@@ -196,10 +209,11 @@ def _write_plugin(
 def test_registry_loads_all_example_plugins():
     manager = PluginManager([EXAMPLES])
     manager.load_plugins()
-    assert len(manager.manifest_plugins) == 4
+    assert len(manager.manifest_plugins) == 5
     assert [d.name for d in manager.decoders] == ["ROT47"]
     assert [a.name for a in manager.analyzers] == ["PrintableStrings"]
     assert [d.name for d in manager.detections] == ["Example Marker"]
+    assert [e.name for e in manager.extractors] == ["Titan Beacon Config"]
     assert [r.name for r in manager.reports] == ["Example Summary"]
     assert manager.errors == []
 

--- a/tests/test_plugin_sdk_integration.py
+++ b/tests/test_plugin_sdk_integration.py
@@ -33,6 +33,7 @@ def test_engine_loads_manifest_plugins_from_config_dir():
         "example.rot47",
         "example.strings",
         "example.marker",
+        "example.config-extractor",
         "example.summary",
     }
 
@@ -79,6 +80,35 @@ def test_detection_plugins_run_in_detection_stage():
     # Plugin findings persist in the report and feed risk scoring.
     assert hit in report["detections"]
     assert risk is not None
+
+
+def test_config_extractor_runs_over_artifact_payloads():
+    engine = TitanEngine(Config())
+    engine.plugin_manager = _manager()
+    engine.run_analysis(
+        b"TITAN-BEACON|c2=https://c2.example/gate|campaign=red|key=001122"
+    )
+    report = {"meta": {}, "nodes": [], "iocs": {}}
+
+    cli.run_config_extractors_stage(_args(quiet=True), Config(), report, engine)
+
+    assert report["config_extractions"] == [
+        {
+            "family": "TitanBeacon",
+            "confidence": 1.0,
+            "values": {
+                "c2": "https://c2.example/gate",
+                "campaign": "red",
+                "key": "001122",
+            },
+            "c2": ["https://c2.example/gate"],
+            "keys": ["001122"],
+            "campaign_id": "red",
+            "metadata": {"format": "synthetic-example-v1"},
+            "node_id": 0,
+            "plugin": "Titan Beacon Config",
+        }
+    ]
 
 
 def test_detection_plugin_failure_never_aborts_stage(tmp_path, capsys):
@@ -141,7 +171,7 @@ def test_cli_plugin_list_mode(capsys):
     args = _args(plugin_list=True, plugin_dir=[EXAMPLES])
     assert cli.handle_info_commands(args, Config()) == 0
     listing = json.loads(capsys.readouterr().out)
-    assert listing["api_version"] == "1.1"
+    assert listing["api_version"] == "1.2"
     assert {p["id"] for p in listing["manifest_plugins"]} >= {"example.rot47"}
     assert "ROT47" in listing["decoders"]
 

--- a/titan_decoder/cli.py
+++ b/titan_decoder/cli.py
@@ -974,6 +974,7 @@ def attach_evidence_stage(args, report, evidence_result) -> None:
 # or report sections per run, mirroring the per-pack rule limit.
 MAX_PLUGIN_FINDINGS = 200
 MAX_PLUGIN_SECTIONS = 20
+MAX_PLUGIN_EXTRACTIONS = 100
 
 
 def _plugin_context(config, args):
@@ -1024,6 +1025,53 @@ def _run_detection_plugins(args, config, report, iocs, engine):
             data["source"] = {"type": "plugin", "plugin": str(plugin.name)}
             results.append(data)
     return results
+
+
+def run_config_extractors_stage(args, config, report, engine) -> None:
+    """Run isolated config extractors over every artifact-graph payload."""
+    manager = getattr(engine, "plugin_manager", None)
+    if manager is None or not getattr(manager, "extractors", None):
+        return
+
+    context = _plugin_context(config, args)
+    results: list[dict[str, Any]] = []
+    for plugin in manager.get_extractors():
+        for node_id, payload in engine.artifact_payloads():
+            if len(results) >= MAX_PLUGIN_EXTRACTIONS:
+                break
+            try:
+                if not plugin.can_extract(payload, context):
+                    continue
+                extracted = list(plugin.extract(payload, context))
+            except Exception as exc:
+                if not args.quiet:
+                    print(
+                        f"Warning: config extractor {plugin.name} failed: {exc}",
+                        file=sys.stderr,
+                    )
+                continue
+            for value in extracted[:MAX_PLUGIN_EXTRACTIONS]:
+                data = value.to_dict() if hasattr(value, "to_dict") else None
+                if not isinstance(data, dict):
+                    continue
+                data["node_id"] = int(node_id)
+                data["plugin"] = str(plugin.name)
+                try:
+                    json.dumps(data)
+                except (TypeError, ValueError):
+                    continue
+                results.append(data)
+                if len(results) >= MAX_PLUGIN_EXTRACTIONS:
+                    break
+    if results:
+        results.sort(
+            key=lambda item: (
+                item.get("family", ""),
+                item.get("node_id", -1),
+                item.get("plugin", ""),
+            )
+        )
+        report["config_extractions"] = results
 
 
 def _run_yara_stage(args, config, report, detections, engine):
@@ -1787,6 +1835,7 @@ def main():
 
     report, engine = run_analysis_stage(args, config, data)
     attach_evidence_stage(args, report, evidence_result)
+    run_config_extractors_stage(args, config, report, engine)
     detections, risk_assessment = run_detections_stage(
         args, config, report, evidence_result, engine=engine
     )

--- a/titan_decoder/plugins/__init__.py
+++ b/titan_decoder/plugins/__init__.py
@@ -10,7 +10,7 @@ Two plugin styles are supported side by side:
 
 - Single-file plugins (API 1.0): a ``.py`` file in a plugin directory.
 - Manifest plugins (API 1.1): a directory with ``titan-plugin.json`` plus
-  its entry-point module, supporting all four SDK capabilities.
+  its entry-point module, supporting all five SDK capabilities.
 
 See docs/PLUGIN_API.md for the full contract.
 """
@@ -19,10 +19,12 @@ from .contracts import (
     PLUGIN_API_VERSION,
     AnalysisArtifact,
     AnalyzerPlugin,
+    ConfigExtraction,
     DecodeResult,
     DecoderPlugin,
     DetectionFinding,
     DetectionPlugin,
+    ExtractorPlugin,
     PluginAnalyzer,
     PluginCapability,
     PluginContext,
@@ -54,10 +56,12 @@ from .validation import (
 __all__ = [
     "AnalysisArtifact",
     "AnalyzerPlugin",
+    "ConfigExtraction",
     "DecodeResult",
     "DecoderPlugin",
     "DetectionFinding",
     "DetectionPlugin",
+    "ExtractorPlugin",
     "LoadedPlugin",
     "PLUGIN_API_VERSION",
     "PLUGIN_MANIFEST_FILENAME",

--- a/titan_decoder/plugins/api.py
+++ b/titan_decoder/plugins/api.py
@@ -25,9 +25,10 @@ Single-file plugin (``myplugin.py`` dropped in a plugin dir, API 1.0)::
                         for b in data)
             return out, out != data
 
-Manifest plugin (a directory with ``titan-plugin.json``, API 1.1) may use any
-of the four SDK base classes — :class:`DecoderPlugin`,
-:class:`AnalyzerPlugin`, :class:`DetectionPlugin`, :class:`ReportPlugin` —
+Manifest plugin (a directory with ``titan-plugin.json``, API 1.1+) may use any
+of the five SDK base classes — :class:`DecoderPlugin`,
+:class:`AnalyzerPlugin`, :class:`DetectionPlugin`, :class:`ExtractorPlugin`,
+:class:`ReportPlugin` —
 with typed results and an optional :class:`PluginContext`. See
 ``examples/plugins/`` for one complete plugin per capability.
 
@@ -44,10 +45,12 @@ from .contracts import (
     PLUGIN_API_VERSION,
     AnalysisArtifact,
     AnalyzerPlugin,
+    ConfigExtraction,
     DecodeResult,
     DecoderPlugin,
     DetectionFinding,
     DetectionPlugin,
+    ExtractorPlugin,
     PluginAnalyzer,
     PluginCapability,
     PluginContext,
@@ -76,10 +79,12 @@ __all__ = [
     "PLUGIN_MANIFEST_SCHEMA_VERSION",
     "AnalysisArtifact",
     "AnalyzerPlugin",
+    "ConfigExtraction",
     "DecodeResult",
     "DecoderPlugin",
     "DetectionFinding",
     "DetectionPlugin",
+    "ExtractorPlugin",
     "PluginAnalyzer",
     "PluginCapability",
     "PluginContext",

--- a/titan_decoder/plugins/contracts.py
+++ b/titan_decoder/plugins/contracts.py
@@ -1,7 +1,7 @@
 """Plugin SDK v1 contracts: base classes and typed results.
 
-This module defines the four plugin SDKs (decoder, analyzer, detection,
-report) plus the typed values they exchange with the engine. Everything here
+This module defines the five plugin SDKs (decoder, analyzer, detection,
+extractor, report) plus the typed values they exchange with the engine. Everything here
 is part of the versioned public API surface re-exported by
 ``titan_decoder.plugins.api`` — third-party plugins import only from there.
 
@@ -30,7 +30,8 @@ from typing import Any, Iterator, Mapping, Sequence
 # History: 1.0 = single-file PluginDecoder/PluginAnalyzer contract.
 #          1.1 = adds the manifest-based SDK (detection/report plugins,
 #                PluginContext, typed results) — purely additive.
-PLUGIN_API_VERSION = "1.1"
+#          1.2 = adds bounded malware configuration extractors.
+PLUGIN_API_VERSION = "1.2"
 
 
 def _api_major(version: str) -> int:
@@ -56,6 +57,7 @@ class PluginCapability(str, Enum):
     DECODER = "decoder"
     ANALYZER = "analyzer"
     DETECTION = "detection"
+    EXTRACTOR = "extractor"
     REPORT = "report"
 
 
@@ -154,6 +156,40 @@ class DetectionFinding:
             "severity": self.severity,
             "attack_ids": list(self.attack_ids),
             "evidence": [dict(item) for item in self.evidence],
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class ConfigExtraction:
+    """One family-attributed configuration recovered from an artifact."""
+
+    family: str
+    confidence: float
+    values: Mapping[str, Any]
+    c2: tuple[str, ...] = ()
+    keys: tuple[str, ...] = ()
+    campaign_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.family.strip():
+            raise ValueError("family must not be empty")
+        if not 0.0 <= float(self.confidence) <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+        object.__setattr__(self, "values", dict(self.values))
+        object.__setattr__(self, "c2", tuple(sorted(set(map(str, self.c2)))))
+        object.__setattr__(self, "keys", tuple(sorted(set(map(str, self.keys)))))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "family": self.family,
+            "confidence": float(self.confidence),
+            "values": dict(self.values),
+            "c2": list(self.c2),
+            "keys": list(self.keys),
+            "campaign_id": self.campaign_id,
             "metadata": dict(self.metadata),
         }
 
@@ -309,6 +345,27 @@ class DetectionPlugin(ABC):
         iocs: Mapping[str, Any],
         context: PluginContext | None = None,
     ) -> Sequence[DetectionFinding]: ...
+
+
+class ExtractorPlugin(ABC):
+    """Malware configuration extractor SDK base class (API 1.2)."""
+
+    api_version = PLUGIN_API_VERSION
+    priority = 0
+
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @abstractmethod
+    def can_extract(
+        self, data: bytes, context: PluginContext | None = None
+    ) -> bool: ...
+
+    @abstractmethod
+    def extract(
+        self, data: bytes, context: PluginContext | None = None
+    ) -> Sequence[ConfigExtraction]: ...
 
 
 class ReportPlugin(ABC):

--- a/titan_decoder/plugins/isolation.py
+++ b/titan_decoder/plugins/isolation.py
@@ -20,10 +20,12 @@ from typing import Any, Mapping
 from .contracts import (
     AnalysisArtifact,
     AnalyzerPlugin,
+    ConfigExtraction,
     DecodeResult,
     DecoderPlugin,
     DetectionFinding,
     DetectionPlugin,
+    ExtractorPlugin,
     PluginContext,
     ReportPlugin,
     ReportSection,
@@ -304,6 +306,42 @@ class IsolatedDetectionProxy(_ProxyBase, DetectionPlugin):
         ]
 
 
+class IsolatedExtractorProxy(_ProxyBase, ExtractorPlugin):
+    def can_extract(self, data: bytes, context: PluginContext | None = None) -> bool:
+        value = self._client.invoke(
+            "can_extract", {"data": base64.b64encode(data).decode("ascii")}, context
+        )
+        if not isinstance(value, bool):
+            raise TypeError("extractor can_extract returned a non-boolean value")
+        return value
+
+    def extract(
+        self, data: bytes, context: PluginContext | None = None
+    ) -> list[ConfigExtraction]:
+        values = self._client.invoke(
+            "extract", {"data": base64.b64encode(data).decode("ascii")}, context
+        )
+        if not isinstance(values, list):
+            raise TypeError("extractor returned an invalid result")
+        return [
+            ConfigExtraction(
+                family=str(value.get("family") or ""),
+                confidence=float(value.get("confidence") or 0.0),
+                values=_metadata_mapping(value.get("values")),
+                c2=tuple(value.get("c2") or ()),
+                keys=tuple(value.get("keys") or ()),
+                campaign_id=(
+                    str(value["campaign_id"])
+                    if value.get("campaign_id") is not None
+                    else None
+                ),
+                metadata=_metadata_mapping(value.get("metadata")),
+            )
+            for value in values[: self._client.max_children]
+            if isinstance(value, dict)
+        ]
+
+
 class IsolatedReportProxy(_ProxyBase, ReportPlugin):
     def build_sections(
         self,
@@ -351,6 +389,7 @@ def build_isolated_proxies(
             "decoder": IsolatedDecoderProxy,
             "analyzer": IsolatedAnalyzerProxy,
             "detection": IsolatedDetectionProxy,
+            "extractor": IsolatedExtractorProxy,
             "report": IsolatedReportProxy,
         }[capability]
         proxies.append(proxy_type(client, metadata))

--- a/titan_decoder/plugins/registry.py
+++ b/titan_decoder/plugins/registry.py
@@ -26,6 +26,7 @@ from .contracts import (
     AnalyzerPlugin,
     DecoderPlugin,
     DetectionPlugin,
+    ExtractorPlugin,
     PluginAnalyzer,
     PluginDecoder,
     ReportPlugin,
@@ -82,6 +83,7 @@ class PluginManager:
         self.decoders: list[PluginDecoder] = []
         self.analyzers: list[PluginAnalyzer] = []
         self.detections: list[DetectionPlugin] = []
+        self.extractors: list[ExtractorPlugin] = []
         self.reports: list[ReportPlugin] = []
         self.loaded_plugins: dict[str, Any] = {}
         self.manifest_plugins: dict[str, LoadedPlugin] = {}
@@ -108,6 +110,7 @@ class PluginManager:
         self.decoders.sort(key=_key)
         self.analyzers.sort(key=_key)
         self.detections.sort(key=_key)
+        self.extractors.sort(key=_key)
         self.reports.sort(key=_key)
 
     # Package-infrastructure modules in the built-in plugin dir that are not
@@ -180,6 +183,7 @@ class PluginManager:
             DecoderPlugin,
             AnalyzerPlugin,
             DetectionPlugin,
+            ExtractorPlugin,
             ReportPlugin,
         }
         for attr_name in dir(module):
@@ -198,6 +202,9 @@ class PluginManager:
                     self._check_rule_ids(instance)
                     self.detections.append(instance)
                     logger.info("Loaded detection plugin: %s", instance.name)
+                elif issubclass(attr, ExtractorPlugin):
+                    self.extractors.append(attr())
+                    logger.info("Loaded extractor plugin: %s", self.extractors[-1].name)
                 elif issubclass(attr, ReportPlugin):
                     self.reports.append(attr())
                     logger.info("Loaded report plugin: %s", self.reports[-1].name)
@@ -298,6 +305,9 @@ class PluginManager:
                     self._check_rule_ids(instance)
                     self.detections.append(instance)
                     registered = True
+                if isinstance(instance, ExtractorPlugin):
+                    self.extractors.append(instance)
+                    registered = True
                 if isinstance(instance, ReportPlugin):
                     self.reports.append(instance)
                     registered = True
@@ -350,6 +360,10 @@ class PluginManager:
         """Get all loaded detection plugins."""
         return self.detections.copy()
 
+    def get_extractors(self) -> list[ExtractorPlugin]:
+        """Get all loaded malware configuration extractor plugins."""
+        return self.extractors.copy()
+
     def get_reports(self) -> list[ReportPlugin]:
         """Get all loaded report plugins."""
         return self.reports.copy()
@@ -369,6 +383,7 @@ class PluginManager:
             "decoders": [d.name for d in self.decoders],
             "analyzers": [a.name for a in self.analyzers],
             "detections": [d.name for d in self.detections],
+            "extractors": [e.name for e in self.extractors],
             "reports": [r.name for r in self.reports],
             "errors": list(self.errors),
         }

--- a/titan_decoder/plugins/validation.py
+++ b/titan_decoder/plugins/validation.py
@@ -19,10 +19,12 @@ from typing import Any
 from .contracts import (
     AnalysisArtifact,
     AnalyzerPlugin,
+    ConfigExtraction,
     DecodeResult,
     DecoderPlugin,
     DetectionFinding,
     DetectionPlugin,
+    ExtractorPlugin,
     PluginContext,
     ReportPlugin,
     ReportSection,
@@ -161,6 +163,24 @@ def _probe_report(instance: ReportPlugin, context: PluginContext, report):
             )
 
 
+def _probe_extractor(instance: ExtractorPlugin, context: PluginContext, report):
+    can = instance.can_extract(_PROBE_INPUT, context)
+    if not isinstance(can, bool):
+        report.error("extractor.can_extract_type", "can_extract must return bool")
+    values = instance.extract(_PROBE_INPUT, context)
+    if len(values) > context.max_children:
+        report.error(
+            "extractor.child_limit",
+            f"extract produced more than {context.max_children} results",
+        )
+    for value in values:
+        if not isinstance(value, ConfigExtraction):
+            report.error(
+                "extractor.result_type",
+                "extract must return ConfigExtraction items",
+            )
+
+
 def validate_plugin(
     path: str | Path,
     *,
@@ -210,6 +230,7 @@ def validate_plugin(
         "decoder": DecoderPlugin,
         "analyzer": AnalyzerPlugin,
         "detection": DetectionPlugin,
+        "extractor": ExtractorPlugin,
         "report": ReportPlugin,
     }
     implemented = {
@@ -248,6 +269,8 @@ def validate_plugin(
             _probe_analyzer(instance, context, report, max_probe_output_bytes)
         if isinstance(instance, DetectionPlugin):
             _probe_detection(instance, context, report)
+        if isinstance(instance, ExtractorPlugin):
+            _probe_extractor(instance, context, report)
         if isinstance(instance, ReportPlugin):
             _probe_report(instance, context, report)
     except Exception as exc:

--- a/titan_decoder/plugins/worker.py
+++ b/titan_decoder/plugins/worker.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping
 
 from .contracts import (
     DetectionPlugin,
+    ExtractorPlugin,
     PluginAnalyzer,
     PluginContext,
     PluginDecoder,
@@ -72,6 +73,8 @@ def _metadata(instance: Any) -> dict[str, Any]:
         capabilities.append("analyzer")
     if isinstance(instance, DetectionPlugin):
         capabilities.append("detection")
+    if isinstance(instance, ExtractorPlugin):
+        capabilities.append("extractor")
     if isinstance(instance, ReportPlugin):
         capabilities.append("report")
     return {
@@ -123,6 +126,12 @@ def _invoke(instance: Any, request: Mapping[str, Any]) -> Any:
             context,
         )
         return [value.to_dict() for value in values]
+    if operation == "can_extract":
+        return instance.can_extract(_bytes(payload), context)
+    if operation == "extract":
+        return [
+            value.to_dict() for value in instance.extract(_bytes(payload), context)
+        ]
     if operation == "build_sections":
         report = payload.get("report")
         return [


### PR DESCRIPTION
## Summary

- add Plugin API 1.2 `ExtractorPlugin` and `ConfigExtraction` contracts
- execute extractors through the existing bounded, offline isolated worker protocol
- scan every raw, decoded, and extracted artifact node and persist deterministic config results
- validate extractor manifests and runtime return types
- ship a complete synthetic example and update SDK/roadmap documentation

## Impact

Third-party family extractors can now recover C2 addresses, keys, campaign IDs, and arbitrary structured configuration without running inside Titan's main process. Results carry source node and plugin provenance and are bounded by the existing plugin limits.

## Validation

- full suite: 756 passed, 9 skipped
- focused plugin/isolation suite: 45 passed
- Ruff: passed
- Mypy: passed
- golden corpus regenerated and verified
- `git diff --check`: passed
