### PR TITLE
feat: add persistent Titan service mode

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,8 +74,9 @@ constraints: deterministic, bounded, offline-first, fail-closed.
    lands with a labeled corpus slice and resource-bound regression tests.
 4. **Service mode.** A `titan-server` deployment shape: REST API, work
    queue, horizontally scalable workers, artifact store, and hash-based
-   dedup cache (reference architecture: CCCS Assemblyline), so Titan runs as
-   pipeline infrastructure rather than a single-process CLI.
+   dedup cache now ships as a dependency-free, loopback-only-by-default
+   reference deployment. Next: production queue/object-store adapters and
+   deployment manifests for multi-host operation.
 5. **Bounded emulation.** Instruction-budgeted, no-I/O emulation for
    shellcode (Unicorn-class) and sandboxed JavaScript evaluation for
    deobfuscation — deterministic and fail-closed by construction, extending

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -1,0 +1,54 @@
+# Titan service mode
+
+`titan-server` turns the deterministic engine into local pipeline
+infrastructure without adding a web-framework dependency. It combines a REST
+surface, a persistent SQLite work queue, hash-addressed artifact/report storage,
+and one or more workers.
+
+## Quick start
+
+```console
+titan-server --data-dir ./titan-data
+```
+
+The default binds only to `127.0.0.1:8787` and starts one worker. Submit raw
+bytes and retrieve the eventual report:
+
+```console
+curl --data-binary @sample.bin http://127.0.0.1:8787/v1/jobs
+curl http://127.0.0.1:8787/v1/jobs/<sha256>
+curl http://127.0.0.1:8787/v1/jobs/<sha256>/report
+```
+
+Endpoints are `GET /v1/health`, `POST /v1/jobs`, `GET /v1/jobs/{sha256}`,
+and `GET /v1/jobs/{sha256}/report`. Uploads default to 50 MiB maximum.
+
+## Deployment shapes
+
+The API and workers can run separately against a shared data directory:
+
+```console
+titan-server --mode serve --data-dir /srv/titan
+titan-server --mode worker --workers 4 --worker-id worker-a --data-dir /srv/titan
+```
+
+SQLite transactions ensure one worker claims a queued artifact. A stopped
+worker's claim returns to the queue after 15 minutes; Titan's default analysis
+timeout is five minutes. The SHA-256 digest is both job identity and storage
+key, so repeat submissions reuse queued, running, or completed work. Failed
+jobs can be resubmitted.
+
+The storage directory contains immutable blobs under `blobs/<prefix>/<hash>`,
+canonical JSON reports under `reports/<hash>.json`, and `queue.sqlite3`.
+Writes publish atomically. Horizontal workers therefore require a filesystem
+and SQLite locking implementation that is safe for every participating host;
+for multi-host production deployments, place this interface behind a durable
+shared-volume/queue adapter.
+
+## Network security
+
+Non-loopback binding is rejected unless both `--allow-remote` and
+`--api-token` are supplied. Send the token as `Authorization: Bearer <token>`.
+This built-in server is an offline-first reference deployment; put TLS,
+identity, request logging, and rate limiting at a trusted reverse proxy before
+exposing it outside a controlled network.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ titan-workbench-ui = "titan_decoder.workbench_ui.app:main"
 titan-tui = "titan_decoder.workbench_ui.app:main"
 titan-ui = "titan_decoder.desktop_ui.app:main"
 titan-analyst = "titan_decoder.analyst.cli:main"
+titan-server = "titan_decoder.server.app:main"
 
 # Keep these lists in sync with requirements-dev.txt / requirements-optional.txt.
 [project.optional-dependencies]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,90 @@
