### PR TITLE
feat: analyze Mach-O and DEX structures

### DIFF
--- a/docs/EXECUTABLE_FORMATS.md
+++ b/docs/EXECUTABLE_FORMATS.md
@@ -1,0 +1,31 @@
+# Executable format analysis
+
+Titan performs deterministic structural analysis without loading or executing
+the artifact. The Mach-O and DEX analyzers extend the existing PE and ELF
+coverage and are enabled by default under the `analyzers.macho` and
+`analyzers.dex` configuration keys.
+
+## Mach-O
+
+The analyzer accepts thin 32-bit and 64-bit, little-endian and big-endian
+Mach-O files. It validates the complete load-command region before emitting
+metadata, caps parsing at 2,048 commands and 1,024 sections, and reports:
+
+- CPU, bitness, byte order, file type, flags, UUID, and entry-file offset;
+- linked dynamic libraries;
+- section names, segments, offsets, sizes, flags, and bounded entropy;
+- invalid section ranges and load-command padding as anomalies.
+
+Universal/fat containers are not yet expanded; each thin member can be
+analyzed once extracted.
+
+## Android DEX
+
+The analyzer validates the 112-byte header, endian tag, declared file size,
+and all primary table counts/offsets. It emits table metadata and up to 4,096
+strings, with 4 KiB per-string and 2 MiB aggregate output limits. The string
+artifact enters Titan's normal recursive graph, allowing URLs and other IOCs
+embedded in DEX string data to be recovered without executing bytecode.
+
+Malformed offsets, oversized tables, unterminated strings, and invalid ULEB128
+prefixes fail closed or are skipped within the documented bounds.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,9 +69,10 @@ constraints: deterministic, bounded, offline-first, fail-closed.
    SDK and a seed set of extractors for prevalent families.
 3. **Format coverage depth.** .NET assembly structure, MSI/NSIS/InnoSetup
    installers, OneNote, RTF exploit structures, Excel 4.0 XLM macros, VBA
-   p-code, PDF stream filters with JavaScript extraction, Mach-O, APK/DEX,
-   VHD/VHDX, and password-protected archives (`infected`). Every new parser
-   lands with a labeled corpus slice and resource-bound regression tests.
+   p-code, PDF stream filters with JavaScript extraction, APK/DEX, VHD/VHDX,
+   and password-protected archives (`infected`). Thin Mach-O and DEX structural
+   analyzers now ship with malformed-input corpus slices and explicit resource
+   bounds; continue prioritizing the remaining formats by measured misses.
 4. **Service mode.** A `titan-server` deployment shape: REST API, work
    queue, horizontally scalable workers, artifact store, and hash-based
    dedup cache (reference architecture: CCCS Assemblyline), so Titan runs as

