### PR TITLE
feat: add seed malware config extractors

### DIFF
--- a/docs/CONFIG_EXTRACTORS.md
+++ b/docs/CONFIG_EXTRACTORS.md
@@ -1,0 +1,38 @@
+# Malware configuration extractors
+
+Titan's seed set demonstrates production-oriented API 1.2 extractors with
+strict input bounds and format-specific validation. They execute in Titan's
+isolated, offline plugin worker and contribute normalized results to
+`report["config_extractions"]`.
+
+## Seed families
+
+| Family | Accepted representation | Maximum input | Required validation |
+| --- | --- | ---: | --- |
+| Cobalt Strike Beacon 3.x/4.x | Decoded or `0x69`/`0x2e` XOR-encoded 4 KiB settings block embedded in an artifact | 16 MiB | Beacon TLV prefix plus valid port, sleep interval, and C2 fields |
+| Remcos | Decrypted settings envelope recovered from a resource or memory | 1 MiB | Exact settings delimiter, at least 15 fields, endpoint tuple, and stable boolean slots |
+
+The Cobalt Strike extractor normalizes the endpoint, timing, jitter, user
+agent, URI, pipe, watermark, and host-header fields when present. The Remcos
+extractor normalizes its C2 endpoint, botnet/campaign, connection interval,
+and mutex. Remcos resource discovery and RC4 decryption remain separate
+forensic preprocessing steps; the extractor intentionally does not guess at
+arbitrary PE resource blobs.
+
+## Calibration and safety
+
+Tests use byte fixtures that reproduce the families' real serialized layouts,
+cover both supported Beacon XOR variants, and include truncated, marker-only,
+invalid-timing, short-delimiter, and invalid-boolean near misses. Parsers cap
+the bytes inspected, cap field counts, avoid network and filesystem I/O, and
+return no partial attribution when required invariants fail.
+
+The layouts were independently implemented from public technical references:
+
+- CAPE Sandbox's `CobaltStrikeBeacon.py` configuration definitions.
+- CAPE Sandbox's `Remcos.py` field layout, including research references to
+  Cisco Talos and Elastic Security Labs in its source header.
+
+These are seed implementations, not a claim of universal family/version
+coverage. New variants should add a labeled positive/negative fixture before
+loosening any invariant.

--- a/docs/PLUGIN_API.md
+++ b/docs/PLUGIN_API.md
@@ -190,6 +190,10 @@ source node ID and plugin name. Manifest extractors use the same isolated,
 offline worker as other plugin capabilities. `values` and `metadata` must be
 JSON-serializable; `confidence` must be between 0 and 1.
 