+import http.client
+import json
+import threading
+
+import pytest
+
+from titan_decoder.server.app import TitanHTTPServer, main
+from titan_decoder.server.service import ArtifactStore, JobQueue, TitanService
+
+
+def test_artifact_store_is_hash_addressed_bounded_and_atomic(tmp_path):
+    store = ArtifactStore(tmp_path, max_artifact_bytes=8)
+    digest, created = store.put(b"payload")
+    assert created and store.get(digest) == b"payload"
+    assert store.put(b"payload") == (digest, False)
+    with pytest.raises(ValueError, match="size limit"):
+        store.put(b"x" * 9)
+
+
+def test_queue_deduplicates_and_leases_in_order(tmp_path):
+    queue = JobQueue(tmp_path / "queue.sqlite3")
+    first, created = queue.enqueue("a" * 64)
+    assert created and first["state"] == "queued"
+    assert queue.enqueue("a" * 64)[1] is False
+    leased = queue.lease("worker-1")
+    assert leased["id"] == "a" * 64 and leased["state"] == "running"
+    assert queue.lease("worker-2") is None
+    queue.complete(leased["id"])
+    assert queue.get(leased["id"])["state"] == "completed"
+
+
+def test_failed_job_can_be_resubmitted(tmp_path):
+    queue = JobQueue(tmp_path / "queue.sqlite3")
+    queue.enqueue("b" * 64)
+    leased = queue.lease("worker-1")
+    queue.fail(leased["id"], "transient failure")
+    retried, created = queue.enqueue(leased["id"])
+    assert created
+    assert retried["state"] == "queued"
+    assert retried["error"] is None
+
+
+def test_service_runs_job_and_reuses_completed_hash(tmp_path):
+    service = TitanService(tmp_path)
+    job, created = service.submit(b"https://server.example/gate")
+    assert created
+    finished = service.work_once("worker")
+    assert finished["state"] == "completed"
+    assert service.submit(b"https://server.example/gate")[1] is False
+    report = service.store.get_report(job["id"])
+    assert "https://server.example/gate" in report["iocs"]["urls"]
+
+
+def test_http_submit_status_report_and_auth(tmp_path):
+    service = TitanService(tmp_path)
+    server = TitanHTTPServer(("127.0.0.1", 0), service, "secret")
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    connection = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)
+    try:
+        connection.request("GET", "/v1/health")
+        unauthorized = connection.getresponse()
+        assert unauthorized.status == 401
+        unauthorized.read()
+        connection.close()
+        connection = http.client.HTTPConnection(
+            "127.0.0.1", server.server_port, timeout=5
+        )
+        headers = {"Authorization": "Bearer secret", "Content-Length": "7"}
+        connection.request("POST", "/v1/jobs", body=b"payload", headers=headers)
+        response = connection.getresponse()
+        assert response.status == 202
+        job = json.loads(response.read())
+        service.work_once("test")
+        connection.request("GET", f"/v1/jobs/{job['id']}/report", headers=headers)
+        report_response = connection.getresponse()
+        assert report_response.status == 200
+        assert json.loads(report_response.read())["meta"]["analysis_id"]
+    finally:
+        connection.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_remote_binding_requires_explicit_authentication():
+    with pytest.raises(SystemExit, match="requires --allow-remote"):
+        main(["--mode", "serve", "--host", "0.0.0.0"])
+    with pytest.raises(SystemExit, match="requires --api-token"):
+        main(["--mode", "serve", "--host", "0.0.0.0", "--allow-remote"])

--- a/titan_decoder/server/__init__.py
+++ b/titan_decoder/server/__init__.py
@@ -1,0 +1,5 @@
+"""Local, deterministic service-mode primitives for Titan."""
+
+from .service import ArtifactStore, JobQueue, TitanService
+
+__all__ = ["ArtifactStore", "JobQueue", "TitanService"]