--- a/tests/golden/expected/cfb_macro.doc.json
+++ b/tests/golden/expected/cfb_macro.doc.json
@@ -87,8 +87,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -142,9 +144,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/golden/expected/gzip_text.bin.json
+++ b/tests/golden/expected/gzip_text.bin.json
@@ -118,8 +118,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -173,9 +175,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/golden/expected/high_entropy.bin.json
+++ b/tests/golden/expected/high_entropy.bin.json
@@ -60,8 +60,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -115,9 +117,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/golden/expected/multi_ioc.txt.json
+++ b/tests/golden/expected/multi_ioc.txt.json
@@ -68,8 +68,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -123,9 +125,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/golden/expected/nested_base64.txt.json
+++ b/tests/golden/expected/nested_base64.txt.json
@@ -87,8 +87,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -142,9 +144,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/golden/expected/pdf_js.pdf.json
+++ b/tests/golden/expected/pdf_js.pdf.json
@@ -88,8 +88,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -143,9 +145,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/golden/expected/plain_iocs.txt.json
+++ b/tests/golden/expected/plain_iocs.txt.json
@@ -67,8 +67,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -122,9 +124,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/golden/expected/xor_url.bin.json
+++ b/tests/golden/expected/xor_url.bin.json
@@ -93,8 +93,10 @@
   "run_manifest": {
     "components": {
       "analyzers": [
+        "DEX",
         "ELF",
         "Email",
+        "Mach-O",
         "OfficeOOXML",
         "OptionalArchive",
         "PE",
@@ -148,9 +150,11 @@
       "analysis_timeout_seconds": 300,
       "analyzer_timeout_seconds": 10,
       "analyzers": {
+        "dex": true,
         "elf": true,
         "email": true,
         "lnk": true,
+        "macho": true,
         "office": true,
         "optional_archives": true,
         "pe": true,

--- a/tests/test_executable_formats.py
+++ b/tests/test_executable_formats.py
@@ -1,0 +1,85 @@
+"""Bounded corpus tests for Mach-O and DEX structural analyzers."""
+
+import json
+import struct
+
+from titan_decoder.config import Config
+from titan_decoder.core.analyzers.executable_formats import DexAnalyzer, MachOAnalyzer
+from titan_decoder.core.engine import TitanEngine
+
+
+def _macho64() -> bytes:
+    section_data = b"Mach-O payload http://macho.example/x"
+    section_offset = 32 + 152 + 56
+    header = b"\xcf\xfa\xed\xfe" + struct.pack(
+        "<IIIIIII", 0x01000007, 3, 2, 2, 208, 0x200000, 0
+    )
+    segment = struct.pack("<II16sQQQQIIII", 0x19, 152, b"__TEXT", 0x100000000, 0x1000, 0, len(section_data), 7, 5, 1, 0)
+    section = struct.pack("<16s16sQQIIIIIIII", b"__text", b"__TEXT", 0x100000F50, len(section_data), section_offset, 4, 0, 0, 0x80000400, 0, 0, 0)
+    dylib_name = b"/usr/lib/libSystem.B.dylib\x00"
+    dylib = struct.pack("<IIIIII", 0xC, 56, 24, 0, 0, 0) + dylib_name.ljust(32, b"\x00")
+    return header + segment + section + dylib + section_data
+
+
+def _dex(strings: list[bytes]) -> bytes:
+    ids_offset = 112
+    data_offset = ids_offset + len(strings) * 4
+    items = bytearray()
+    offsets = []
+    for value in strings:
+        offsets.append(data_offset + len(items))
+        items.extend(bytes((len(value),)) + value + b"\x00")
+    file_size = data_offset + len(items)
+    header = bytearray(112)
+    header[:8] = b"dex\n035\x00"
+    struct.pack_into("<III", header, 32, file_size, 112, 0x12345678)
+    struct.pack_into("<II", header, 56, len(strings), ids_offset)
+    struct.pack_into("<II", header, 104, len(items), data_offset)
+    return bytes(header) + b"".join(struct.pack("<I", item) for item in offsets) + bytes(items)
+
+
+def test_macho_extracts_load_commands_sections_and_dylibs():
+    analyzer = MachOAnalyzer()
+    data = _macho64()
+    assert analyzer.can_analyze(data)
+    result = json.loads(analyzer.analyze(data)[0][1])
+    assert result["bits"] == 64
+    assert result["cpu_type"] == "x86_64"
+    assert result["dylibs"] == ["/usr/lib/libSystem.B.dylib"]
+    assert result["sections"][0]["name"] == "__text"
+    assert result["sections"][0]["size"] == 37
+
+
+def test_macho_rejects_truncated_and_impossible_command_regions():
+    analyzer = MachOAnalyzer()
+    assert not analyzer.can_analyze(b"\xcf\xfa\xed\xfe")
+    malformed = bytearray(_macho64())
+    struct.pack_into("<I", malformed, 20, len(malformed) + 1)
+    assert analyzer.analyze(bytes(malformed)) == []
+
+
+def test_dex_extracts_bounded_strings_and_table_metadata():
+    analyzer = DexAnalyzer()
+    data = _dex([b"Lcom/example/Main;", b"https://dex.example/gate"])
+    artifacts = dict(analyzer.analyze(data))
+    metadata = json.loads(artifacts["dex_metadata.json"])
+    assert metadata["version"] == "035"
+    assert metadata["tables"]["string"]["count"] == 2
+    assert artifacts["dex_strings.txt"] == b"Lcom/example/Main;\nhttps://dex.example/gate"
+
+
+def test_dex_rejects_bad_endian_tag_and_out_of_range_table():
+    analyzer = DexAnalyzer()
+    bad_endian = bytearray(_dex([b"hello"]))
+    struct.pack_into("<I", bad_endian, 40, 0)
+    assert analyzer.analyze(bytes(bad_endian)) == []
+    bad_table = bytearray(_dex([b"hello"]))
+    struct.pack_into("<I", bad_table, 60, len(bad_table) + 10)
+    assert analyzer.analyze(bytes(bad_table)) == []
+
+
+def test_engine_registers_new_executable_analyzers_and_extracts_dex_ioc():
+    engine = TitanEngine(Config())
+    assert {analyzer.name for analyzer in engine.analyzers} >= {"DEX", "Mach-O"}
+    report = engine.run_analysis(_dex([b"https://dex.example/gate"]))
+    assert "https://dex.example/gate" in report["iocs"]["urls"]

--- a/titan_decoder/config.py
+++ b/titan_decoder/config.py
@@ -88,6 +88,8 @@ class Config:
             "tar": True,
             "pe": True,
             "elf": True,
+            "macho": True,
+            "dex": True,
             "steganography": True,
             "email": True,
             "office": True,

--- a/titan_decoder/core/analyzers/executable_formats.py
+++ b/titan_decoder/core/analyzers/executable_formats.py
@@ -1,0 +1,238 @@
+"""Bounded structural analyzers for additional executable formats."""
+
+from __future__ import annotations
+
+import json
+import struct
+from typing import Any
+
+from .base import Analyzer
+from ...utils.helpers import entropy
+
+
+class MachOAnalyzer(Analyzer):
+    """Parse thin 32/64-bit Mach-O headers, load commands, and sections."""
+
+    _MAGICS = {
+        b"\xce\xfa\xed\xfe": ("<", 32),
+        b"\xcf\xfa\xed\xfe": ("<", 64),
+        b"\xfe\xed\xfa\xce": (">", 32),
+        b"\xfe\xed\xfa\xcf": (">", 64),
+    }
+    _CPU_TYPES = {
+        7: "x86",
+        0x01000007: "x86_64",
+        12: "arm",
+        0x0100000C: "arm64",
+        18: "powerpc",
+        0x01000012: "powerpc64",
+    }
+    _FILE_TYPES = {1: "object", 2: "executable", 6: "dylib", 8: "bundle"}
+    _DYLIB_COMMANDS = {0xC, 0x18, 0x1F, 0x80000018, 0x8000001F}
+    _MAX_COMMANDS = 2048
+    _MAX_SECTIONS = 1024
+
+    @property
+    def name(self) -> str:
+        return "Mach-O"
+
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"macho_metadata.json"})
+
+    def can_analyze(self, data: bytes) -> bool:
+        return len(data) >= 28 and data[:4] in self._MAGICS
+
+    @staticmethod
+    def _cstring(raw: bytes) -> str:
+        return raw.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+
+    def analyze(self, data: bytes) -> list[tuple[str, bytes]]:
+        metadata = self._parse(data)
+        if metadata is None:
+            return []
+        return [("macho_metadata.json", json.dumps(metadata, indent=2).encode())]
+
+    def _parse(self, data: bytes) -> dict[str, Any] | None:
+        layout = self._MAGICS.get(data[:4])
+        if layout is None:
+            return None
+        endian, bits = layout
+        header_size = 32 if bits == 64 else 28
+        if len(data) < header_size:
+            return None
+        cpu_type, cpu_subtype, file_type, ncmds, commands_size, flags = struct.unpack_from(
+            f"{endian}IIIIII", data, 4
+        )
+        if ncmds > self._MAX_COMMANDS or commands_size > len(data) - header_size:
+            return None
+        commands_end = header_size + commands_size
+        cursor = header_size
+        sections: list[dict[str, Any]] = []
+        dylibs: list[str] = []
+        entry_offset: int | None = None
+        uuid: str | None = None
+        anomalies: list[str] = []
+        for _ in range(ncmds):
+            if cursor + 8 > commands_end:
+                return None
+            command, command_size = struct.unpack_from(f"{endian}II", data, cursor)
+            if command_size < 8 or command_size > commands_end - cursor:
+                return None
+            if command in (1, 0x19):
+                is_64 = command == 0x19
+                segment_header = 72 if is_64 else 56
+                section_size = 80 if is_64 else 68
+                if command_size < segment_header:
+                    return None
+                nsects_at = cursor + (64 if is_64 else 48)
+                nsects = struct.unpack_from(f"{endian}I", data, nsects_at)[0]
+                if nsects > self._MAX_SECTIONS - len(sections):
+                    return None
+                if segment_header + nsects * section_size > command_size:
+                    return None
+                for index in range(nsects):
+                    at = cursor + segment_header + index * section_size
+                    section_name = self._cstring(data[at : at + 16])
+                    segment_name = self._cstring(data[at + 16 : at + 32])
+                    if is_64:
+                        address, size, offset, _align, _reloc, _nreloc, sec_flags = struct.unpack_from(
+                            f"{endian}QQIIIII", data, at + 32
+                        )
+                    else:
+                        address, size, offset, _align, _reloc, _nreloc, sec_flags = struct.unpack_from(
+                            f"{endian}IIIIIII", data, at + 32
+                        )
+                    raw = data[offset : offset + size] if offset <= len(data) and size <= len(data) - offset else b""
+                    if size and not raw:
+                        anomalies.append(f"invalid_section_range:{segment_name},{section_name}")
+                    sections.append(
+                        {
+                            "segment": segment_name,
+                            "name": section_name,
+                            "address": f"0x{address:x}",
+                            "offset": offset,
+                            "size": size,
+                            "entropy": round(entropy(raw), 4) if raw else 0.0,
+                            "flags": f"0x{sec_flags:08x}",
+                        }
+                    )
+            elif command in self._DYLIB_COMMANDS and command_size >= 24:
+                name_offset = struct.unpack_from(f"{endian}I", data, cursor + 8)[0]
+                if 24 <= name_offset < command_size:
+                    name = self._cstring(data[cursor + name_offset : cursor + command_size])
+                    if name:
+                        dylibs.append(name)
+            elif command == 0x80000028 and command_size >= 24:
+                entry_offset = struct.unpack_from(f"{endian}Q", data, cursor + 8)[0]
+            elif command == 0x1B and command_size >= 24:
+                raw_uuid = data[cursor + 8 : cursor + 24].hex()
+                uuid = "-".join((raw_uuid[:8], raw_uuid[8:12], raw_uuid[12:16], raw_uuid[16:20], raw_uuid[20:]))
+            cursor += command_size
+        if cursor != commands_end:
+            anomalies.append("load_command_padding")
+        return {
+            "file_type": "Mach-O",
+            "bits": bits,
+            "endianness": "little" if endian == "<" else "big",
+            "cpu_type": self._CPU_TYPES.get(cpu_type, f"unknown:0x{cpu_type:08x}"),
+            "cpu_subtype": f"0x{cpu_subtype:08x}",
+            "macho_type": self._FILE_TYPES.get(file_type, f"unknown:{file_type}"),
+            "flags": f"0x{flags:08x}",
+            "load_command_count": ncmds,
+            "entry_offset": entry_offset,
+            "uuid": uuid,
+            "dylibs": sorted(set(dylibs), key=str.lower),
+            "sections": sections,
+            "anomalies": sorted(set(anomalies)),
+        }
+
+
+class DexAnalyzer(Analyzer):
+    """Parse DEX headers and a bounded subset of the string table."""
+
+    _MAX_TABLE_ITEMS = 1_000_000
+    _MAX_STRINGS = 4096
+    _MAX_STRING_BYTES = 4096
+    _MAX_TOTAL_STRING_BYTES = 2 * 1024 * 1024
+
+    @property
+    def name(self) -> str:
+        return "DEX"
+
+    @property
+    def metadata_artifact_names(self) -> frozenset:
+        return frozenset({"dex_metadata.json"})
+
+    def can_analyze(self, data: bytes) -> bool:
+        return len(data) >= 112 and data[:4] == b"dex\n" and data[7] == 0
+
+    def analyze(self, data: bytes) -> list[tuple[str, bytes]]:
+        parsed = self._parse(data)
+        if parsed is None:
+            return []
+        metadata, strings = parsed
+        artifacts = [("dex_metadata.json", json.dumps(metadata, indent=2).encode())]
+        if strings:
+            artifacts.append(("dex_strings.txt", "\n".join(strings).encode("utf-8")))
+        return artifacts
+
+    @staticmethod
+    def _uleb128(data: bytes, offset: int) -> tuple[int, int] | None:
+        value = 0
+        for index in range(5):
+            if offset + index >= len(data):
+                return None
+            byte = data[offset + index]
+            value |= (byte & 0x7F) << (index * 7)
+            if not byte & 0x80:
+                return value, offset + index + 1
+        return None
+
+    def _parse(self, data: bytes) -> tuple[dict[str, Any], list[str]] | None:
+        if not self.can_analyze(data):
+            return None
+        version = data[4:7].decode("ascii", errors="replace")
+        file_size, header_size, endian_tag = struct.unpack_from("<III", data, 32)
+        if file_size < 112 or file_size > len(data) or header_size != 112 or endian_tag != 0x12345678:
+            return None
+        table_names = ("string", "type", "proto", "field", "method", "class")
+        tables: dict[str, dict[str, int]] = {}
+        for index, name in enumerate(table_names):
+            count, offset = struct.unpack_from("<II", data, 56 + index * 8)
+            if count > self._MAX_TABLE_ITEMS or (count and not 112 <= offset < file_size):
+                return None
+            tables[name] = {"count": count, "offset": offset}
+        string_count = tables["string"]["count"]
+        string_offset = tables["string"]["offset"]
+        if string_count and (string_count > (file_size - string_offset) // 4):
+            return None
+        strings: list[str] = []
+        total = 0
+        for index in range(min(string_count, self._MAX_STRINGS)):
+            item_offset = struct.unpack_from("<I", data, string_offset + index * 4)[0]
+            prefix = self._uleb128(data, item_offset)
+            if prefix is None:
+                continue
+            _utf16_length, start = prefix
+            end = data.find(b"\x00", start, min(file_size, start + self._MAX_STRING_BYTES + 1))
+            if end < 0:
+                continue
+            raw = data[start:end]
+            total += len(raw)
+            if total > self._MAX_TOTAL_STRING_BYTES:
+                break
+            text = raw.decode("utf-8", errors="replace").strip()
+            if text:
+                strings.append(text)
+        metadata = {
+            "file_type": "DEX",
+            "version": version,
+            "file_size": file_size,
+            "checksum_adler32": f"0x{struct.unpack_from('<I', data, 8)[0]:08x}",
+            "signature_sha1": data[12:32].hex(),
+            "tables": tables,
+            "strings_emitted": len(strings),
+            "strings_truncated": string_count > len(strings),
+        }
+        return metadata, strings

--- a/titan_decoder/core/engine.py
+++ b/titan_decoder/core/engine.py
@@ -43,6 +43,7 @@ from ..decoders.advanced import (
     ZstandardDecoder,
 )
 from .analyzers.base import Analyzer, ZipAnalyzer, TarAnalyzer, PEAnalyzer, ELFAnalyzer
+from .analyzers.executable_formats import DexAnalyzer, MachOAnalyzer
 from .analyzers.steganography import SteganographyAnalyzer
 from .analyzers.structured import (
     EmailAnalyzer,
@@ -315,6 +316,10 @@ class TitanEngine:
             self.analyzers.append(PEAnalyzer())
         if self.config.get("analyzers", {}).get("elf", True):
             self.analyzers.append(ELFAnalyzer())
+        if self.config.get("analyzers", {}).get("macho", True):
+            self.analyzers.append(MachOAnalyzer())
+        if self.config.get("analyzers", {}).get("dex", True):
+            self.analyzers.append(DexAnalyzer())
         if self.config.get("analyzers", {}).get("steganography", True):
             media_config = {
                 "max_media_artifacts": self.config.get("max_media_artifacts", 8),


### PR DESCRIPTION
## Summary

- add bounded thin Mach-O parsing for 32/64-bit and little/big-endian files
- extract load-command, dylib, entry, UUID, section, entropy, and anomaly metadata
- add strict DEX header/table validation and bounded string extraction
- feed DEX strings into Titan's recursive graph so embedded IOCs are recovered
- document format scope, fail-closed behavior, and resource limits

## Validation

- `pytest -q`: 759 passed, 9 skipped
- focused engine/resource suite: 34 passed
- `ruff check titan_decoder tests examples tools`
- `mypy titan_decoder`
- golden reports regenerated and reviewed for the two new enabled analyzers