+See [CONFIG_EXTRACTORS.md](CONFIG_EXTRACTORS.md) for the bounded Cobalt Strike
+Beacon and Remcos seed implementations, accepted representations, and
+calibration limits.
+
 ## Report SDK
 
 ```python
@@ -295,7 +299,8 @@ legacy plugin.
 
 Complete working examples — one per capability — live in
 `examples/plugins/`: `rot47_decoder`, `string_analyzer`, `marker_detection`,
-`config_extractor`, and `summary_report`. All five pass `--plugin-validate` and are exercised by
+`config_extractor`, `cobalt_strike_config`, `remcos_config`, and `summary_report`.
+All seven pass `--plugin-validate` and are exercised by
 the test suite (`tests/test_plugin_sdk.py`,
 `tests/test_plugin_sdk_integration.py`).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -66,8 +66,9 @@ constraints: deterministic, bounded, offline-first, fail-closed.
 2. **Malware config extraction.** Family identification plus C2/config
    recovery (addresses, keys, campaign ids) now has a documented API 1.2
    extractor SDK, isolated-worker transport, validation, report integration,
-   and a complete synthetic example; next: ship and calibrate the seed set of
-   extractors for prevalent families.
+   and bounded seed extractors for Cobalt Strike Beacon and decrypted Remcos
+   settings, with real-layout positive/adversarial fixtures. Next: expand the
+   calibrated family and version matrix from measured field samples.
 3. **Format coverage depth.** .NET assembly structure, MSI/NSIS/InnoSetup
    installers, OneNote, RTF exploit structures, Excel 4.0 XLM macros, VBA
    p-code, PDF stream filters with JavaScript extraction, Mach-O, APK/DEX,

--- a/examples/plugins/cobalt_strike_config/plugin.py
+++ b/examples/plugins/cobalt_strike_config/plugin.py
@@ -1,0 +1,89 @@
+"""Extract selected fields from Cobalt Strike 3.x and 4.x Beacon configs."""
+
+from titan_decoder.plugins.api import ConfigExtraction, ExtractorPlugin
+
+
+class CobaltStrikeConfigExtractor(ExtractorPlugin):
+    name = "Cobalt Strike Beacon Config"
+    _MAX_INPUT = 16 * 1024 * 1024
+    _CONFIG_SIZE = 4096
+    _XOR_KEYS = (0x69, 0x2E)
+    _START = b"\x00\x01\x00\x01\x00\x02"
+    _FIELDS = {
+        1: ("beacon_type", 1, 2),
+        2: ("port", 1, 2),
+        3: ("sleep_ms", 2, 4),
+        5: ("jitter", 1, 2),
+        8: ("c2_server", 3, 256),
+        9: ("user_agent", 3, 128),
+        10: ("http_post_uri", 3, 64),
+        15: ("pipe_name", 3, 128),
+        37: ("watermark", 2, 4),
+        54: ("host_header", 3, 128),
+    }
+
+    @classmethod
+    def _candidate(cls, data):
+        if not 18 <= len(data) <= cls._MAX_INPUT:
+            return None
+        decoded_at = data.find(cls._START)
+        if decoded_at >= 0:
+            return data[decoded_at : decoded_at + cls._CONFIG_SIZE], "decoded", None
+        for key in cls._XOR_KEYS:
+            marker = bytes(value ^ key for value in cls._START)
+            offset = data.find(marker)
+            if offset >= 0:
+                block = data[offset : offset + cls._CONFIG_SIZE]
+                return bytes(value ^ key for value in block), "xor", key
+        return None
+
+    @classmethod
+    def _parse(cls, data):
+        candidate = cls._candidate(data)
+        if candidate is None:
+            return None
+        block, encoding, xor_key = candidate
+        values = {}
+        for field_id, (label, data_type, length) in cls._FIELDS.items():
+            header = bytes((0, field_id, 0, data_type)) + length.to_bytes(2, "big")
+            offset = block.find(header)
+            if offset < 0 or offset + 6 + length > len(block):
+                continue
+            raw = block[offset + 6 : offset + 6 + length]
+            if data_type == 3:
+                text = raw.split(b"\x00", 1)[0].decode("utf-8", errors="replace").strip()
+                if text:
+                    values[label] = text
+            else:
+                values[label] = int.from_bytes(raw, "big")
+        # Endpoint and timing fields jointly make the short start marker specific.
+        required = {"port", "sleep_ms", "c2_server"}
+        if not required <= values.keys() or not 1 <= values["port"] <= 65535:
+            return None
+        if not 1 <= values["sleep_ms"] <= 86_400_000:
+            return None
+        return values, encoding, xor_key
+
+    def can_extract(self, data, context=None):
+        return self._parse(data) is not None
+
+    def extract(self, data, context=None):
+        parsed = self._parse(data)
+        if parsed is None:
+            return []
+        values, encoding, xor_key = parsed
+        server = values["c2_server"]
+        port = values["port"]
+        endpoint = server if "://" in server else f"tcp://{server}:{port}"
+        metadata = {"format": "beacon-config-tlv", "encoding": encoding}
+        if xor_key is not None:
+            metadata["xor_key_hex"] = f"{xor_key:02x}"
+        return [
+            ConfigExtraction(
+                family="Cobalt Strike Beacon",
+                confidence=0.99,
+                values=values,
+                c2=(endpoint,),
+                metadata=metadata,
+            )
+        ]

--- a/examples/plugins/cobalt_strike_config/titan-plugin.json
+++ b/examples/plugins/cobalt_strike_config/titan-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0",
+  "id": "titan.extractor.cobalt-strike",
+  "name": "Cobalt Strike Beacon Config Extractor",
+  "version": "1.0.0",
+  "api_version": "1.2.0",
+  "entry_point": "plugin:CobaltStrikeConfigExtractor",
+  "capabilities": ["extractor"],
+  "description": "Bounded extractor for Cobalt Strike 3.x/4.x Beacon configuration blocks.",
+  "author": "Titan contributors",
+  "license": "AGPL-3.0-or-later",
+  "permissions": [],
+  "dependencies": {}
+}

--- a/examples/plugins/remcos_config/plugin.py
+++ b/examples/plugins/remcos_config/plugin.py
@@ -1,0 +1,70 @@
+"""Extract high-value fields from a decrypted Remcos settings envelope."""
+
+from titan_decoder.plugins.api import ConfigExtraction, ExtractorPlugin
+
+
+class RemcosConfigExtractor(ExtractorPlugin):
+    name = "Remcos Config"
+    _MAX_INPUT = 1024 * 1024
+    _DELIMITER = b"|\x1e\x1e\x1f|"
+
+    @classmethod
+    def _parse(cls, data):
+        if not 32 <= len(data) <= cls._MAX_INPUT or cls._DELIMITER not in data:
+            return None
+        fields = data.split(cls._DELIMITER, 67)
+        if len(fields) < 15:
+            return None
+        endpoint_record = fields[0]
+        separator = next(
+            (item for item in (b"|", b"\x1e", b"\xff\xff\xff\xff") if item in endpoint_record),
+            None,
+        )
+        if separator is None:
+            return None
+        endpoint_part = endpoint_record.split(separator, 1)[0]
+        pieces = endpoint_part.split(b":")
+        if len(pieces) != 3:
+            return None
+        try:
+            host = pieces[0].decode("ascii").encode("ascii").decode("idna").strip()
+        except UnicodeError:
+            return None
+        try:
+            port = int(pieces[1])
+        except ValueError:
+            return None
+        if not host or not 1 <= port <= 65535:
+            return None
+        botnet = fields[1].decode("utf-8", errors="replace").strip("\x00 ")[:256]
+        interval = fields[2].decode("ascii", errors="ignore").strip("\x00 ")[:32]
+        mutex = fields[14].decode("utf-8", errors="replace").strip("\x00 ")[:256]
+        # Boolean settings occupy stable positions and sharply reduce delimiter false positives.
+        if any(fields[index] not in (b"\x00", b"\x01") for index in (3, 4, 5, 6)):
+            return None
+        values = {"host": host, "port": port}
+        if botnet:
+            values["botnet"] = botnet
+        if interval.isdigit():
+            values["connect_interval_seconds"] = int(interval)
+        if mutex:
+            values["mutex"] = mutex
+        return values
+
+    def can_extract(self, data, context=None):
+        return self._parse(data) is not None
+
+    def extract(self, data, context=None):
+        values = self._parse(data)
+        if values is None:
+            return []
+        return [
+            ConfigExtraction(
+                family="Remcos",
+                confidence=0.98,
+                values=values,
+                c2=(f"tcp://{values['host']}:{values['port']}",),
+                campaign_id=values.get("botnet"),
+                metadata={"format": "decrypted-settings-v1"},
+            )
+        ]

--- a/examples/plugins/remcos_config/titan-plugin.json
+++ b/examples/plugins/remcos_config/titan-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0",
+  "id": "titan.extractor.remcos",
+  "name": "Remcos Config Extractor",
+  "version": "1.0.0",
+  "api_version": "1.2.0",
+  "entry_point": "plugin:RemcosConfigExtractor",
+  "capabilities": ["extractor"],
+  "description": "Bounded extractor for decrypted Remcos settings envelopes.",
+  "author": "Titan contributors",
+  "license": "AGPL-3.0-or-later",
+  "permissions": [],
+  "dependencies": {}
+}

--- a/tests/test_config_extractor_seeds.py
+++ b/tests/test_config_extractor_seeds.py
@@ -1,0 +1,85 @@
+"""Real-format fixtures and near misses for Titan's seed config extractors."""
+
+from pathlib import Path
+
+import pytest
+
+from titan_decoder.plugins import PluginManager
+
+
+PLUGINS = Path(__file__).resolve().parents[1] / "examples" / "plugins"
+
+
+def _field(field_id: int, kind: int, size: int, value: bytes | int) -> bytes:
+    raw = value.to_bytes(size, "big") if isinstance(value, int) else value.ljust(size, b"\x00")
+    return bytes((0, field_id, 0, kind)) + size.to_bytes(2, "big") + raw
+
+
+def _cobalt_config(*, xor_key: int | None = None) -> bytes:
+    decoded = b"".join(
+        (
+            _field(1, 1, 2, 8),
+            _field(2, 1, 2, 443),
+            _field(3, 2, 4, 60_000),
+            _field(5, 1, 2, 20),
+            _field(8, 3, 256, b"team.example"),
+            _field(9, 3, 128, b"Mozilla/5.0"),
+            _field(10, 3, 64, b"/submit.php"),
+            _field(37, 2, 4, 0x10203040),
+        )
+    ).ljust(4096, b"\x00")
+    if xor_key is None:
+        return decoded
+    return bytes(value ^ xor_key for value in decoded)
+
+
+def _extractor(plugin: str):
+    manager = PluginManager([PLUGINS / plugin])
+    manager.load_plugins()
+    assert manager.errors == []
+    return manager.extractors[0]
+
+
+@pytest.mark.parametrize("xor_key", [None, 0x69, 0x2E])
+def test_cobalt_strike_decoded_and_xor_variants_run_isolated(xor_key):
+    extractor = _extractor("cobalt_strike_config")
+    results = extractor.extract(b"prefix" + _cobalt_config(xor_key=xor_key))
+    assert len(results) == 1
+    result = results[0]
+    assert result.family == "Cobalt Strike Beacon"
+    assert result.values["sleep_ms"] == 60_000
+    assert result.values["jitter"] == 20
+    assert result.values["watermark"] == 0x10203040
+    assert result.c2 == ("tcp://team.example:443",)
+    assert result.metadata["encoding"] == ("decoded" if xor_key is None else "xor")
+
+
+def test_cobalt_strike_rejects_marker_only_and_invalid_timing():
+    extractor = _extractor("cobalt_strike_config")
+    assert not extractor.can_extract(b"\x00\x01\x00\x01\x00\x02" + b"noise" * 20)
+    invalid = _cobalt_config().replace((60_000).to_bytes(4, "big"), b"\x00\x00\x00\x00", 1)
+    assert extractor.extract(invalid) == []
+
+
+def _remcos_config() -> bytes:
+    fields = [b"c2.example:2404:secret\x1eTLS", b"blue-team", b"10"]
+    fields.extend((b"\x01", b"\x01", b"\x00", b"\x00"))
+    fields.extend(b"unused" for _ in range(7))
+    fields.append(b"Global\\Remcos-Mutex")
+    return b"|\x1e\x1e\x1f|".join(fields)
+
+
+def test_remcos_decrypted_settings_extract_high_value_fields():
+    result = _extractor("remcos_config").extract(_remcos_config())[0]
+    assert result.family == "Remcos"
+    assert result.c2 == ("tcp://c2.example:2404",)
+    assert result.campaign_id == "blue-team"
+    assert result.values["connect_interval_seconds"] == 10
+    assert result.values["mutex"] == "Global\\Remcos-Mutex"
+
+
+def test_remcos_rejects_short_delimited_text_and_bad_boolean_layout():
+    extractor = _extractor("remcos_config")
+    assert extractor.extract(b"host:80:key" + extractor._DELIMITER + b"noise") == []
+    invalid = _remcos_config().replace(b"\x01", b"maybe", 1)
+    assert not extractor.can_extract(invalid)

--- a/tests/test_plugin_sdk.py
+++ b/tests/test_plugin_sdk.py
@@ -209,11 +209,15 @@ def _write_plugin(
 def test_registry_loads_all_example_plugins():
     manager = PluginManager([EXAMPLES])
     manager.load_plugins()
-    assert len(manager.manifest_plugins) == 5
+    assert len(manager.manifest_plugins) == 7
     assert [d.name for d in manager.decoders] == ["ROT47"]
     assert [a.name for a in manager.analyzers] == ["PrintableStrings"]
     assert [d.name for d in manager.detections] == ["Example Marker"]
-    assert [e.name for e in manager.extractors] == ["Titan Beacon Config"]
+    assert {e.name for e in manager.extractors} == {
+        "Cobalt Strike Beacon Config",
+        "Remcos Config",
+        "Titan Beacon Config",
+    }
     assert [r.name for r in manager.reports] == ["Example Summary"]
     assert manager.errors == []
 


### PR DESCRIPTION
## Summary

- add bounded Cobalt Strike Beacon 3.x/4.x configuration extraction for decoded and `0x69`/`0x2e` XOR layouts
- add bounded extraction for decrypted Remcos settings envelopes
- add real-layout positive fixtures and adversarial near misses through the isolated plugin worker
- document accepted representations, limits, calibration strategy, and preprocessing boundaries

## Validation

- `pytest -q`: 762 passed, 9 skipped
- focused plugin/extractor suite: 55 passed
- `ruff check titan_decoder tests examples tools`
- `mypy titan_decoder`
- both manifests pass `titan-decoder --plugin-validate`

## Stacking

This PR targets `agent/config-extractor-sdk` and depends on #138 (Plugin API 1.2 extractor support).