--- a/titan_decoder/server/app.py
+++ b/titan_decoder/server/app.py
@@ -1,0 +1,167 @@
+"""Dependency-free REST surface and worker command for ``titan-server``."""
+
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import signal
+import socket
+import threading
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from .service import TitanService
+
+
+class TitanHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address, service: TitanService, api_token: str | None = None):
+        self.service = service
+        self.api_token = api_token
+        super().__init__(address, TitanHandler)
+
+
+class TitanHandler(BaseHTTPRequestHandler):
+    server: TitanHTTPServer
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):
+        return
+
+    def _json(self, status: int, value) -> None:
+        payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        if status == HTTPStatus.UNAUTHORIZED:
+            self.send_header("Connection", "close")
+            self.close_connection = True
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _authorized(self) -> bool:
+        expected = self.server.api_token
+        if expected is None:
+            return True
+        supplied = self.headers.get("Authorization", "")
+        return hmac.compare_digest(supplied, f"Bearer {expected}")
+
+    def _path(self) -> list[str]:
+        return [part for part in urlsplit(self.path).path.split("/") if part]
+
+    def do_GET(self):
+        if not self._authorized():
+            self._json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+            return
+        parts = self._path()
+        if parts == ["v1", "health"]:
+            self._json(HTTPStatus.OK, {"status": "ok"})
+            return
+        if len(parts) in (3, 4) and parts[:2] == ["v1", "jobs"]:
+            job_id = parts[2]
+            try:
+                job = self.server.service.queue.get(job_id)
+                if len(parts) == 4:
+                    if parts[3] != "report":
+                        raise KeyError(job_id)
+                    if job["state"] != "completed":
+                        self._json(HTTPStatus.CONFLICT, {"error": "report not ready", "state": job["state"]})
+                        return
+                    self._json(HTTPStatus.OK, self.server.service.store.get_report(job_id))
+                    return
+                self._json(HTTPStatus.OK, job)
+            except (KeyError, FileNotFoundError):
+                self._json(HTTPStatus.NOT_FOUND, {"error": "job not found"})
+            return
+        self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def do_POST(self):
+        if not self._authorized():
+            self._json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+            return
+        if self._path() != ["v1", "jobs"]:
+            self._json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", ""))
+        except ValueError:
+            length = -1
+        maximum = self.server.service.store.max_artifact_bytes
+        if length <= 0 or length > maximum:
+            self._json(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, {"error": "invalid artifact size", "max_bytes": maximum})
+            return
+        data = self.rfile.read(length)
+        try:
+            job, created = self.server.service.submit(data)
+        except ValueError as error:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(error)})
+            return
+        self._json(HTTPStatus.ACCEPTED if created else HTTPStatus.OK, job)
+
+
+def _worker_loop(service: TitanService, worker: str, stop: threading.Event) -> None:
+    while not stop.is_set():
+        if service.work_once(worker) is None:
+            stop.wait(0.2)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="titan-server")
+    parser.add_argument("--mode", choices=("all", "serve", "worker"), default="all")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--data-dir", type=Path, default=Path(".titan-server"))
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--worker-id", default=socket.gethostname())
+    parser.add_argument("--max-artifact-bytes", type=int, default=50 * 1024 * 1024)
+    parser.add_argument("--api-token")
+    parser.add_argument("--allow-remote", action="store_true")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.workers < 1 or args.workers > 64:
+        raise SystemExit("--workers must be between 1 and 64")
+    if args.max_artifact_bytes < 1:
+        raise SystemExit("--max-artifact-bytes must be positive")
+    if args.host not in {"127.0.0.1", "localhost", "::1"} and not args.allow_remote:
+        raise SystemExit("non-loopback binding requires --allow-remote")
+    if args.allow_remote and not args.api_token:
+        raise SystemExit("remote binding requires --api-token")
+    service = TitanService(args.data_dir, max_artifact_bytes=args.max_artifact_bytes)
+    stop = threading.Event()
+    try:
+        signal.signal(signal.SIGINT, lambda *_: stop.set())
+        signal.signal(signal.SIGTERM, lambda *_: stop.set())
+    except ValueError:
+        pass
+    threads = []
+    if args.mode in {"all", "worker"}:
+        for index in range(args.workers):
+            thread = threading.Thread(target=_worker_loop, args=(service, f"{args.worker_id}:{index}", stop), daemon=True)
+            thread.start()
+            threads.append(thread)
+    if args.mode in {"all", "serve"}:
+        server = TitanHTTPServer((args.host, args.port), service, args.api_token)
+        server.timeout = 0.2
+        try:
+            while not stop.is_set():
+                server.handle_request()
+        finally:
+            server.server_close()
+            stop.set()
+    else:
+        while not stop.wait(0.5):
+            pass
+    for thread in threads:
+        thread.join(timeout=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/titan_decoder/server/service.py
+++ b/titan_decoder/server/service.py
@@ -1,0 +1,189 @@
+"""Persistent artifact store, hash-deduplicated queue, and analysis workers."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from titan_decoder.config import Config
+from titan_decoder.core.engine import TitanEngine
+from titan_decoder.utils.helpers import sha256
+
+
+class ArtifactStore:
+    """Hash-addressed artifacts and reports with atomic publication."""
+
+    def __init__(self, root: Path, max_artifact_bytes: int = 50 * 1024 * 1024):
+        self.root = Path(root)
+        self.max_artifact_bytes = max_artifact_bytes
+        self.blobs = self.root / "blobs"
+        self.reports = self.root / "reports"
+        self.blobs.mkdir(parents=True, exist_ok=True)
+        self.reports.mkdir(parents=True, exist_ok=True)
+
+    def _blob_path(self, digest: str) -> Path:
+        return self.blobs / digest[:2] / digest
+
+    def put(self, data: bytes) -> tuple[str, bool]:
+        if not data:
+            raise ValueError("artifact must not be empty")
+        if len(data) > self.max_artifact_bytes:
+            raise ValueError("artifact exceeds configured size limit")
+        digest = sha256(data)
+        target = self._blob_path(digest)
+        if target.exists():
+            return digest, False
+        target.parent.mkdir(parents=True, exist_ok=True)
+        temporary = target.with_name(f".{target.name}.{os.getpid()}.{threading.get_ident()}")
+        try:
+            with temporary.open("xb") as stream:
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+            try:
+                os.replace(temporary, target)
+            except FileExistsError:
+                temporary.unlink(missing_ok=True)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return digest, True
+
+    def get(self, digest: str) -> bytes:
+        return self._blob_path(digest).read_bytes()
+
+    def put_report(self, digest: str, report: dict[str, Any]) -> None:
+        target = self.reports / f"{digest}.json"
+        temporary = target.with_suffix(f".{os.getpid()}.{threading.get_ident()}.tmp")
+        payload = json.dumps(report, sort_keys=True, separators=(",", ":")).encode()
+        try:
+            with temporary.open("xb") as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, target)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+    def get_report(self, digest: str) -> dict[str, Any]:
+        return json.loads((self.reports / f"{digest}.json").read_text(encoding="utf-8"))
+
+
+class JobQueue:
+    """SQLite-backed queue whose job identity is the artifact SHA-256."""
+
+    def __init__(self, path: Path, lease_timeout_seconds: int = 900):
+        self.path = Path(path)
+        self.lease_timeout_seconds = max(60, lease_timeout_seconds)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=30, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout=30000")
+        connection.execute("PRAGMA journal_mode=WAL")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """CREATE TABLE IF NOT EXISTS jobs (
+                    id TEXT PRIMARY KEY,
+                    state TEXT NOT NULL CHECK (state IN ('queued','running','completed','failed')),
+                    created REAL NOT NULL,
+                    updated REAL NOT NULL,
+                    worker TEXT,
+                    error TEXT
+                )"""
+            )
+
+    def enqueue(self, digest: str) -> tuple[dict[str, Any], bool]:
+        now = time.time()
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "INSERT OR IGNORE INTO jobs(id,state,created,updated) VALUES(?, 'queued', ?, ?)",
+                (digest, now, now),
+            )
+            created = cursor.rowcount == 1
+            if not created:
+                cursor = connection.execute(
+                    "UPDATE jobs SET state='queued', worker=NULL, error=NULL, updated=? "
+                    "WHERE id=? AND state='failed'",
+                    (now, digest),
+                )
+                created = cursor.rowcount == 1
+        return self.get(digest), created
+
+    def get(self, job_id: str) -> dict[str, Any]:
+        with self._connect() as connection:
+            row = connection.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+        if row is None:
+            raise KeyError(job_id)
+        return dict(row)
+
+    def lease(self, worker: str) -> dict[str, Any] | None:
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            now = time.time()
+            connection.execute(
+                "UPDATE jobs SET state='queued', worker=NULL, updated=? "
+                "WHERE state='running' AND updated < ?",
+                (now, now - self.lease_timeout_seconds),
+            )
+            row = connection.execute(
+                "SELECT id FROM jobs WHERE state = 'queued' ORDER BY created, id LIMIT 1"
+            ).fetchone()
+            if row is None:
+                connection.execute("COMMIT")
+                return None
+            connection.execute(
+                "UPDATE jobs SET state='running', worker=?, updated=? WHERE id=? AND state='queued'",
+                (worker, now, row["id"]),
+            )
+            connection.execute("COMMIT")
+        return self.get(row["id"])
+
+    def complete(self, job_id: str) -> None:
+        self._finish(job_id, "completed", None)
+
+    def fail(self, job_id: str, error: str) -> None:
+        self._finish(job_id, "failed", error[:4096])
+
+    def _finish(self, job_id: str, state: str, error: str | None) -> None:
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "UPDATE jobs SET state=?, error=?, updated=? WHERE id=? AND state='running'",
+                (state, error, time.time(), job_id),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("job is not leased")
+
+
+class TitanService:
+    """Coordinates submission, persistent workers, and report retrieval."""
+
+    def __init__(self, root: Path, config: Config | None = None, max_artifact_bytes: int = 50 * 1024 * 1024):
+        self.store = ArtifactStore(Path(root), max_artifact_bytes)
+        self.queue = JobQueue(Path(root) / "queue.sqlite3")
+        self.config = config or Config()
+
+    def submit(self, data: bytes) -> tuple[dict[str, Any], bool]:
+        digest, _stored = self.store.put(data)
+        return self.queue.enqueue(digest)
+
+    def work_once(self, worker: str) -> dict[str, Any] | None:
+        job = self.queue.lease(worker)
+        if job is None:
+            return None
+        try:
+            report = TitanEngine(self.config).run_analysis(self.store.get(job["id"]))
+            self.store.put_report(job["id"], report)
+            self.queue.complete(job["id"])
+        except Exception as error:
+            self.queue.fail(job["id"], f"{type(error).__name__}: {error}")
+        return self.queue.get(job["id"])


### PR DESCRIPTION
## Summary

- add the dependency-free `titan-server` REST and worker entry point
- persist jobs in a transactional SQLite queue with crash lease recovery
- store artifacts/reports atomically under SHA-256 identities and reuse duplicate work
- support combined, API-only, and worker-only deployment shapes
- require explicit opt-in and bearer authentication for non-loopback binding
- document endpoints, storage layout, bounds, security posture, and multi-host adapter boundary

## Validation

- `pytest -q`: 760 passed, 9 skipped
- service tests: 6 passed
- `ruff check titan_decoder tests examples tools`
- `mypy titan_decoder`
- wheel build succeeded and includes the new server package/entry point
